### PR TITLE
Add AuthMethods to executeJs params so that it matches what we have in lit-js-sdk

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -18,5 +18,4 @@
   "trailingComma": "es5",
   "useTabs": false,
   "vueIndentScriptAndStyle": false,
-  "parser": "babel"
 }

--- a/packages/encryption/src/lib/params-validators.ts
+++ b/packages/encryption/src/lib/params-validators.ts
@@ -47,7 +47,7 @@ export const safeParams = ({
 export const paramsValidators = {
   executeJs: (params: ExecuteJsProps) => {
     // -- prepare params
-    const { code, ipfsId, authSig, jsParams, debug, sessionSigs } = params;
+    const { code, ipfsId, authSig, jsParams, debug, sessionSigs, authMethods = [] } = params;
 
     // -- validate: either 'code' or 'ipfsId' must exists
     if (!code && !ipfsId) {
@@ -71,6 +71,18 @@ export const paramsValidators = {
         value: authSig,
         allowedTypes: ['Object'],
         paramName: 'authSig',
+        functionName: 'executeJs',
+      })
+    )
+      return false;
+
+    // -- validate: authMethods and its type is correct
+    if (
+      authMethods && authMethods.length > 0 &&
+      !checkType({
+        value: authMethods,
+        allowedTypes: ['Array'],
+        paramName: 'authMethods',
         functionName: 'executeJs',
       })
     )

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -12,7 +12,7 @@ import {
 } from '@lit-protocol/access-control-conditions';
 import { wasmBlsSdkHelpers } from '@lit-protocol/bls-sdk';
 
-import { 
+import {
   defaultLitnodeClientConfig,
   LIT_ERROR,
   LIT_NETWORKS,
@@ -29,7 +29,7 @@ import {
   ExecuteJsResponse,
   FormattedMultipleAccs,
   GetSessionSigsProps,
-  GetSignSessionKeySharesProp,  
+  GetSignSessionKeySharesProp,
   GetVerifyWebAuthnAuthenticationKeyShareProps,
   HandshakeWithSgx,
   JsonAuthSig,
@@ -43,7 +43,6 @@ import {
   JsonStoreSigningRequest,
   KV,
   LitNodeClientConfig,
-  
   NodeCommandResponse,
   NodeCommandServerKeysResponse,
   NodeLog,
@@ -107,7 +106,9 @@ export class LitNodeClientNodeJs {
   subnetPubKey: string | null;
   networkPubKey: string | null;
   networkPubKeySet: string | null;
-  defaultAuthCallback?: (authSigParams: CheckAndSignAuthParams) => Promise<JsonAuthSig>;
+  defaultAuthCallback?: (
+    authSigParams: CheckAndSignAuthParams
+  ) => Promise<JsonAuthSig>;
 
   // ========== Constructor ==========
   constructor(args: any[LitNodeClientConfig | CustomNetwork | any]) {
@@ -225,6 +226,10 @@ export class LitNodeClientNodeJs {
 
     if (params.ipfsId) {
       reqBody.ipfsId = params.ipfsId;
+    }
+
+    if (params.authMethods && params.authMethods.length > 0) {
+      reqBody.authMethods = params.authMethods;
     }
 
     return reqBody;
@@ -392,12 +397,11 @@ export class LitNodeClientNodeJs {
           uri: sessionKeyUri,
         });
       } else {
-        
-        if(!this.defaultAuthCallback){
+        if (!this.defaultAuthCallback) {
           return throwError({
             message: 'No default auth callback provided',
             error: LIT_ERROR.PARAMS_MISSING_ERROR,
-          })
+          });
         }
         walletSig = await this.defaultAuthCallback({
           chain,
@@ -2445,7 +2449,7 @@ export class LitNodeClientNodeJs {
 
     let siweMessage: SiweMessage = new SiweMessage({
       domain: globalThis.location.host,
-      address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", // This will be populated by the node.
+      address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', // This will be populated by the node.
       statement: 'Lit Protocol PKP session signature',
       uri: sessionKeyUri,
       version: '1',
@@ -2584,11 +2588,11 @@ export class LitNodeClientNodeJs {
           litNodeClient: this,
         });
       } else {
-        if(!this.defaultAuthCallback){
+        if (!this.defaultAuthCallback) {
           return throwError({
             message: 'No default auth callback provided',
             error: LIT_ERROR.PARAMS_MISSING_ERROR,
-          })
+          });
         }
         walletSig = await this.defaultAuthCallback({
           chain: params.chain,

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -228,6 +228,9 @@ export interface JsonExecutionRequest {
 
   // whether to run this on a single node or many
   targetNodeRange?: number;
+
+  // auth methods to resolve 
+  authMethods?: Array<Object>;
 }
 
 /**


### PR DESCRIPTION
remove parser: babel from .prettierrc so it works with typescript.  add functionality to send AuthMethods with executeJS request