### PR TITLE
feat: add npm registry metadata

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": true,
   "useWorkspaces": true,
-  "version": "2.1.49"
+  "version": "2.1.50"
 }

--- a/packages/access-control-conditions/package.json
+++ b/packages/access-control-conditions/package.json
@@ -1,6 +1,18 @@
 {
   "name": "@lit-protocol/access-control-conditions",
-  "version": "2.1.49",
+  "version": "2.1.50",
+  "license": "MIT",
+  "homepage": "https://github.com/Lit-Protocol/js-sdk",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LIT-Protocol/js-sdk"
+  },
+  "keywords": [
+    "library"
+  ],
+  "bugs": {
+    "url": "https://github.com/LIT-Protocol/js-sdk/issues"
+  },
   "type": "commonjs",
   "publishConfig": {
     "access": "public",

--- a/packages/auth-browser/package.json
+++ b/packages/auth-browser/package.json
@@ -1,6 +1,18 @@
 {
   "name": "@lit-protocol/auth-browser",
-  "version": "2.1.49",
+  "version": "2.1.50",
+  "license": "MIT",
+  "homepage": "https://github.com/Lit-Protocol/js-sdk",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LIT-Protocol/js-sdk"
+  },
+  "keywords": [
+    "library"
+  ],
+  "bugs": {
+    "url": "https://github.com/LIT-Protocol/js-sdk/issues"
+  },
   "type": "commonjs",
   "publishConfig": {
     "access": "public",

--- a/packages/bls-sdk/package.json
+++ b/packages/bls-sdk/package.json
@@ -1,6 +1,18 @@
 {
   "name": "@lit-protocol/bls-sdk",
-  "version": "2.1.49",
+  "version": "2.1.50",
+  "license": "MIT",
+  "homepage": "https://github.com/Lit-Protocol/js-sdk",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LIT-Protocol/js-sdk"
+  },
+  "keywords": [
+    "library"
+  ],
+  "bugs": {
+    "url": "https://github.com/LIT-Protocol/js-sdk/issues"
+  },
   "type": "commonjs",
   "publishConfig": {
     "access": "public",

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -1,6 +1,18 @@
 {
   "name": "@lit-protocol/constants",
-  "version": "2.1.49",
+  "version": "2.1.50",
+  "license": "MIT",
+  "homepage": "https://github.com/Lit-Protocol/js-sdk",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LIT-Protocol/js-sdk"
+  },
+  "keywords": [
+    "library"
+  ],
+  "bugs": {
+    "url": "https://github.com/LIT-Protocol/js-sdk/issues"
+  },
   "publishConfig": {
     "access": "public",
     "directory": "../../dist/packages/constants"

--- a/packages/contracts-sdk/package.json
+++ b/packages/contracts-sdk/package.json
@@ -1,6 +1,18 @@
 {
   "name": "@lit-protocol/contracts-sdk",
-  "version": "2.1.49",
+  "version": "2.1.50",
+  "license": "MIT",
+  "homepage": "https://github.com/Lit-Protocol/js-sdk",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LIT-Protocol/js-sdk"
+  },
+  "keywords": [
+    "library"
+  ],
+  "bugs": {
+    "url": "https://github.com/LIT-Protocol/js-sdk/issues"
+  },
   "type": "commonjs",
   "scripts": {},
   "publishConfig": {

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,6 +1,18 @@
 {
   "name": "@lit-protocol/crypto",
-  "version": "2.1.49",
+  "version": "2.1.50",
+  "license": "MIT",
+  "homepage": "https://github.com/Lit-Protocol/js-sdk",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LIT-Protocol/js-sdk"
+  },
+  "keywords": [
+    "library"
+  ],
+  "bugs": {
+    "url": "https://github.com/LIT-Protocol/js-sdk/issues"
+  },
   "type": "commonjs",
   "publishConfig": {
     "access": "public",

--- a/packages/ecdsa-sdk/package.json
+++ b/packages/ecdsa-sdk/package.json
@@ -1,6 +1,18 @@
 {
   "name": "@lit-protocol/ecdsa-sdk",
-  "version": "2.1.49",
+  "version": "2.1.50",
+  "license": "MIT",
+  "homepage": "https://github.com/Lit-Protocol/js-sdk",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LIT-Protocol/js-sdk"
+  },
+  "keywords": [
+    "library"
+  ],
+  "bugs": {
+    "url": "https://github.com/LIT-Protocol/js-sdk/issues"
+  },
   "type": "commonjs",
   "publishConfig": {
     "access": "public",

--- a/packages/encryption/package.json
+++ b/packages/encryption/package.json
@@ -1,6 +1,18 @@
 {
   "name": "@lit-protocol/encryption",
-  "version": "2.1.49",
+  "version": "2.1.50",
+  "license": "MIT",
+  "homepage": "https://github.com/Lit-Protocol/js-sdk",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LIT-Protocol/js-sdk"
+  },
+  "keywords": [
+    "library"
+  ],
+  "bugs": {
+    "url": "https://github.com/LIT-Protocol/js-sdk/issues"
+  },
   "type": "commonjs",
   "publishConfig": {
     "access": "public",

--- a/packages/lit-node-client/package.json
+++ b/packages/lit-node-client/package.json
@@ -1,6 +1,18 @@
 {
   "name": "@lit-protocol/lit-node-client",
-  "version": "2.1.49",
+  "version": "2.1.50",
+  "license": "MIT",
+  "homepage": "https://github.com/Lit-Protocol/js-sdk",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LIT-Protocol/js-sdk"
+  },
+  "keywords": [
+    "library"
+  ],
+  "bugs": {
+    "url": "https://github.com/LIT-Protocol/js-sdk/issues"
+  },
   "type": "commonjs",
   "publishConfig": {
     "access": "public",

--- a/packages/lit-third-party-libs/package.json
+++ b/packages/lit-third-party-libs/package.json
@@ -1,6 +1,18 @@
 {
   "name": "@lit-protocol/lit-third-party-libs",
-  "version": "2.1.49",
+  "version": "2.1.50",
+  "license": "MIT",
+  "homepage": "https://github.com/Lit-Protocol/js-sdk",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LIT-Protocol/js-sdk"
+  },
+  "keywords": [
+    "library"
+  ],
+  "bugs": {
+    "url": "https://github.com/LIT-Protocol/js-sdk/issues"
+  },
   "type": "commonjs",
   "publishConfig": {
     "access": "public",

--- a/packages/misc-browser/package.json
+++ b/packages/misc-browser/package.json
@@ -1,6 +1,18 @@
 {
   "name": "@lit-protocol/misc-browser",
-  "version": "2.1.49",
+  "version": "2.1.50",
+  "license": "MIT",
+  "homepage": "https://github.com/Lit-Protocol/js-sdk",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LIT-Protocol/js-sdk"
+  },
+  "keywords": [
+    "library"
+  ],
+  "bugs": {
+    "url": "https://github.com/LIT-Protocol/js-sdk/issues"
+  },
   "type": "commonjs",
   "publishConfig": {
     "access": "public",

--- a/packages/misc/package.json
+++ b/packages/misc/package.json
@@ -1,6 +1,18 @@
 {
   "name": "@lit-protocol/misc",
-  "version": "2.1.49",
+  "version": "2.1.50",
+  "license": "MIT",
+  "homepage": "https://github.com/Lit-Protocol/js-sdk",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LIT-Protocol/js-sdk"
+  },
+  "keywords": [
+    "library"
+  ],
+  "bugs": {
+    "url": "https://github.com/LIT-Protocol/js-sdk/issues"
+  },
   "type": "commonjs",
   "dependencies": {
     "ethers": "^5.7.1"

--- a/packages/nacl/package.json
+++ b/packages/nacl/package.json
@@ -1,6 +1,18 @@
 {
   "name": "@lit-protocol/nacl",
-  "version": "2.1.49",
+  "version": "2.1.50",
+  "license": "MIT",
+  "homepage": "https://github.com/Lit-Protocol/js-sdk",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LIT-Protocol/js-sdk"
+  },
+  "keywords": [
+    "library"
+  ],
+  "bugs": {
+    "url": "https://github.com/LIT-Protocol/js-sdk/issues"
+  },
   "type": "commonjs",
   "tags": [
     "universal"

--- a/packages/uint8arrays/package.json
+++ b/packages/uint8arrays/package.json
@@ -1,6 +1,18 @@
 {
   "name": "@lit-protocol/uint8arrays",
-  "version": "2.1.49",
+  "version": "2.1.50",
+  "license": "MIT",
+  "homepage": "https://github.com/Lit-Protocol/js-sdk",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LIT-Protocol/js-sdk"
+  },
+  "keywords": [
+    "library"
+  ],
+  "bugs": {
+    "url": "https://github.com/LIT-Protocol/js-sdk/issues"
+  },
   "type": "commonjs",
   "publishConfig": {
     "access": "public",


### PR DESCRIPTION
# What

We want to Repository and homepage links on the npm package page

# Solution

Add the following to each of the package.json
```
  "homepage": "https://github.com/Lit-Protocol/js-sdk",
  "repository": {
    "type": "git",
    "url": "https://github.com/LIT-Protocol/js-sdk"
  },
```