### PR TITLE
Import Blob to fix Reference not found error

### DIFF
--- a/packages/crypto/src/lib/crypto.ts
+++ b/packages/crypto/src/lib/crypto.ts
@@ -12,6 +12,8 @@ import * as wasmECDSA from '@lit-protocol/ecdsa-sdk';
 
 import { log } from '@lit-protocol/misc';
 
+import { Blob } from 'buffer';
+
 import {
   uint8arrayFromString,
   uint8arrayToString,


### PR DESCRIPTION
In the lit-node-client, when calling the function `litClient.saveEncryptionKey`, an error is thrown
`ReferenceError: Blob is not defined`

Full error:

```
ReferenceError: Blob is not defined
    at encryptWithSymmetricKey (/node_modules/@lit-protocol/lit-node-client/node_modules/@lit-protocol/encryption/packages/crypto/src/lib/crypto.ts:93:28)
    at Object.encryptString (/node_modules/@lit-protocol/lit-node-client/packages/encryption/src/lib/encryption.ts:117:33)
    at SimpleTaskDefinition.action (/src/tasks/generateSignatures.ts:111:15)
    at Environment._runTaskDefinition (/node_modules/hardhat/src/internal/core/runtime-environment.ts:217:14)
    at Environment.run (/node_modules/hardhat/src/internal/core/runtime-environment.ts:130:14)
    at main (/node_modules/hardhat/src/internal/cli/cli.ts:188:5)
```

An issue has already been raised [here](https://github.com/LIT-Protocol/lit-demo-simple-string-encrypt-nodejs/issues/1#issue-1596575528).
