### PR TITLE
Implement generating authSig from nodes for WebAuthn authentication flow

### DIFF
--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -710,3 +710,35 @@ export interface SessionSigningTemplate {
   issuedAt: string;
   expiration: string;
 }
+
+export interface GetWebAuthnAuthenticationAuthSigProps {
+  verificationParams: WebAuthnAuthenticationVerificationParams;
+  username: string;
+  sessionKey?: any;
+  // The expiration of the auth sig that will be signed. This is a RFC3339 timestamp. The default is 24 hours from now.
+  expiration?: string;
+  resources?: any;
+}
+
+export interface GetVerifyWebAuthnAuthenticationKeyShareProps {
+  credential: WebAuthnAuthenticationVerificationParams;
+  sessionPubkey: string;
+  siweMessage: string;
+  username: string;
+}
+
+export interface WebAuthnAuthenticationVerificationParams {
+  id: string;
+  rawId: string;
+  response: {
+    authenticatorData: string;
+    clientDataJSON: string;
+    signature: string;
+    userHandle: string;
+  };
+  type: string;
+  clientExtensionResults: object;
+  authenticatorAttachment: AuthenticatorAttachment;
+}
+
+export declare type AuthenticatorAttachment = 'cross-platform' | 'platform';


### PR DESCRIPTION
# What

- Added several functions that finishes the WebAuthn authentication flow by sending a credential assertion to the Lit Nodes and asking them to generate signature shares for signing an **AuthSig** (not **SessionSig**) with the PKP tied to the WebAuthn credential. The shares are then recombined in the SDK into a valid signature. 

# Testing

- Manually tested and it works.

<img width="1799" alt="Screenshot 2023-03-12 at 11 32 45 PM" src="https://user-images.githubusercontent.com/9898215/224577859-d217e9ed-9722-4747-838c-ef09c1bf8b0c.png">
