### PR TITLE
Trying to remove extra logging

### DIFF
--- a/packages/encryption/src/lib/params-validators.ts
+++ b/packages/encryption/src/lib/params-validators.ts
@@ -136,7 +136,7 @@ export const paramsValidators = {
     )
       return false;
 
-    console.log('authSig:', authSig);
+    log('authSig:', authSig);
     if (!is(authSig, 'Object', 'authSig', 'saveEncryptionKey')) return false;
     if (!checkIfAuthSigRequiresChainParam(authSig, chain, 'saveEncryptionKey'))
       return false;
@@ -239,7 +239,7 @@ export const paramsValidators = {
     )
       return false;
 
-    console.log('TYPEOF:', typeof toDecrypt);
+    log('TYPEOF:', typeof toDecrypt);
     if (!is(toDecrypt, 'String', 'toDecrypt', 'getEncryptionKey')) return false;
     if (!is(authSig, 'Object', 'authSig', 'getEncryptionKey')) return false;
 
@@ -343,7 +343,7 @@ export const paramsValidators = {
   decryptZip: (params: any) => {
     const { encryptedZipBlob, symmKey } = params;
 
-    console.log('encryptedZipBlob:', encryptedZipBlob);
+    log('encryptedZipBlob:', encryptedZipBlob);
 
     // -- validate
     if (
@@ -375,7 +375,7 @@ export const paramsValidators = {
   ) => {
     // -- validate
 
-    console.log('params:', params);
+    log('params:', params);
 
     if (
       !checkType({

--- a/packages/lit-node-client/src/index.ts
+++ b/packages/lit-node-client/src/index.ts
@@ -3,7 +3,7 @@ import * as _LitNodeClient from './lib/lit-node-client';
 
 // ==================== Environment ====================
 if (isNode()) {
-  console.log('Oh hey you are running in Node.js!');
+  log('Oh hey you are running in Node.js!');
   const fetch = require('node-fetch');
   globalThis.fetch = fetch;
 }

--- a/packages/lit-node-client/src/lib/lit-node-client.ts
+++ b/packages/lit-node-client/src/lib/lit-node-client.ts
@@ -328,7 +328,7 @@ export class LitNodeClient {
           );
         }
       } else {
-        console.log('storedSessionKeyOrError');
+        log('storedSessionKeyOrError');
         sessionKey = JSON.parse(storedSessionKeyOrError.result);
       }
     }
@@ -701,7 +701,7 @@ export class LitNodeClient {
     url: string,
     params: SignWithECDSA
   ): Promise<NodeCommandResponse> => {
-    console.log('sign_message_ecdsa');
+    log('sign_message_ecdsa');
 
     const urlWithPath = `${url}/web/signing/sign_message_ecdsa`;
 
@@ -1091,7 +1091,7 @@ export class LitNodeClient {
         siweMessage: s.siweMessage,
       }));
 
-      console.log('sigShares', sigShares);
+      log('sigShares', sigShares);
 
       const sigType = mostCommonString(sigShares.map((s: any) => s.sigType));
 
@@ -1170,7 +1170,7 @@ export class LitNodeClient {
         dataSigned: s.dataSigned,
       }));
 
-      console.log('sigShares', sigShares);
+      log('sigShares', sigShares);
 
       const sigType = mostCommonString(sigShares.map((s: any) => s.sigType));
 
@@ -1303,7 +1303,7 @@ export class LitNodeClient {
 
     await wasmECDSA.initWasmEcdsaSdk(); // init WASM
     const signature = wasmECDSA.combine_signature(R_x, R_y, shares);
-    console.log('raw ecdsa sig', signature);
+    log('raw ecdsa sig', signature);
 
     return signature;
   };
@@ -1985,7 +1985,7 @@ export class LitNodeClient {
       // ----- Result -----
       return signature;
     } catch (e) {
-      console.log('Error - signed_ecdsa_messages ');
+      log('Error - signed_ecdsa_messages ', e);
       const signed_ecdsa_message = nodePromises[0];
 
       // ----- Result -----
@@ -2068,7 +2068,7 @@ export class LitNodeClient {
 
       return signature;
     } catch (e) {
-      console.log('Error - signed_ecdsa_messages - ', e);
+      log('Error - signed_ecdsa_messages - ', e);
       const signed_ecdsa_message = nodePromises[0];
       return signed_ecdsa_message;
     }
@@ -2347,7 +2347,6 @@ export class LitNodeClient {
 
       const uint8arrayMessage = uint8arrayFromString(signedMessage, 'utf8');
       let signature = nacl.sign.detached(uint8arrayMessage, uint8arrayKey);
-      // console.log("signature", signature);
       signatures[nodeAddress] = {
         sig: uint8arrayToString(signature, 'base16'),
         derivedVia: 'litSessionSignViaNacl',
@@ -2357,7 +2356,7 @@ export class LitNodeClient {
       };
     });
 
-    console.log('signatures:', signatures);
+    log('signatures:', signatures);
 
     return signatures;
   };


### PR DESCRIPTION
So I removed almost all the `console.log`'s and replaced them with `log` but there is still a problem.  

These 3 lines get logged even though debug is set to false in the LitNodeClient config, because the config hasn't been loaded yet, I think.  

```[Lit-JS-SDK] Oh hey you are running in Node.js!
[Lit-JS-SDK] ✅ [ECDSA SDK] wasmECDSA loaded. 2 functions available. Run 'wasmECDSA' in the console to see them.
[Lit-JS-SDK] ✅ [BLS SDK] wasmExports loaded. 310 functions available. Run 'wasmExports' in the console to see them.
```

two options i can think of...  write to an array / cache and then print after config is loaded.  the other option is just try to load the config first before anything else.

@Ansonhkg can you fix this?