### PR TITLE
 globalThis.location.host nodejs fix

### DIFF
--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -2348,7 +2348,7 @@ export class LitNodeClientNodeJs {
     })();
 
     let siweMessage: SiweMessage = new SiweMessage({
-      domain: globalThis.location.host,
+      domain: params.domain ?? globalThis.location.host,
       address: pkpEthAddress,
       statement: 'Lit Protocol PKP session signature',
       uri: sessionKeyUri,

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -2348,7 +2348,7 @@ export class LitNodeClientNodeJs {
     })();
 
     let siweMessage: SiweMessage = new SiweMessage({
-      domain: params.domain ?? globalThis.location.host,
+      domain: globalThis.location?.host || params.domain || 'litprotocol.com',
       address: pkpEthAddress,
       statement: 'Lit Protocol PKP session signature',
       uri: sessionKeyUri,

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -724,6 +724,9 @@ export interface SignSessionKeyProp {
   resources: any;
 
   chainId?: number;
+  
+  //domain param is required, when calling from environment that doesn't have the 'location' object. i.e. NodeJs server.
+  domain?: string;
 }
 
 export interface SignSessionKeyResponse {


### PR DESCRIPTION
to avoid this error when running from nodejs server: 

```
TypeError: Cannot read properties of undefined (reading 'host')
    at LitNodeClientNodeJs.signSessionKey (/Users/saike/Code/null.world/null-network-backend/node_modules/@lit-protocol/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.js:1609:45)
    at Object.authNeededCallback (file:///Users/saike/Code/null.world/null-network-backend/utils/lit.js:199:46)
    at LitNodeClientNodeJs.getSessionSigs (/Users/saike/Code/null.world/null-network-backend/node_modules/@lit-protocol/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.js:1784:46)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Lit.getSessionSig (file:///Users/saike/Code/null.world/null-network-backend/utils/lit.js:211:18)
    at async file:///Users/saike/Code/null.world/null-network-backend/routes/auth/discord.js:207:25

```

we need to have ability to provide custom domain parameter to signSessionKey method