### PR TITLE
Handle New / Old SDK Errors

### DIFF
--- a/apps/html/manual_tests.html
+++ b/apps/html/manual_tests.html
@@ -1290,7 +1290,7 @@
           console.log('updated the condition');
         } catch (e) {
           console.log('error getting symmetric key - this is expected', e);
-          if (isNodeStorageError(e.error_code)) {
+          if (isNodeStorageError(e.errorCode)) {
             document.getElementById(
               'status'
             ).innerText = `${testName}: Success.  We were unable to update.`;
@@ -1372,7 +1372,7 @@
           console.log('updated the condition');
         } catch (e) {
           console.log('error getting symmetric key - this is expected', e);
-          if (isNodeStorageError(e.error_code)) {
+          if (isNodeStorageError(e.errorCode)) {
             document.getElementById(
               'status'
             ).innerText = `${testName}: Success.  We were unable to update.`;
@@ -1454,7 +1454,7 @@
           console.log('updated the condition');
         } catch (e) {
           console.log('error getting symmetric key - this is expected', e);
-          if (isNodeStorageError(e.error_code)) {
+          if (isNodeStorageError(e.errorCode)) {
             document.getElementById(
               'status'
             ).innerText = `${testName}: Success.  We were unable to update.`;
@@ -1745,7 +1745,7 @@
           console.log('updated the condition');
         } catch (e) {
           console.log('error updating the condition - this is expected', e);
-          if (isNodeStorageError(e.error_code)) {
+          if (isNodeStorageError(e.errorCode)) {
             document.getElementById(
               'status'
             ).innerText = `${testName}: Success.  We were unable to update.`;
@@ -1905,7 +1905,7 @@
           console.log('updated the condition');
         } catch (e) {
           console.log('error updating the condition - this is expected', e);
-          if (isNodeStorageError(e.error_code)) {
+          if (isNodeStorageError(e.errorCode)) {
             document.getElementById(
               'status'
             ).innerText = `${testName}: Success.  We were unable to update.`;
@@ -1995,7 +1995,7 @@
           console.log('updated the condition');
         } catch (e) {
           console.log('error updating the condition - this is expected', e);
-          if (isNodeStorageError(e.error_code)) {
+          if (isNodeStorageError(e.errorCode)) {
             document.getElementById(
               'status'
             ).innerText = `${testName}: Success.  We were unable to update.`;

--- a/apps/html/manual_tests.html
+++ b/apps/html/manual_tests.html
@@ -1290,7 +1290,7 @@
           console.log('updated the condition');
         } catch (e) {
           console.log('error getting symmetric key - this is expected', e);
-          if (e.errorCode === 'storage_error') {
+          if (isNodeStorageError(e.error_code)) {
             document.getElementById(
               'status'
             ).innerText = `${testName}: Success.  We were unable to update.`;
@@ -1372,7 +1372,7 @@
           console.log('updated the condition');
         } catch (e) {
           console.log('error getting symmetric key - this is expected', e);
-          if (e.errorCode === 'storage_error') {
+          if (isNodeStorageError(e.error_code)) {
             document.getElementById(
               'status'
             ).innerText = `${testName}: Success.  We were unable to update.`;
@@ -1454,7 +1454,7 @@
           console.log('updated the condition');
         } catch (e) {
           console.log('error getting symmetric key - this is expected', e);
-          if (e.errorCode === 'storage_error') {
+          if (isNodeStorageError(e.error_code)) {
             document.getElementById(
               'status'
             ).innerText = `${testName}: Success.  We were unable to update.`;
@@ -1745,7 +1745,7 @@
           console.log('updated the condition');
         } catch (e) {
           console.log('error updating the condition - this is expected', e);
-          if (e.errorCode === 'storage_error') {
+          if (isNodeStorageError(e.error_code)) {
             document.getElementById(
               'status'
             ).innerText = `${testName}: Success.  We were unable to update.`;
@@ -1905,7 +1905,7 @@
           console.log('updated the condition');
         } catch (e) {
           console.log('error updating the condition - this is expected', e);
-          if (e.errorCode === 'storage_error') {
+          if (isNodeStorageError(e.error_code)) {
             document.getElementById(
               'status'
             ).innerText = `${testName}: Success.  We were unable to update.`;
@@ -1995,7 +1995,7 @@
           console.log('updated the condition');
         } catch (e) {
           console.log('error updating the condition - this is expected', e);
-          if (e.errorCode === 'storage_error') {
+          if (isNodeStorageError(e.error_code)) {
             document.getElementById(
               'status'
             ).innerText = `${testName}: Success.  We were unable to update.`;
@@ -2339,6 +2339,10 @@
         },
         false
       );
+
+      function isNodeStorageError(errorCode) {
+        return errorCode === 'storage_error' || errorCode === 'NodeStorageError';
+      }
     </script>
   </head>
 

--- a/apps/html/manual_tests_error_messages.html
+++ b/apps/html/manual_tests_error_messages.html
@@ -394,7 +394,7 @@
           console.log("updated the condition");
         } catch (e) {
           console.log("error updating the condition - this is expected", e);
-          if (e.errorCode === "storage_error") {
+          if (isNodeStorageError(e.error_code)) {
             document.getElementById(
               "status"
             ).innerText = `${testName}: Success.  We were unable to update.`;
@@ -664,7 +664,7 @@
           console.log("updated the condition");
         } catch (e) {
           console.log("error getting symmetric key - this is expected", e);
-          if (e.errorCode === "storage_error") {
+          if (isNodeStorageError(e.error_code)) {
             document.getElementById(
               "status"
             ).innerText = `${testName}: Success.  We were unable to update.`;
@@ -701,6 +701,10 @@
         },
         false
       );
+
+      function isNodeStorageError(errorCode) {
+        return errorCode === 'storage_error' || errorCode === 'NodeStorageError';
+      }
     </script>
   </head>
 

--- a/apps/html/manual_tests_error_messages.html
+++ b/apps/html/manual_tests_error_messages.html
@@ -394,7 +394,7 @@
           console.log("updated the condition");
         } catch (e) {
           console.log("error updating the condition - this is expected", e);
-          if (isNodeStorageError(e.error_code)) {
+          if (isNodeStorageError(e.errorCode)) {
             document.getElementById(
               "status"
             ).innerText = `${testName}: Success.  We were unable to update.`;
@@ -664,7 +664,7 @@
           console.log("updated the condition");
         } catch (e) {
           console.log("error getting symmetric key - this is expected", e);
-          if (isNodeStorageError(e.error_code)) {
+          if (isNodeStorageError(e.errorCode)) {
             document.getElementById(
               "status"
             ).innerText = `${testName}: Success.  We were unable to update.`;

--- a/apps/html/manual_tests_session_keys.html
+++ b/apps/html/manual_tests_session_keys.html
@@ -134,7 +134,7 @@
             });
           } catch (e) {
             console.log("exception thrown when unlocking", e);
-            if (e.errorCode === "not_authorized") {
+            if (isNodeNotAuthorized(e.error_code)) {
               failed = true;
             }
           }
@@ -264,6 +264,10 @@
         },
         false
       );
+
+      function isNodeNotAuthorized(errorCode) {
+        return errorCode === 'not_authorized' || errorCode === 'NodeNotAuthorized';
+      }
     </script>
   </head>
 

--- a/apps/html/manual_tests_session_keys.html
+++ b/apps/html/manual_tests_session_keys.html
@@ -134,7 +134,7 @@
             });
           } catch (e) {
             console.log("exception thrown when unlocking", e);
-            if (isNodeNotAuthorized(e.error_code)) {
+            if (isNodeNotAuthorized(e.errorCode)) {
               failed = true;
             }
           }

--- a/apps/html/manual_tests_unified.html
+++ b/apps/html/manual_tests_unified.html
@@ -133,7 +133,7 @@
             });
           } catch (e) {
             console.log("exception thrown when unlocking", e);
-            if (isNodeNotAuthorized(e.error_code)) {
+            if (isNodeNotAuthorized(e.errorCode)) {
               failed = true;
             }
           }

--- a/apps/html/manual_tests_unified.html
+++ b/apps/html/manual_tests_unified.html
@@ -133,7 +133,7 @@
             });
           } catch (e) {
             console.log("exception thrown when unlocking", e);
-            if (e.errorCode === "not_authorized") {
+            if (isNodeNotAuthorized(e.error_code)) {
               failed = true;
             }
           }
@@ -394,6 +394,10 @@
         },
         false
       );
+
+      function isNodeNotAuthorized(errorCode) {
+        return errorCode === 'not_authorized' || errorCode === 'NodeNotAuthorized';
+      }
     </script>
   </head>
 

--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -570,7 +570,7 @@ describe('Lit Action', () => {
       savedParams.litNodeClient.throwNodeError(res);
     } catch (error) {
       console.log(error);
-      expect(error).to.have.property('error_code', 'NodeNotAuthorized');
+      expect(error).to.have.property('errorCode', 'NodeNotAuthorized');
       expect(error).to.have.property('name', 'NodeError');
     }
   });

--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -571,7 +571,6 @@ describe('Lit Action', () => {
     } catch (error) {
       console.log(error);
       expect(error).to.have.property('errorCode', 'NodeNotAuthorized');
-      expect(error).to.have.property('name', 'NodeError');
     }
   });
 

--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -570,7 +570,7 @@ describe('Lit Action', () => {
       savedParams.litNodeClient.throwNodeError(res);
     } catch (error) {
       console.log(error);
-      expect(error).to.have.property('errorCode', 'not_authorized');
+      expect(error).to.have.property('error_code', 'NodeNotAuthorized');
       expect(error).to.have.property('name', 'NodeError');
     }
   });

--- a/packages/access-control-conditions/src/lib/canonicalFormatter.spec.ts
+++ b/packages/access-control-conditions/src/lib/canonicalFormatter.spec.ts
@@ -148,8 +148,8 @@ describe('canonicalFormatter.ts', () => {
       console.log(e);
     }
 
-    expect((console.log as any).mock.calls[0][0].errorCode).toBe(
-      'invalid_access_control_conditions'
+    expect((console.log as any).mock.calls[0][0].error_code).toBe(
+      'InvalidAccessControlConditions'
     );
   });
 

--- a/packages/access-control-conditions/src/lib/canonicalFormatter.spec.ts
+++ b/packages/access-control-conditions/src/lib/canonicalFormatter.spec.ts
@@ -148,7 +148,7 @@ describe('canonicalFormatter.ts', () => {
       console.log(e);
     }
 
-    expect((console.log as any).mock.calls[0][0].error_code).toBe(
+    expect((console.log as any).mock.calls[0][0].errorCode).toBe(
       'InvalidAccessControlConditions'
     );
   });
@@ -180,7 +180,7 @@ describe('canonicalFormatter.ts', () => {
       console.log(e);
     }
 
-    expect((console.log as any).mock.calls[0][0].error_code).toBe(
+    expect((console.log as any).mock.calls[0][0].errorCode).toBe(
       'InvalidAccessControlConditions'
     );
   });

--- a/packages/access-control-conditions/src/lib/canonicalFormatter.spec.ts
+++ b/packages/access-control-conditions/src/lib/canonicalFormatter.spec.ts
@@ -180,8 +180,8 @@ describe('canonicalFormatter.ts', () => {
       console.log(e);
     }
 
-    expect((console.log as any).mock.calls[0][0].errorCode).toBe(
-      'invalid_access_control_conditions'
+    expect((console.log as any).mock.calls[0][0].error_code).toBe(
+      'InvalidAccessControlConditions'
     );
   });
 

--- a/packages/access-control-conditions/src/lib/canonicalFormatter.ts
+++ b/packages/access-control-conditions/src/lib/canonicalFormatter.ts
@@ -87,16 +87,16 @@ export const canonicalUnifiedAccessControlConditionFormatter = (
           message: `You passed an invalid access control condition that is missing or has a wrong "conditionType": ${JSON.stringify(
             cond
           )}`,
-          error_kind: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.kind,
-          error_code: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.name,
+          errorKind: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.kind,
+          errorCode: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.name,
         });
     }
   }
 
   throwError({
     message: `You passed an invalid access control condition: ${cond}`,
-    error_kind: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.kind,
-    error_code: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.name,
+    errorKind: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.kind,
+    errorCode: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.name,
   });
 };
 
@@ -177,8 +177,8 @@ export const canonicalSolRpcConditionFormatter = (
       ) {
         throwError({
           message: `Solana RPC Conditions have changed and there are some new fields you must include in your condition.  Check the docs here: https://developer.litprotocol.com/AccessControlConditions/solRpcConditions`,
-          error_kind: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.kind,
-          error_code: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.name,
+          errorKind: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.kind,
+          errorCode: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.name,
         });
       }
 
@@ -220,8 +220,8 @@ export const canonicalSolRpcConditionFormatter = (
   // -- else
   throwError({
     message: `You passed an invalid access control condition: ${cond}`,
-    error_kind: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.kind,
-    error_code: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.name,
+    errorKind: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.kind,
+    errorCode: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.name,
   });
 };
 
@@ -278,8 +278,8 @@ export const canonicalAccessControlConditionFormatter = (
 
   throwError({
     message: `You passed an invalid access control condition: ${cond}`,
-    error_kind: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.kind,
-    error_code: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.name,
+    errorKind: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.kind,
+    errorCode: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.name,
   });
 };
 
@@ -373,8 +373,8 @@ export const canonicalEVMContractConditionFormatter = (
 
   throwError({
     message: `You passed an invalid access control condition: ${cond}`,
-    error_kind: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.kind,
-    error_code: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.name,
+    errorKind: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.kind,
+    errorCode: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.name,
   });
 };
 
@@ -432,8 +432,8 @@ export const canonicalCosmosConditionFormatter = (
 
   throwError({
     message: `You passed an invalid access control condition: ${cond}`,
-    error_kind: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.kind,
-    error_code: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.name,
+    errorKind: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.kind,
+    errorCode: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.name,
   });
 };
 

--- a/packages/access-control-conditions/src/lib/canonicalFormatter.ts
+++ b/packages/access-control-conditions/src/lib/canonicalFormatter.ts
@@ -1,7 +1,4 @@
-import {
-  ILitError,
-  LIT_ERROR,
-} from '@lit-protocol/constants';
+import { ILitError, LIT_ERROR } from '@lit-protocol/constants';
 
 import {
   ABIParams,
@@ -90,14 +87,16 @@ export const canonicalUnifiedAccessControlConditionFormatter = (
           message: `You passed an invalid access control condition that is missing or has a wrong "conditionType": ${JSON.stringify(
             cond
           )}`,
-          error: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS,
+          error_kind: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.kind,
+          error_code: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.name,
         });
     }
   }
 
   throwError({
     message: `You passed an invalid access control condition: ${cond}`,
-    error: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS,
+    error_kind: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.kind,
+    error_code: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.name,
   });
 };
 
@@ -178,7 +177,8 @@ export const canonicalSolRpcConditionFormatter = (
       ) {
         throwError({
           message: `Solana RPC Conditions have changed and there are some new fields you must include in your condition.  Check the docs here: https://developer.litprotocol.com/AccessControlConditions/solRpcConditions`,
-          error: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS,
+          error_kind: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.kind,
+          error_code: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.name,
         });
       }
 
@@ -220,7 +220,8 @@ export const canonicalSolRpcConditionFormatter = (
   // -- else
   throwError({
     message: `You passed an invalid access control condition: ${cond}`,
-    error: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS,
+    error_kind: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.kind,
+    error_code: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.name,
   });
 };
 
@@ -277,7 +278,8 @@ export const canonicalAccessControlConditionFormatter = (
 
   throwError({
     message: `You passed an invalid access control condition: ${cond}`,
-    error: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS,
+    error_kind: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.kind,
+    error_code: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.name,
   });
 };
 
@@ -371,7 +373,8 @@ export const canonicalEVMContractConditionFormatter = (
 
   throwError({
     message: `You passed an invalid access control condition: ${cond}`,
-    error: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS,
+    error_kind: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.kind,
+    error_code: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.name,
   });
 };
 
@@ -429,7 +432,8 @@ export const canonicalCosmosConditionFormatter = (
 
   throwError({
     message: `You passed an invalid access control condition: ${cond}`,
-    error: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS,
+    error_kind: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.kind,
+    error_code: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.name,
   });
 };
 

--- a/packages/access-control-conditions/src/lib/hashing.ts
+++ b/packages/access-control-conditions/src/lib/hashing.ts
@@ -43,14 +43,16 @@ export const hashUnifiedAccessControlConditions = (
   if (hasUndefined) {
     throwError({
       message: 'Invalid access control conditions',
-      error: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS,
+      error_kind: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.kind,
+      error_code: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.name,
     });
   }
 
   if (conditions.length === 0) {
     throwError({
       message: 'No conditions provided',
-      error: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS,
+      error_kind: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.kind,
+      error_code: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.name,
     });
   }
   const toHash = JSON.stringify(conditions);

--- a/packages/access-control-conditions/src/lib/hashing.ts
+++ b/packages/access-control-conditions/src/lib/hashing.ts
@@ -43,16 +43,16 @@ export const hashUnifiedAccessControlConditions = (
   if (hasUndefined) {
     throwError({
       message: 'Invalid access control conditions',
-      error_kind: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.kind,
-      error_code: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.name,
+      errorKind: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.kind,
+      errorCode: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.name,
     });
   }
 
   if (conditions.length === 0) {
     throwError({
       message: 'No conditions provided',
-      error_kind: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.kind,
-      error_code: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.name,
+      errorKind: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.kind,
+      errorCode: LIT_ERROR.INVALID_ACCESS_CONTROL_CONDITIONS.name,
     });
   }
   const toHash = JSON.stringify(conditions);

--- a/packages/access-control-conditions/src/lib/humanizer.ts
+++ b/packages/access-control-conditions/src/lib/humanizer.ts
@@ -82,9 +82,9 @@ export const humanizeEvmBasicAccessControlConditions = async ({
   tokenList,
   myWalletAddress,
 }: {
-  accessControlConditions: Array<AccsRegularParams | AccsDefaultParams | any>,
-  tokenList?: Array<any | string>,
-  myWalletAddress?: string,
+  accessControlConditions: Array<AccsRegularParams | AccsDefaultParams | any>;
+  tokenList?: Array<any | string>;
+  myWalletAddress?: string;
 }): Promise<string> => {
   log('humanizing evm basic access control conditions');
   log('myWalletAddress', myWalletAddress);
@@ -278,9 +278,9 @@ export const humanizeEvmContractConditions = async ({
   tokenList,
   myWalletAddress,
 }: {
-  evmContractConditions: Array<AccsEVMParams>,
-  tokenList?: Array<any | string>,
-  myWalletAddress?: string,
+  evmContractConditions: Array<AccsEVMParams>;
+  tokenList?: Array<any | string>;
+  myWalletAddress?: string;
 }): Promise<string> => {
   log('humanizing evm contract conditions');
   log('myWalletAddress', myWalletAddress);
@@ -339,9 +339,9 @@ export const humanizeSolRpcConditions = async ({
   tokenList,
   myWalletAddress,
 }: {
-  solRpcConditions: Array<AccsSOLV2Params>,
-  tokenList?: Array<any | string>,
-  myWalletAddress?: string,
+  solRpcConditions: Array<AccsSOLV2Params>;
+  tokenList?: Array<any | string>;
+  myWalletAddress?: string;
 }): Promise<string> => {
   log('humanizing sol rpc conditions');
   log('myWalletAddress', myWalletAddress);
@@ -413,9 +413,9 @@ export const humanizeCosmosConditions = async ({
   tokenList,
   myWalletAddress,
 }: {
-  cosmosConditions: Array<AccsCOSMOSParams | any>,
-  tokenList?: Array<any | string>,
-  myWalletAddress?: string,
+  cosmosConditions: Array<AccsCOSMOSParams | any>;
+  tokenList?: Array<any | string>;
+  myWalletAddress?: string;
 }): Promise<string> => {
   log('humanizing cosmos conditions');
   log('myWalletAddress', myWalletAddress);
@@ -491,9 +491,9 @@ export const humanizeUnifiedAccessControlConditions = async ({
   tokenList,
   myWalletAddress,
 }: {
-  unifiedAccessControlConditions: UnifiedAccessControlConditions,
-  tokenList?: Array<any | string>,
-  myWalletAddress?: string,
+  unifiedAccessControlConditions: UnifiedAccessControlConditions;
+  tokenList?: Array<any | string>;
+  myWalletAddress?: string;
 }): Promise<string> => {
   const promises = await Promise.all(
     unifiedAccessControlConditions.map(async (acc: any): Promise<any> => {
@@ -542,7 +542,8 @@ export const humanizeUnifiedAccessControlConditions = async ({
       } else {
         throwError({
           message: `Unrecognized condition type: ${acc.conditionType}`,
-          error: LIT_ERROR.INVALID_UNIFIED_CONDITION_TYPE,
+          error_kind: LIT_ERROR.INVALID_UNIFIED_CONDITION_TYPE.kind,
+          error_code: LIT_ERROR.INVALID_UNIFIED_CONDITION_TYPE.name,
         });
       }
     })

--- a/packages/access-control-conditions/src/lib/humanizer.ts
+++ b/packages/access-control-conditions/src/lib/humanizer.ts
@@ -542,8 +542,8 @@ export const humanizeUnifiedAccessControlConditions = async ({
       } else {
         throwError({
           message: `Unrecognized condition type: ${acc.conditionType}`,
-          error_kind: LIT_ERROR.INVALID_UNIFIED_CONDITION_TYPE.kind,
-          error_code: LIT_ERROR.INVALID_UNIFIED_CONDITION_TYPE.name,
+          errorKind: LIT_ERROR.INVALID_UNIFIED_CONDITION_TYPE.kind,
+          errorCode: LIT_ERROR.INVALID_UNIFIED_CONDITION_TYPE.name,
         });
       }
     })

--- a/packages/auth-browser/src/lib/auth-browser.ts
+++ b/packages/auth-browser/src/lib/auth-browser.ts
@@ -30,8 +30,8 @@ export const checkAndSignAuthMessage = ({
       message: `Unsupported chain selected.  Please select one of: ${Object.keys(
         ALL_LIT_CHAINS
       )}`,
-      error_kind: LIT_ERROR.UNSUPPORTED_CHAIN_EXCEPTION.kind,
-      error_code: LIT_ERROR.UNSUPPORTED_CHAIN_EXCEPTION.name,
+      errorKind: LIT_ERROR.UNSUPPORTED_CHAIN_EXCEPTION.kind,
+      errorCode: LIT_ERROR.UNSUPPORTED_CHAIN_EXCEPTION.name,
     });
   }
 
@@ -58,8 +58,8 @@ export const checkAndSignAuthMessage = ({
       message: `vmType not found for this chain: ${chain}.  This should not happen.  Unsupported chain selected.  Please select one of: ${Object.keys(
         ALL_LIT_CHAINS
       )}`,
-      error_kind: LIT_ERROR.UNSUPPORTED_CHAIN_EXCEPTION.kind,
-      error_code: LIT_ERROR.UNSUPPORTED_CHAIN_EXCEPTION.name,
+      errorKind: LIT_ERROR.UNSUPPORTED_CHAIN_EXCEPTION.kind,
+      errorCode: LIT_ERROR.UNSUPPORTED_CHAIN_EXCEPTION.name,
     });
   }
 };

--- a/packages/auth-browser/src/lib/auth-browser.ts
+++ b/packages/auth-browser/src/lib/auth-browser.ts
@@ -30,7 +30,8 @@ export const checkAndSignAuthMessage = ({
       message: `Unsupported chain selected.  Please select one of: ${Object.keys(
         ALL_LIT_CHAINS
       )}`,
-      error: LIT_ERROR.UNSUPPORTED_CHAIN_EXCEPTION,
+      error_kind: LIT_ERROR.UNSUPPORTED_CHAIN_EXCEPTION.kind,
+      error_code: LIT_ERROR.UNSUPPORTED_CHAIN_EXCEPTION.name,
     });
   }
 
@@ -57,7 +58,8 @@ export const checkAndSignAuthMessage = ({
       message: `vmType not found for this chain: ${chain}.  This should not happen.  Unsupported chain selected.  Please select one of: ${Object.keys(
         ALL_LIT_CHAINS
       )}`,
-      error: LIT_ERROR.UNSUPPORTED_CHAIN_EXCEPTION,
+      error_kind: LIT_ERROR.UNSUPPORTED_CHAIN_EXCEPTION.kind,
+      error_code: LIT_ERROR.UNSUPPORTED_CHAIN_EXCEPTION.name,
     });
   }
 };

--- a/packages/auth-browser/src/lib/chains/cosmos.ts
+++ b/packages/auth-browser/src/lib/chains/cosmos.ts
@@ -10,9 +10,7 @@ import {
   LOCAL_STORAGE_KEYS,
 } from '@lit-protocol/constants';
 
-import { 
-  JsonAuthSig
-} from '@lit-protocol/types';
+import { JsonAuthSig } from '@lit-protocol/types';
 import { log, sortedObject, throwError } from '@lit-protocol/misc';
 
 /** ---------- Declaration ---------- */
@@ -77,7 +75,8 @@ const getProvider = (): any => {
 
   throwError({
     message,
-    error,
+    error_kind: error.kind,
+    error_code: error.name,
   });
 };
 

--- a/packages/auth-browser/src/lib/chains/cosmos.ts
+++ b/packages/auth-browser/src/lib/chains/cosmos.ts
@@ -75,8 +75,8 @@ const getProvider = (): any => {
 
   throwError({
     message,
-    error_kind: error.kind,
-    error_code: error.name,
+    errorKind: error.kind,
+    errorCode: error.name,
   });
 };
 

--- a/packages/auth-browser/src/lib/chains/eth.ts
+++ b/packages/auth-browser/src/lib/chains/eth.ts
@@ -158,8 +158,8 @@ export const chainHexIdToChainName = (chainHexId: string): void | string => {
   if (!chainHexId.startsWith('0x')) {
     throwError({
       message: `${chainHexId} should begin with "0x"`,
-      error_kind: LIT_ERROR.WRONG_PARAM_FORMAT.kind,
-      error_code: LIT_ERROR.WRONG_PARAM_FORMAT.name,
+      errorKind: LIT_ERROR.WRONG_PARAM_FORMAT.kind,
+      errorCode: LIT_ERROR.WRONG_PARAM_FORMAT.name,
     });
   }
 
@@ -167,8 +167,8 @@ export const chainHexIdToChainName = (chainHexId: string): void | string => {
   if (!hexIds.includes(chainHexId)) {
     throwError({
       message: `${chainHexId} cannot be found in LIT_CHAINS`,
-      error_kind: LIT_ERROR.UNSUPPORTED_CHAIN_EXCEPTION.kind,
-      error_code: LIT_ERROR.UNSUPPORTED_CHAIN_EXCEPTION.name,
+      errorKind: LIT_ERROR.UNSUPPORTED_CHAIN_EXCEPTION.kind,
+      errorCode: LIT_ERROR.UNSUPPORTED_CHAIN_EXCEPTION.name,
     });
   }
 
@@ -186,8 +186,8 @@ export const chainHexIdToChainName = (chainHexId: string): void | string => {
   // -- fail case
   throwError({
     message: `Failed to convert ${chainHexId}`,
-    error_kind: LIT_ERROR.UNKNOWN_ERROR.kind,
-    error_code: LIT_ERROR.UNKNOWN_ERROR.name,
+    errorKind: LIT_ERROR.UNKNOWN_ERROR.kind,
+    errorCode: LIT_ERROR.UNKNOWN_ERROR.name,
   });
 };
 
@@ -212,8 +212,8 @@ export const getChainId = async (
 
     resultOrError = ELeft({
       message: `Incorrect network selected.  Please switch to the ${chain} network in your wallet and try again.`,
-      error_kind: LIT_ERROR.WRONG_NETWORK_EXCEPTION.kind,
-      error_code: LIT_ERROR.WRONG_NETWORK_EXCEPTION.name,
+      errorKind: LIT_ERROR.WRONG_NETWORK_EXCEPTION.kind,
+      errorCode: LIT_ERROR.WRONG_NETWORK_EXCEPTION.name,
     });
   }
 
@@ -444,8 +444,8 @@ export const checkAndSignEVMAuthMessage = async ({
     if (error.code === WALLET_ERROR.NO_SUCH_METHOD) {
       throwError({
         message: `Incorrect network selected.  Please switch to the ${chain} network in your wallet and try again.`,
-        error_kind: LIT_ERROR.WRONG_NETWORK_EXCEPTION.kind,
-        error_code: LIT_ERROR.WRONG_NETWORK_EXCEPTION.name,
+        errorKind: LIT_ERROR.WRONG_NETWORK_EXCEPTION.kind,
+        errorCode: LIT_ERROR.WRONG_NETWORK_EXCEPTION.name,
       });
     } else {
       throw error;
@@ -476,8 +476,8 @@ export const checkAndSignEVMAuthMessage = async ({
     if (authSigOrError.type === 'ERROR') {
       throwError({
         message: 'Failed to get authSig from local storage',
-        error_kind: LIT_ERROR.LOCAL_STORAGE_ITEM_NOT_FOUND_EXCEPTION.kind,
-        error_code: LIT_ERROR.LOCAL_STORAGE_ITEM_NOT_FOUND_EXCEPTION.name,
+        errorKind: LIT_ERROR.LOCAL_STORAGE_ITEM_NOT_FOUND_EXCEPTION.kind,
+        errorCode: LIT_ERROR.LOCAL_STORAGE_ITEM_NOT_FOUND_EXCEPTION.name,
       });
     }
 
@@ -601,8 +601,8 @@ export const checkAndSignEVMAuthMessage = async ({
       log(e);
       return throwError({
         message: e.message,
-        error_kind: LIT_ERROR.UNKNOWN_ERROR.kind,
-        error_code: LIT_ERROR.UNKNOWN_ERROR.name,
+        errorKind: LIT_ERROR.UNKNOWN_ERROR.kind,
+        errorCode: LIT_ERROR.UNKNOWN_ERROR.name,
       });
     }
     authSigOrError.type = EITHER_TYPE.SUCCESS;

--- a/packages/auth-browser/src/lib/chains/eth.ts
+++ b/packages/auth-browser/src/lib/chains/eth.ts
@@ -8,10 +8,7 @@ import {
   LOCAL_STORAGE_KEYS,
 } from '@lit-protocol/constants';
 
-import{
-  JsonAuthSig,
-  CheckAndSignAuthParams,
-}from '@lit-protocol/types'
+import { JsonAuthSig, CheckAndSignAuthParams } from '@lit-protocol/types';
 
 import { ethers } from 'ethers';
 // import WalletConnectProvider from '@walletconnect/ethereum-provider';
@@ -161,7 +158,8 @@ export const chainHexIdToChainName = (chainHexId: string): void | string => {
   if (!chainHexId.startsWith('0x')) {
     throwError({
       message: `${chainHexId} should begin with "0x"`,
-      error: LIT_ERROR.WRONG_PARAM_FORMAT,
+      error_kind: LIT_ERROR.WRONG_PARAM_FORMAT.kind,
+      error_code: LIT_ERROR.WRONG_PARAM_FORMAT.name,
     });
   }
 
@@ -169,7 +167,8 @@ export const chainHexIdToChainName = (chainHexId: string): void | string => {
   if (!hexIds.includes(chainHexId)) {
     throwError({
       message: `${chainHexId} cannot be found in LIT_CHAINS`,
-      error: LIT_ERROR.UNSUPPORTED_CHAIN_EXCEPTION,
+      error_kind: LIT_ERROR.UNSUPPORTED_CHAIN_EXCEPTION.kind,
+      error_code: LIT_ERROR.UNSUPPORTED_CHAIN_EXCEPTION.name,
     });
   }
 
@@ -187,7 +186,8 @@ export const chainHexIdToChainName = (chainHexId: string): void | string => {
   // -- fail case
   throwError({
     message: `Failed to convert ${chainHexId}`,
-    error: LIT_ERROR.UNKNOWN_ERROR,
+    error_kind: LIT_ERROR.UNKNOWN_ERROR.kind,
+    error_code: LIT_ERROR.UNKNOWN_ERROR.name,
   });
 };
 
@@ -212,7 +212,8 @@ export const getChainId = async (
 
     resultOrError = ELeft({
       message: `Incorrect network selected.  Please switch to the ${chain} network in your wallet and try again.`,
-      error: LIT_ERROR.WRONG_NETWORK_EXCEPTION,
+      error_kind: LIT_ERROR.WRONG_NETWORK_EXCEPTION.kind,
+      error_code: LIT_ERROR.WRONG_NETWORK_EXCEPTION.name,
     });
   }
 
@@ -368,7 +369,9 @@ export const connectWeb3 = async ({
 
   // trigger metamask popup
   try {
-    log("@deprecated soon to be removed. - trying to enable provider.  this will trigger the metamask popup.");
+    log(
+      '@deprecated soon to be removed. - trying to enable provider.  this will trigger the metamask popup.'
+    );
     await provider.enable();
   } catch (e) {
     log(
@@ -441,7 +444,8 @@ export const checkAndSignEVMAuthMessage = async ({
     if (error.code === WALLET_ERROR.NO_SUCH_METHOD) {
       throwError({
         message: `Incorrect network selected.  Please switch to the ${chain} network in your wallet and try again.`,
-        error: LIT_ERROR.WRONG_NETWORK_EXCEPTION,
+        error_kind: LIT_ERROR.WRONG_NETWORK_EXCEPTION.kind,
+        error_code: LIT_ERROR.WRONG_NETWORK_EXCEPTION.name,
       });
     } else {
       throw error;
@@ -472,7 +476,8 @@ export const checkAndSignEVMAuthMessage = async ({
     if (authSigOrError.type === 'ERROR') {
       throwError({
         message: 'Failed to get authSig from local storage',
-        error: LIT_ERROR.LOCAL_STORAGE_ITEM_NOT_FOUND_EXCEPTION,
+        error_kind: LIT_ERROR.LOCAL_STORAGE_ITEM_NOT_FOUND_EXCEPTION.kind,
+        error_code: LIT_ERROR.LOCAL_STORAGE_ITEM_NOT_FOUND_EXCEPTION.name,
       });
     }
 
@@ -596,7 +601,8 @@ export const checkAndSignEVMAuthMessage = async ({
       log(e);
       return throwError({
         message: e.message,
-        error: LIT_ERROR.UNKNOWN_ERROR,
+        error_kind: LIT_ERROR.UNKNOWN_ERROR.kind,
+        error_code: LIT_ERROR.UNKNOWN_ERROR.name,
       });
     }
     authSigOrError.type = EITHER_TYPE.SUCCESS;

--- a/packages/auth-browser/src/lib/chains/sol.ts
+++ b/packages/auth-browser/src/lib/chains/sol.ts
@@ -37,7 +37,8 @@ const getProvider = (): IEither => {
 
     resultOrError = ELeft({
       message,
-      error: LIT_ERROR.NO_WALLET_EXCEPTION,
+      error_kind: LIT_ERROR.NO_WALLET_EXCEPTION.kind,
+      error_code: LIT_ERROR.NO_WALLET_EXCEPTION.name,
     });
   }
 
@@ -138,7 +139,7 @@ export const checkAndSignSolAuthMessage = async (): Promise<JsonAuthSig> => {
 export const signAndSaveAuthMessage = async ({
   provider,
 }: {
-  provider: any,
+  provider: any;
 }): Promise<JsonAuthSig | undefined> => {
   const now = new Date().toISOString();
   const body = AUTH_SIGNATURE_BODY.replace('{{timestamp}}', now);

--- a/packages/auth-browser/src/lib/chains/sol.ts
+++ b/packages/auth-browser/src/lib/chains/sol.ts
@@ -37,8 +37,8 @@ const getProvider = (): IEither => {
 
     resultOrError = ELeft({
       message,
-      error_kind: LIT_ERROR.NO_WALLET_EXCEPTION.kind,
-      error_code: LIT_ERROR.NO_WALLET_EXCEPTION.name,
+      errorKind: LIT_ERROR.NO_WALLET_EXCEPTION.kind,
+      errorCode: LIT_ERROR.NO_WALLET_EXCEPTION.name,
     });
   }
 

--- a/packages/constants/src/lib/errors.ts
+++ b/packages/constants/src/lib/errors.ts
@@ -1,93 +1,133 @@
+export enum LitErrorKind {
+  Unknown = 'Unknown',
+  Unexpected = 'Unexpected',
+  Generic = 'Generic',
+  Config = 'Config',
+  Validation = 'Validation',
+  Conversion = 'Conversion',
+  Parser = 'Parser',
+  Serializer = 'Serializer',
+  Timeout = 'Timeout',
+}
+
 export const LIT_ERROR = {
   INVALID_PARAM_TYPE: {
     name: 'InvalidParamType',
     code: 'invalid_param_type',
+    kind: LitErrorKind.Validation,
   },
   INVALID_ACCESS_CONTROL_CONDITIONS: {
     name: 'InvalidAccessControlConditions',
     code: 'invalid_access_control_conditions',
+    kind: LitErrorKind.Validation,
   },
   WRONG_NETWORK_EXCEPTION: {
     name: 'WrongNetworkException',
     code: 'wrong_network_exception',
+    kind: LitErrorKind.Validation,
   },
   MINTING_NOT_SUPPORTED: {
     name: 'MintingNotSupported',
     code: 'minting_not_supported',
+    kind: LitErrorKind.Validation,
   },
   UNSUPPORTED_CHAIN_EXCEPTION: {
     name: 'UnsupportedChainException',
     code: 'unsupported_chain_exception',
+    kind: LitErrorKind.Validation,
   },
   INVALID_UNIFIED_CONDITION_TYPE: {
     name: 'InvalidUnifiedConditionType',
     code: 'invalid_unified_condition_type',
+    kind: LitErrorKind.Validation,
   },
   LIT_NODE_CLIENT_NOT_READY_ERROR: {
     name: 'LitNodeClientNotReadyError',
     code: 'lit_node_client_not_ready_error',
+    kind: LitErrorKind.Unexpected,
   },
   UNAUTHROZIED_EXCEPTION: {
     name: 'UnauthroziedException',
     code: 'unauthrozied_exception',
+    kind: LitErrorKind.Validation,
   },
   INVALID_ARGUMENT_EXCEPTION: {
     name: 'InvalidArgumentException',
     code: 'invalid_argument_exception',
+    kind: LitErrorKind.Validation,
   },
   UNKNOWN_ERROR: {
     name: 'UnknownError',
     code: 'unknown_error',
+    kind: LitErrorKind.Unknown,
   },
   NO_WALLET_EXCEPTION: {
     name: 'NoWalletException',
     code: 'no_wallet_exception',
+    kind: LitErrorKind.Validation,
   },
   WRONG_PARAM_FORMAT: {
     name: 'WrongParamFormat',
     code: 'wrong_param_format',
+    kind: LitErrorKind.Validation,
   },
   LOCAL_STORAGE_ITEM_NOT_FOUND_EXCEPTION: {
     name: 'LocalStorageItemNotFoundException',
     code: 'local_storage_item_not_found_exception',
+    kind: LitErrorKind.Unexpected,
   },
   REMOVED_FUNCTION_ERROR: {
     name: 'RemovedFunctionError',
     code: 'removed_function_error',
+    kind: LitErrorKind.Validation,
   },
   LIT_NODE_CLIENT_BAD_CONFIG_ERROR: {
     name: 'LitNodeClientBadConfigError',
     code: 'lit_node_client_bad_config_error',
+    kind: LitErrorKind.Config,
   },
   PARAMS_MISSING_ERROR: {
     name: 'ParamsMissingError',
     code: 'params_missing_error',
+    kind: LitErrorKind.Validation,
   },
   UNKNOWN_SIGNATURE_TYPE: {
     name: 'UnknownSignatureType',
     code: 'unknown_signature_type',
+    kind: LitErrorKind.Validation,
   },
   PARAM_NULL_ERROR: {
     name: 'ParamNullError',
     code: 'param_null_error',
+    kind: LitErrorKind.Validation,
   },
   UNKNOWN_DECRYPTION_ALGORITHM_TYPE_ERROR: {
     name: 'UnknownDecryptionAlgorithmTypeError',
     code: 'unknown_decryption_algorithm_type_error',
+    kind: LitErrorKind.Validation,
   },
   WASM_INIT_ERROR: {
     name: 'WasmInitError',
     code: 'wasm_init_error',
+    kind: LitErrorKind.Unexpected,
   },
   NODEJS_EXCEPTION: {
     name: 'NodejsException',
     code: 'nodejs_exception',
+    kind: LitErrorKind.Unexpected,
   },
   WALLET_SIGNATURE_NOT_FOUND_ERROR: {
     name: 'WalletSignatureNotFoundError',
     code: 'wallet_signature_not_found_error',
+    kind: LitErrorKind.Validation,
   },
   NO_VALID_SHARES: {
     name: 'NoValidShares',
-  }
+    code: 'no_valid_shares',
+    kind: LitErrorKind.Unexpected,
+  },
+};
+
+export const LIT_ERROR_CODE = {
+  NODE_NOT_AUTHORIZED: 'NodeNotAuthorized',
 };

--- a/packages/crypto/src/lib/crypto.ts
+++ b/packages/crypto/src/lib/crypto.ts
@@ -3,6 +3,7 @@
 import { wasmBlsSdkHelpers, initWasmBlsSdk } from '@lit-protocol/bls-sdk';
 
 import {
+  LIT_ERROR,
   SessionKeyPair,
   SigShare,
   SYMM_KEY_ALGO_PARAMS,
@@ -191,8 +192,7 @@ export const combineBlsShares = (
  *
  */
 export const combineEcdsaShares = (sigShares: Array<SigShare>): any => {
-
-  log("sigShares:", sigShares);
+  log('sigShares:', sigShares);
 
   // the public key can come from any node - it obviously will be identical from each node
   // const publicKey = sigShares[0].publicKey;
@@ -205,23 +205,24 @@ export const combineEcdsaShares = (sigShares: Array<SigShare>): any => {
     return acc;
   }, []);
 
-  log("Valid Shares:", validShares);
+  log('Valid Shares:', validShares);
 
   // if there are no valid shares, throw an error
   if (validShares.length === 0) {
     return throwError({
-      code: 'NO_VALID_SHARES',
       message: 'No valid shares to combine',
-    })
+      error_kind: LIT_ERROR.NO_VALID_SHARES.kind,
+      error_code: LIT_ERROR.NO_VALID_SHARES.name,
+    });
   }
 
   // R_x & R_y values can come from any node (they will be different per node), and will generate a valid signature
   const R_x = validShares[0].localX;
   const R_y = validShares[0].localY;
 
-  log("R_x:", R_x);
-  log("R_y:", R_y);
-  
+  log('R_x:', R_x);
+  log('R_y:', R_y);
+
   const shareHexes = validShares.map((s: any) => s.shareHex);
   log('shareHexes:', shareHexes);
 
@@ -230,10 +231,10 @@ export const combineEcdsaShares = (sigShares: Array<SigShare>): any => {
 
   let sig: string = '';
 
-  try{
+  try {
     sig = JSON.parse(wasmECDSA.combine_signature(R_x, R_y, shares));
-  }catch(e){
-    log("Failed to combine signatures:", e);
+  } catch (e) {
+    log('Failed to combine signatures:', e);
   }
 
   log('signature', sig);

--- a/packages/crypto/src/lib/crypto.ts
+++ b/packages/crypto/src/lib/crypto.ts
@@ -211,8 +211,8 @@ export const combineEcdsaShares = (sigShares: Array<SigShare>): any => {
   if (validShares.length === 0) {
     return throwError({
       message: 'No valid shares to combine',
-      error_kind: LIT_ERROR.NO_VALID_SHARES.kind,
-      error_code: LIT_ERROR.NO_VALID_SHARES.name,
+      errorKind: LIT_ERROR.NO_VALID_SHARES.kind,
+      errorCode: LIT_ERROR.NO_VALID_SHARES.name,
     });
   }
 

--- a/packages/encryption/src/lib/encryption.ts
+++ b/packages/encryption/src/lib/encryption.ts
@@ -132,23 +132,23 @@ export const encryptToIpfs = async ({
   if (!paramsIsSafe)
     return throwError({
       message: `authSig, sessionSigs, accessControlConditions, evmContractConditions, solRpcConditions, unifiedAccessControlConditions, chain, litNodeClient, string or file must be provided`,
-      error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
-      error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
+      errorKind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+      errorCode: LIT_ERROR.INVALID_PARAM_TYPE.name,
     });
 
   if (string === undefined && file === undefined)
     return throwError({
       message: `Either string or file must be provided`,
-      error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
-      error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
+      errorKind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+      errorCode: LIT_ERROR.INVALID_PARAM_TYPE.name,
     });
 
   if (!infuraId || !infuraSecretKey) {
     return throwError({
       message:
         'Please provide your Infura Project Id and Infura API Key Secret to add the encrypted metadata on IPFS',
-      error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
-      error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
+      errorKind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+      errorCode: LIT_ERROR.INVALID_PARAM_TYPE.name,
     });
   }
 
@@ -157,8 +157,8 @@ export const encryptToIpfs = async ({
   if (string !== undefined && file !== undefined) {
     return throwError({
       message: 'Provide only either a string or file to encrypt',
-      error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
-      error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
+      errorKind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+      errorCode: LIT_ERROR.INVALID_PARAM_TYPE.name,
     });
   } else if (string !== undefined) {
     const encryptedString = await encryptString(string);
@@ -219,8 +219,8 @@ export const encryptToIpfs = async ({
     return throwError({
       message:
         "Provided INFURA_ID or INFURA_SECRET_KEY in invalid hence can't upload to IPFS",
-      error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
-      error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
+      errorKind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+      errorCode: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
     });
   }
 };
@@ -254,8 +254,8 @@ export const decryptFromIpfs = async ({
   if (!paramsIsSafe)
     return throwError({
       message: `authSig, sessionSigs, ipfsCid, litNodeClient must be provided`,
-      error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
-      error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
+      errorKind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+      errorCode: LIT_ERROR.INVALID_PARAM_TYPE.name,
     });
 
   try {
@@ -288,8 +288,8 @@ export const decryptFromIpfs = async ({
   } catch (e) {
     return throwError({
       message: 'Invalid ipfsCid',
-      error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
-      error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
+      errorKind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+      errorCode: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
     });
   }
 };
@@ -315,8 +315,8 @@ export const encryptString = async (str: string): Promise<EncryptedString> => {
   ) {
     return throwError({
       message: `{${str}} must be a string`,
-      error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
-      error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
+      errorKind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+      errorCode: LIT_ERROR.INVALID_PARAM_TYPE.name,
     });
   }
 
@@ -363,8 +363,8 @@ export const decryptString = async (
   if (!paramsIsSafe) {
     throwError({
       message: 'Invalid params',
-      error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
-      error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
+      errorKind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+      errorCode: LIT_ERROR.INVALID_PARAM_TYPE.name,
     });
   }
 
@@ -401,8 +401,8 @@ export const zipAndEncryptString = async (
   )
     throwError({
       message: 'Invalid string',
-      error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
-      error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
+      errorKind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+      errorCode: LIT_ERROR.INVALID_PARAM_TYPE.name,
     });
 
   let zip;
@@ -452,8 +452,8 @@ export const zipAndEncryptFiles = async (
     )
       throwError({
         message: 'Invalid file type',
-        error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
-        error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
+        errorKind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+        errorCode: LIT_ERROR.INVALID_PARAM_TYPE.name,
       });
 
     const folder: JSZip | null = zip.folder('encryptedAssets');
@@ -462,8 +462,8 @@ export const zipAndEncryptFiles = async (
       log("Failed to get 'encryptedAssets' from zip.folder() ");
       return throwError({
         message: "Failed to get 'encryptedAssets' from zip.folder() ",
-        error_kind: LIT_ERROR.UNKNOWN_ERROR.kind,
-        error_code: LIT_ERROR.UNKNOWN_ERROR.name,
+        errorKind: LIT_ERROR.UNKNOWN_ERROR.kind,
+        errorCode: LIT_ERROR.UNKNOWN_ERROR.name,
       });
     }
 
@@ -498,8 +498,8 @@ export const decryptZip = async (
   if (!paramsIsSafe) {
     throwError({
       message: `encryptedZipBlob must be a Blob or File. symmKey must be a Uint8Array`,
-      error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
-      error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
+      errorKind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+      errorCode: LIT_ERROR.INVALID_PARAM_TYPE.name,
     });
   }
 
@@ -606,8 +606,8 @@ export const encryptFileAndZipWithMetadata = async ({
   if (!paramsIsSafe)
     return throwError({
       message: `authSig, sessionSigs, accessControlConditions, evmContractConditions, solRpcConditions, unifiedAccessControlConditions, chain, file, litNodeClient, and readme must be provided`,
-      error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
-      error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
+      errorKind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+      errorCode: LIT_ERROR.INVALID_PARAM_TYPE.name,
     });
 
   // -- validate
@@ -667,8 +667,8 @@ export const encryptFileAndZipWithMetadata = async ({
     log("Failed to get 'encryptedAssets' from zip.folder() ");
     return throwError({
       message: `Failed to get 'encryptedAssets' from zip.folder()`,
-      error_kind: LIT_ERROR.UNKNOWN_ERROR.kind,
-      error_code: LIT_ERROR.UNKNOWN_ERROR.name,
+      errorKind: LIT_ERROR.UNKNOWN_ERROR.kind,
+      errorCode: LIT_ERROR.UNKNOWN_ERROR.name,
     });
   }
 
@@ -747,8 +747,8 @@ export const decryptZipFileWithMetadata = async ({
     });
   } catch (e: any) {
     if (
-      e.error_code === 'NodeNotAuthorized' ||
-      e.error_code === 'not_authorized'
+      e.errorCode === 'NodeNotAuthorized' ||
+      e.errorCode === 'not_authorized'
     ) {
       // try more additionalAccessControlConditions
       if (!additionalAccessControlConditions) {
@@ -781,8 +781,8 @@ export const decryptZipFileWithMetadata = async ({
         } catch (e: any) {
           // swallow not_authorized because we are gonna try some more accessControlConditions
           if (
-            e.error_code === 'NodeNotAuthorized' ||
-            e.error_code === 'not_authorized'
+            e.errorCode === 'NodeNotAuthorized' ||
+            e.errorCode === 'not_authorized'
           ) {
             throw e;
           }
@@ -856,8 +856,8 @@ export const encryptFile = async ({
   ) {
     return throwError({
       message: 'file must be a Blob or File',
-      error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
-      error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
+      errorKind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+      errorCode: LIT_ERROR.INVALID_PARAM_TYPE.name,
     });
   }
 
@@ -908,8 +908,8 @@ export const decryptFile = async ({
   if (!paramsIsSafe) {
     return throwError({
       message: `file type must be Blob or File, and symmetricKey type must be Uint8Array | string | CryptoKey | BufferSource`,
-      error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
-      error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
+      errorKind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+      errorCode: LIT_ERROR.INVALID_PARAM_TYPE.name,
     });
   }
 
@@ -950,8 +950,8 @@ export const verifyJwt = ({ jwt }: VerifyJWTProps): IJWT => {
   )
     return throwError({
       message: 'jwt must be a string',
-      error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
-      error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
+      errorKind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+      errorCode: LIT_ERROR.INVALID_PARAM_TYPE.name,
     });
 
   log('verifyJwt', jwt);

--- a/packages/encryption/src/lib/encryption.ts
+++ b/packages/encryption/src/lib/encryption.ts
@@ -1,7 +1,4 @@
-import {
-  LIT_ERROR,
-  NETWORK_PUB_KEY,
-} from '@lit-protocol/constants';
+import { LIT_ERROR, NETWORK_PUB_KEY } from '@lit-protocol/constants';
 
 import {
   AcceptedFileType,
@@ -132,21 +129,27 @@ export const encryptToIpfs = async ({
     },
   });
 
-  if (!paramsIsSafe) return throwError({
-    message: `authSig, sessionSigs, accessControlConditions, evmContractConditions, solRpcConditions, unifiedAccessControlConditions, chain, litNodeClient, string or file must be provided`,
-    error: LIT_ERROR.INVALID_PARAM_TYPE,
-  });
+  if (!paramsIsSafe)
+    return throwError({
+      message: `authSig, sessionSigs, accessControlConditions, evmContractConditions, solRpcConditions, unifiedAccessControlConditions, chain, litNodeClient, string or file must be provided`,
+      error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+      error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
+    });
 
-  if (string === undefined && file === undefined) return throwError({
-    message: `Either string or file must be provided`,
-    error: LIT_ERROR.INVALID_PARAM_TYPE,
-  });
+  if (string === undefined && file === undefined)
+    return throwError({
+      message: `Either string or file must be provided`,
+      error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+      error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
+    });
 
   if (!infuraId || !infuraSecretKey) {
     return throwError({
-      message: 'Please provide your Infura Project Id and Infura API Key Secret to add the encrypted metadata on IPFS',
-      error: LIT_ERROR.INVALID_PARAM_TYPE,
-    })
+      message:
+        'Please provide your Infura Project Id and Infura API Key Secret to add the encrypted metadata on IPFS',
+      error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+      error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
+    });
   }
 
   let encryptedData;
@@ -154,9 +157,9 @@ export const encryptToIpfs = async ({
   if (string !== undefined && file !== undefined) {
     return throwError({
       message: 'Provide only either a string or file to encrypt',
-      error: LIT_ERROR.INVALID_PARAM_TYPE,
-    })
-
+      error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+      error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
+    });
   } else if (string !== undefined) {
     const encryptedString = await encryptString(string);
     encryptedData = encryptedString.encryptedString;
@@ -180,36 +183,47 @@ export const encryptToIpfs = async ({
 
   log('encrypted key saved to Lit', encryptedSymmetricKey);
 
-  const encryptedSymmetricKeyString = uint8arrayToString(encryptedSymmetricKey, "base16");
+  const encryptedSymmetricKeyString = uint8arrayToString(
+    encryptedSymmetricKey,
+    'base16'
+  );
 
-  const authorization = 'Basic ' + Buffer.from(`${infuraId}:${infuraSecretKey}`).toString('base64');
+  const authorization =
+    'Basic ' + Buffer.from(`${infuraId}:${infuraSecretKey}`).toString('base64');
   const ipfs = ipfsClient.create({
-    url: "https://ipfs.infura.io:5001/api/v0",
-    headers:{
-      authorization
-    }
+    url: 'https://ipfs.infura.io:5001/api/v0',
+    headers: {
+      authorization,
+    },
   });
 
-  const encryptedDataJson = Buffer.from(await encryptedData.arrayBuffer()).toJSON();
+  const encryptedDataJson = Buffer.from(
+    await encryptedData.arrayBuffer()
+  ).toJSON();
   try {
-    const res = await ipfs.add(JSON.stringify({
-      [string !== undefined ? "encryptedString" : "encryptedFile"]: encryptedDataJson,
-      encryptedSymmetricKeyString,
-      accessControlConditions,
-      evmContractConditions,
-      solRpcConditions,
-      unifiedAccessControlConditions,
-      chain
-    }));
+    const res = await ipfs.add(
+      JSON.stringify({
+        [string !== undefined ? 'encryptedString' : 'encryptedFile']:
+          encryptedDataJson,
+        encryptedSymmetricKeyString,
+        accessControlConditions,
+        evmContractConditions,
+        solRpcConditions,
+        unifiedAccessControlConditions,
+        chain,
+      })
+    );
 
     return res.path;
-  } catch(e) {
+  } catch (e) {
     return throwError({
-      message: 'Provided INFURA_ID or INFURA_SECRET_KEY in invalid hence can\'t upload to IPFS',
-      error: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION,
-    })
+      message:
+        "Provided INFURA_ID or INFURA_SECRET_KEY in invalid hence can't upload to IPFS",
+      error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+      error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
+    });
   }
-}
+};
 
 /**
  *
@@ -237,13 +251,17 @@ export const decryptFromIpfs = async ({
     },
   });
 
-  if (!paramsIsSafe) return throwError({
-    message: `authSig, sessionSigs, ipfsCid, litNodeClient must be provided`,
-    error: LIT_ERROR.INVALID_PARAM_TYPE,
-  });
+  if (!paramsIsSafe)
+    return throwError({
+      message: `authSig, sessionSigs, ipfsCid, litNodeClient must be provided`,
+      error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+      error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
+    });
 
   try {
-    const metadata = await (await fetch(`https://gateway.pinata.cloud/ipfs/${ipfsCid}`)).json();
+    const metadata = await (
+      await fetch(`https://gateway.pinata.cloud/ipfs/${ipfsCid}`)
+    ).json();
     const symmetricKey = await litNodeClient.getEncryptionKey({
       accessControlConditions: metadata.accessControlConditions,
       evmContractConditions: metadata.evmContractConditions,
@@ -254,21 +272,27 @@ export const decryptFromIpfs = async ({
       authSig,
       sessionSigs,
     });
-  
+
     if (metadata.encryptedString !== undefined) {
-      const encryptedStringBlob = new Blob([Buffer.from(metadata.encryptedString)], { type: 'application/octet-stream' });
+      const encryptedStringBlob = new Blob(
+        [Buffer.from(metadata.encryptedString)],
+        { type: 'application/octet-stream' }
+      );
       return await decryptString(encryptedStringBlob, symmetricKey);
     }
 
-    const encryptedFileBlob = new Blob([Buffer.from(metadata.encryptedFile)], { type: 'application/octet-stream' });
+    const encryptedFileBlob = new Blob([Buffer.from(metadata.encryptedFile)], {
+      type: 'application/octet-stream',
+    });
     return await decryptFile({ file: encryptedFileBlob, symmetricKey });
-  } catch(e) {
+  } catch (e) {
     return throwError({
       message: 'Invalid ipfsCid',
-      error: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION,
-    })
+      error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+      error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
+    });
   }
-}
+};
 
 // ---------- Local Helpers ----------
 
@@ -291,8 +315,9 @@ export const encryptString = async (str: string): Promise<EncryptedString> => {
   ) {
     return throwError({
       message: `{${str}} must be a string`,
-      error: LIT_ERROR.INVALID_PARAM_TYPE,
-    })
+      error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+      error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
+    });
   }
 
   // -- prepare
@@ -338,7 +363,8 @@ export const decryptString = async (
   if (!paramsIsSafe) {
     throwError({
       message: 'Invalid params',
-      error: LIT_ERROR.INVALID_PARAM_TYPE,
+      error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+      error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
     });
   }
 
@@ -375,7 +401,8 @@ export const zipAndEncryptString = async (
   )
     throwError({
       message: 'Invalid string',
-      error: LIT_ERROR.INVALID_PARAM_TYPE,
+      error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+      error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
     });
 
   let zip;
@@ -425,7 +452,8 @@ export const zipAndEncryptFiles = async (
     )
       throwError({
         message: 'Invalid file type',
-        error: LIT_ERROR.INVALID_PARAM_TYPE,
+        error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+        error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
       });
 
     const folder: JSZip | null = zip.folder('encryptedAssets');
@@ -434,7 +462,8 @@ export const zipAndEncryptFiles = async (
       log("Failed to get 'encryptedAssets' from zip.folder() ");
       return throwError({
         message: "Failed to get 'encryptedAssets' from zip.folder() ",
-        error: LIT_ERROR.UNKNOWN_ERROR,
+        error_kind: LIT_ERROR.UNKNOWN_ERROR.kind,
+        error_code: LIT_ERROR.UNKNOWN_ERROR.name,
       });
     }
 
@@ -466,12 +495,13 @@ export const decryptZip = async (
     },
   });
 
-  if (!paramsIsSafe){
+  if (!paramsIsSafe) {
     throwError({
       message: `encryptedZipBlob must be a Blob or File. symmKey must be a Uint8Array`,
-      error: LIT_ERROR.INVALID_PARAM_TYPE,
+      error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+      error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
     });
-  };
+  }
 
   // import the decrypted symm key
   const importedSymmKey = await importSymmetricKey(symmKey);
@@ -573,10 +603,12 @@ export const encryptFileAndZipWithMetadata = async ({
     },
   });
 
-  if (!paramsIsSafe) return throwError({
-    message: `authSig, sessionSigs, accessControlConditions, evmContractConditions, solRpcConditions, unifiedAccessControlConditions, chain, file, litNodeClient, and readme must be provided`,
-    error: LIT_ERROR.INVALID_PARAM_TYPE,
-  });
+  if (!paramsIsSafe)
+    return throwError({
+      message: `authSig, sessionSigs, accessControlConditions, evmContractConditions, solRpcConditions, unifiedAccessControlConditions, chain, file, litNodeClient, and readme must be provided`,
+      error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+      error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
+    });
 
   // -- validate
   const symmetricKey = await generateSymmetricKey();
@@ -635,7 +667,8 @@ export const encryptFileAndZipWithMetadata = async ({
     log("Failed to get 'encryptedAssets' from zip.folder() ");
     return throwError({
       message: `Failed to get 'encryptedAssets' from zip.folder()`,
-      error: LIT_ERROR.UNKNOWN_ERROR,
+      error_kind: LIT_ERROR.UNKNOWN_ERROR.kind,
+      error_code: LIT_ERROR.UNKNOWN_ERROR.name,
     });
   }
 
@@ -713,7 +746,10 @@ export const decryptZipFileWithMetadata = async ({
       sessionSigs,
     });
   } catch (e: any) {
-    if (e.errorCode === 'not_authorized') {
+    if (
+      e.error_code === 'NodeNotAuthorized' ||
+      e.error_code === 'not_authorized'
+    ) {
       // try more additionalAccessControlConditions
       if (!additionalAccessControlConditions) {
         throw e;
@@ -744,7 +780,10 @@ export const decryptZipFileWithMetadata = async ({
           break; // it worked, we can leave the loop and stop checking additional access control conditions
         } catch (e: any) {
           // swallow not_authorized because we are gonna try some more accessControlConditions
-          if (e.errorCode !== 'not_authorized') {
+          if (
+            e.error_code === 'NodeNotAuthorized' ||
+            e.error_code === 'not_authorized'
+          ) {
             throw e;
           }
         }
@@ -801,7 +840,11 @@ export const decryptZipFileWithMetadata = async ({
  *
  * @returns { Promise<Object> } A promise containing an object with keys encryptedFile and symmetricKey.  encryptedFile is a Blob, and symmetricKey is a Uint8Array that can be used to decrypt the file.
  */
-export const encryptFile = async ({ file }: { file: AcceptedFileType }) : Promise<EncryptedFile>=> {
+export const encryptFile = async ({
+  file,
+}: {
+  file: AcceptedFileType;
+}): Promise<EncryptedFile> => {
   // -- validate
   if (
     !checkType({
@@ -810,11 +853,12 @@ export const encryptFile = async ({ file }: { file: AcceptedFileType }) : Promis
       paramName: 'file',
       functionName: 'encryptFile',
     })
-  ){
+  ) {
     return throwError({
       message: 'file must be a Blob or File',
-      error: LIT_ERROR.INVALID_PARAM_TYPE
-    })
+      error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+      error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
+    });
   }
 
   // generate a random symmetric key
@@ -861,12 +905,13 @@ export const decryptFile = async ({
     },
   });
 
-  if (!paramsIsSafe){
+  if (!paramsIsSafe) {
     return throwError({
       message: `file type must be Blob or File, and symmetricKey type must be Uint8Array | string | CryptoKey | BufferSource`,
-      error: LIT_ERROR.INVALID_PARAM_TYPE
-    })
-  };
+      error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+      error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
+    });
+  }
 
   // -- execute
   const importedSymmKey = await importSymmetricKey(symmetricKey);
@@ -905,7 +950,8 @@ export const verifyJwt = ({ jwt }: VerifyJWTProps): IJWT => {
   )
     return throwError({
       message: 'jwt must be a string',
-      error: LIT_ERROR.INVALID_PARAM_TYPE
+      error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+      error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
     });
 
   log('verifyJwt', jwt);

--- a/packages/encryption/src/lib/params-validators.ts
+++ b/packages/encryption/src/lib/params-validators.ts
@@ -62,8 +62,8 @@ export const paramsValidators = {
       const message = 'You must pass either code or ipfsId';
       throwError({
         message,
-        error_kind: LIT_ERROR.PARAMS_MISSING_ERROR.kind,
-        error_code: LIT_ERROR.PARAMS_MISSING_ERROR.name,
+        errorKind: LIT_ERROR.PARAMS_MISSING_ERROR.kind,
+        errorCode: LIT_ERROR.PARAMS_MISSING_ERROR.name,
       });
       return false;
     }
@@ -74,8 +74,8 @@ export const paramsValidators = {
 
       throwError({
         message,
-        error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
-        error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
+        errorKind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+        errorCode: LIT_ERROR.INVALID_PARAM_TYPE.name,
       });
       return false;
     }
@@ -113,8 +113,8 @@ export const paramsValidators = {
     if (!sessionSigs && !authSig) {
       throwError({
         message: 'You must pass either authSig or sessionSigs',
-        error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
-        error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
+        errorKind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+        errorCode: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
       });
       return false;
     }
@@ -123,8 +123,8 @@ export const paramsValidators = {
     if (sessionSigs && authSig) {
       throwError({
         message: 'You must pass only one authSig or sessionSigs',
-        error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
-        error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
+        errorKind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+        errorCode: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
       });
       return false;
     }
@@ -202,8 +202,8 @@ export const paramsValidators = {
     if (!sessionSigs && !authSig) {
       throwError({
         message: 'You must pass either authSig or sessionSigs',
-        error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
-        error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
+        errorKind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+        errorCode: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
       });
       return false;
     }
@@ -253,8 +253,8 @@ export const paramsValidators = {
     if (sessionSigs && authSig) {
       throwError({
         message: 'You must pass only one authSig or sessionSigs',
-        error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
-        error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
+        errorKind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+        errorCode: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
       });
       return false;
     }
@@ -329,8 +329,8 @@ export const paramsValidators = {
     if (!sessionSigs && !authSig) {
       throwError({
         message: 'You must pass either authSig or sessionSigs',
-        error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
-        error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
+        errorKind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+        errorCode: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
       });
       return false;
     }
@@ -339,8 +339,8 @@ export const paramsValidators = {
     if (sessionSigs && authSig) {
       throwError({
         message: 'You must pass only one authSig or sessionSigs',
-        error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
-        error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
+        errorKind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+        errorCode: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
       });
       return false;
     }
@@ -443,8 +443,8 @@ export const paramsValidators = {
     if (!params.sessionSigs && !params.authSig) {
       throwError({
         message: 'You must pass either authSig or sessionSigs',
-        error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
-        error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
+        errorKind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+        errorCode: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
       });
       return false;
     }
@@ -453,8 +453,8 @@ export const paramsValidators = {
     if (params.sessionSigs && params.authSig) {
       throwError({
         message: 'You must pass only one authSig or sessionSigs',
-        error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
-        error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
+        errorKind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+        errorCode: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
       });
       return false;
     }
@@ -590,8 +590,8 @@ export const paramsValidators = {
     if (!params.sessionSigs && !params.authSig) {
       throwError({
         message: 'You must pass either authSig or sessionSigs',
-        error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
-        error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
+        errorKind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+        errorCode: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
       });
       return false;
     }
@@ -600,8 +600,8 @@ export const paramsValidators = {
     if (params.sessionSigs && params.authSig) {
       throwError({
         message: 'You must pass only one authSig or sessionSigs',
-        error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
-        error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
+        errorKind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+        errorCode: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
       });
       return false;
     }
@@ -661,8 +661,8 @@ export const paramsValidators = {
     if (!params.sessionSigs && !params.authSig) {
       throwError({
         message: 'You must pass either authSig or sessionSigs',
-        error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
-        error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
+        errorKind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+        errorCode: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
       });
       return false;
     }
@@ -671,8 +671,8 @@ export const paramsValidators = {
     if (params.sessionSigs && params.authSig) {
       throwError({
         message: 'You must pass only one authSig or sessionSigs',
-        error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
-        error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
+        errorKind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+        errorCode: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
       });
       return false;
     }
@@ -774,8 +774,8 @@ export const paramsValidators = {
     if (!params.sessionSigs && !params.authSig) {
       throwError({
         message: 'You must pass either authSig or sessionSigs',
-        error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
-        error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
+        errorKind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+        errorCode: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
       });
       return false;
     }
@@ -784,8 +784,8 @@ export const paramsValidators = {
     if (params.sessionSigs && params.authSig) {
       throwError({
         message: 'You must pass only one authSig or sessionSigs',
-        error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
-        error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
+        errorKind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+        errorCode: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
       });
       return false;
     }

--- a/packages/encryption/src/lib/params-validators.ts
+++ b/packages/encryption/src/lib/params-validators.ts
@@ -60,7 +60,11 @@ export const paramsValidators = {
     // -- validate: either 'code' or 'ipfsId' must exists
     if (!code && !ipfsId) {
       const message = 'You must pass either code or ipfsId';
-      throwError({ message, error: LIT_ERROR.PARAMS_MISSING_ERROR });
+      throwError({
+        message,
+        error_kind: LIT_ERROR.PARAMS_MISSING_ERROR.kind,
+        error_code: LIT_ERROR.PARAMS_MISSING_ERROR.name,
+      });
       return false;
     }
 
@@ -68,7 +72,11 @@ export const paramsValidators = {
     if (code && ipfsId) {
       const message = "You cannot have both 'code' and 'ipfs' at the same time";
 
-      throwError({ message, error: LIT_ERROR.INVALID_PARAM_TYPE });
+      throwError({
+        message,
+        error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+        error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
+      });
       return false;
     }
 
@@ -105,8 +113,8 @@ export const paramsValidators = {
     if (!sessionSigs && !authSig) {
       throwError({
         message: 'You must pass either authSig or sessionSigs',
-        name: 'InvalidArgumentException',
-        errorCode: 'invalid_argument',
+        error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+        error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
       });
       return false;
     }
@@ -115,8 +123,8 @@ export const paramsValidators = {
     if (sessionSigs && authSig) {
       throwError({
         message: 'You must pass only one authSig or sessionSigs',
-        name: 'InvalidArgumentException',
-        errorCode: 'invalid_argument',
+        error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+        error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
       });
       return false;
     }
@@ -194,8 +202,8 @@ export const paramsValidators = {
     if (!sessionSigs && !authSig) {
       throwError({
         message: 'You must pass either authSig or sessionSigs',
-        name: 'InvalidArgumentException',
-        errorCode: 'invalid_argument',
+        error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+        error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
       });
       return false;
     }
@@ -245,8 +253,8 @@ export const paramsValidators = {
     if (sessionSigs && authSig) {
       throwError({
         message: 'You must pass only one authSig or sessionSigs',
-        name: 'InvalidArgumentException',
-        errorCode: 'invalid_argument',
+        error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+        error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
       });
       return false;
     }
@@ -321,8 +329,8 @@ export const paramsValidators = {
     if (!sessionSigs && !authSig) {
       throwError({
         message: 'You must pass either authSig or sessionSigs',
-        name: 'InvalidArgumentException',
-        errorCode: 'invalid_argument',
+        error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+        error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
       });
       return false;
     }
@@ -331,8 +339,8 @@ export const paramsValidators = {
     if (sessionSigs && authSig) {
       throwError({
         message: 'You must pass only one authSig or sessionSigs',
-        name: 'InvalidArgumentException',
-        errorCode: 'invalid_argument',
+        error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+        error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
       });
       return false;
     }
@@ -342,7 +350,10 @@ export const paramsValidators = {
       return false;
     }
 
-    if (authSig && !checkIfAuthSigRequiresChainParam(authSig, chain, 'getEncryptionKey'))
+    if (
+      authSig &&
+      !checkIfAuthSigRequiresChainParam(authSig, chain, 'getEncryptionKey')
+    )
       return false;
 
     return true;
@@ -417,15 +428,23 @@ export const paramsValidators = {
       return false;
 
     // -- validate: sessionSigs and its type is correct
-    if (params.sessionSigs && !is(params.sessionSigs, 'Object', 'sessionSigs', 'decryptZipFileWithMetadata'))
+    if (
+      params.sessionSigs &&
+      !is(
+        params.sessionSigs,
+        'Object',
+        'sessionSigs',
+        'decryptZipFileWithMetadata'
+      )
+    )
       return false;
 
     // -- validate: if sessionSig or authSig exists
     if (!params.sessionSigs && !params.authSig) {
       throwError({
         message: 'You must pass either authSig or sessionSigs',
-        name: 'InvalidArgumentException',
-        errorCode: 'invalid_argument',
+        error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+        error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
       });
       return false;
     }
@@ -434,8 +453,8 @@ export const paramsValidators = {
     if (params.sessionSigs && params.authSig) {
       throwError({
         message: 'You must pass only one authSig or sessionSigs',
-        name: 'InvalidArgumentException',
-        errorCode: 'invalid_argument',
+        error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+        error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
       });
       return false;
     }
@@ -561,15 +580,18 @@ export const paramsValidators = {
       return false;
 
     // -- validate: sessionSigs and its type is correct
-    if (params.sessionSigs && !is(params.sessionSigs, 'Object', 'sessionSigs', 'encryptToIpfs'))
+    if (
+      params.sessionSigs &&
+      !is(params.sessionSigs, 'Object', 'sessionSigs', 'encryptToIpfs')
+    )
       return false;
 
     // -- validate: if sessionSig or authSig exists
     if (!params.sessionSigs && !params.authSig) {
       throwError({
         message: 'You must pass either authSig or sessionSigs',
-        name: 'InvalidArgumentException',
-        errorCode: 'invalid_argument',
+        error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+        error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
       });
       return false;
     }
@@ -578,8 +600,8 @@ export const paramsValidators = {
     if (params.sessionSigs && params.authSig) {
       throwError({
         message: 'You must pass only one authSig or sessionSigs',
-        name: 'InvalidArgumentException',
-        errorCode: 'invalid_argument',
+        error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+        error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
       });
       return false;
     }
@@ -629,15 +651,18 @@ export const paramsValidators = {
       return false;
 
     // -- validate: sessionSigs and its type is correct
-    if (params.sessionSigs && !is(params.sessionSigs, 'Object', 'sessionSigs', 'decryptFromIpfs'))
+    if (
+      params.sessionSigs &&
+      !is(params.sessionSigs, 'Object', 'sessionSigs', 'decryptFromIpfs')
+    )
       return false;
 
     // -- validate: if sessionSig or authSig exists
     if (!params.sessionSigs && !params.authSig) {
       throwError({
         message: 'You must pass either authSig or sessionSigs',
-        name: 'InvalidArgumentException',
-        errorCode: 'invalid_argument',
+        error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+        error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
       });
       return false;
     }
@@ -646,8 +671,8 @@ export const paramsValidators = {
     if (params.sessionSigs && params.authSig) {
       throwError({
         message: 'You must pass only one authSig or sessionSigs',
-        name: 'InvalidArgumentException',
-        errorCode: 'invalid_argument',
+        error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+        error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
       });
       return false;
     }
@@ -734,15 +759,23 @@ export const paramsValidators = {
       return false;
 
     // -- validate: sessionSigs and its type is correct
-    if (params.sessionSigs && !is(params.sessionSigs, 'Object', 'sessionSigs', 'encryptFileAndZipWithMetadata'))
+    if (
+      params.sessionSigs &&
+      !is(
+        params.sessionSigs,
+        'Object',
+        'sessionSigs',
+        'encryptFileAndZipWithMetadata'
+      )
+    )
       return false;
 
     // -- validate: if sessionSig or authSig exists
     if (!params.sessionSigs && !params.authSig) {
       throwError({
         message: 'You must pass either authSig or sessionSigs',
-        name: 'InvalidArgumentException',
-        errorCode: 'invalid_argument',
+        error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+        error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
       });
       return false;
     }
@@ -751,8 +784,8 @@ export const paramsValidators = {
     if (params.sessionSigs && params.authSig) {
       throwError({
         message: 'You must pass only one authSig or sessionSigs',
-        name: 'InvalidArgumentException',
-        errorCode: 'invalid_argument',
+        error_kind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+        error_code: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
       });
       return false;
     }

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -67,6 +67,8 @@ import {
   WebAuthnAuthenticationVerificationParams,
   AuthMethod,
   SignSessionKeyResponse,
+  NodeClientErrorV0,
+  NodeClientErrorV1,
 } from '@lit-protocol/types';
 import {
   combineBlsDecryptionShares,
@@ -1199,10 +1201,7 @@ export class LitNodeClientNodeJs {
           res.error.message ||
           'You are not authorized to access to this content',
         errorCode: res.error.errorCode!,
-        errorKind: isNodeErrorV1(res.error)
-          ? res.error.errorKind
-          : LitErrorKind.Validation,
-      });
+      } as NodeClientErrorV0 | NodeClientErrorV1);
     } else {
       throwError({
         message: `There was an error getting the signing shares from the nodes`,

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -1182,15 +1182,16 @@ export class LitNodeClientNodeJs {
    *
    */
   throwNodeError = (res: RejectedNodePromises): void => {
-    if (
-      res.error.errorCode &&
-      (res.error.errorCode === LIT_ERROR_CODE.NODE_NOT_AUTHORIZED ||
-        res.error.errorCode === 'not_authorized') &&
-      this.config.alertWhenUnauthorized
-    ) {
-      log(
-        '[Alert originally] You are not authorized to access to this content'
-      );
+    if (res.error && res.error.errorCode) {
+      if (
+        (res.error.errorCode === LIT_ERROR_CODE.NODE_NOT_AUTHORIZED ||
+          res.error.errorCode === 'not_authorized') &&
+        this.config.alertWhenUnauthorized
+      ) {
+        log(
+          '[Alert originally] You are not authorized to access to this content'
+        );
+      }
 
       throwError({
         ...res.error,
@@ -1203,7 +1204,7 @@ export class LitNodeClientNodeJs {
           : LitErrorKind.Validation,
       });
     } else {
-      throwGenericError({
+      throwError({
         message: `There was an error getting the signing shares from the nodes`,
         error: LIT_ERROR.UNKNOWN_ERROR,
       });

--- a/packages/misc-browser/src/lib/misc-browser.ts
+++ b/packages/misc-browser/src/lib/misc-browser.ts
@@ -24,8 +24,8 @@ export const getStorageItem = (key: string): IEither => {
   if (!item) {
     keyOrError = ELeft({
       message: `Failed to get ${key} from local storage`,
-      error_kind: LIT_ERROR.LOCAL_STORAGE_ITEM_NOT_FOUND_EXCEPTION.kind,
-      error_code: LIT_ERROR.LOCAL_STORAGE_ITEM_NOT_FOUND_EXCEPTION.name,
+      errorKind: LIT_ERROR.LOCAL_STORAGE_ITEM_NOT_FOUND_EXCEPTION.kind,
+      errorCode: LIT_ERROR.LOCAL_STORAGE_ITEM_NOT_FOUND_EXCEPTION.name,
     });
   } else {
     keyOrError = ERight(item);

--- a/packages/misc-browser/src/lib/misc-browser.ts
+++ b/packages/misc-browser/src/lib/misc-browser.ts
@@ -24,7 +24,8 @@ export const getStorageItem = (key: string): IEither => {
   if (!item) {
     keyOrError = ELeft({
       message: `Failed to get ${key} from local storage`,
-      error: LIT_ERROR.LOCAL_STORAGE_ITEM_NOT_FOUND_EXCEPTION,
+      error_kind: LIT_ERROR.LOCAL_STORAGE_ITEM_NOT_FOUND_EXCEPTION.kind,
+      error_code: LIT_ERROR.LOCAL_STORAGE_ITEM_NOT_FOUND_EXCEPTION.name,
     });
   } else {
     keyOrError = ERight(item);

--- a/packages/misc/src/lib/misc.spec.ts
+++ b/packages/misc/src/lib/misc.spec.ts
@@ -4,7 +4,7 @@ global.TextEncoder = TextEncoder;
 // @ts-ignore
 global.TextDecoder = TextDecoder;
 
-import { LIT_ERROR } from '@lit-protocol/constants';
+import { LitErrorKind, LIT_ERROR } from '@lit-protocol/constants';
 import * as utilsModule from './misc';
 
 describe('utils', () => {
@@ -51,8 +51,8 @@ describe('utils', () => {
     try {
       err = utilsModule.throwError({
         message: 'Message!',
-        name: 'invalidParamType',
-        errorCode: 'invalid_param_type',
+        error_kind: 'hello',
+        error_code: 'world',
       });
     } catch (e) {
       err = e as Error;
@@ -62,11 +62,11 @@ describe('utils', () => {
     const values = Object.values(err);
 
     expect(keys).toContain('message');
-    expect(keys).toContain('name');
-    expect(keys).toContain('errorCode');
+    expect(keys).toContain('error_kind');
+    expect(keys).toContain('error_code');
     expect(values).toContain('Message!');
-    expect(values).toContain('invalidParamType');
-    expect(values).toContain('invalid_param_type');
+    expect(values).toContain('hello');
+    expect(values).toContain('world');
   });
 
   it('should able to use the error type from constants', () => {
@@ -75,7 +75,8 @@ describe('utils', () => {
     try {
       err = utilsModule.throwError({
         message: 'custom message',
-        error: LIT_ERROR.INVALID_PARAM_TYPE,
+        error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+        error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
       });
     } catch (e) {
       err = e as Error;
@@ -85,11 +86,11 @@ describe('utils', () => {
     const values = Object.values(err);
 
     expect(keys).toContain('message');
-    expect(keys).toContain('name');
-    expect(keys).toContain('errorCode');
+    expect(keys).toContain('error_kind');
+    expect(keys).toContain('error_code');
     expect(values).toContain('custom message');
-    // expect(values).toContain('invalidParamType');
-    expect(values).toContain('invalid_param_type');
+    expect(values).toContain(LitErrorKind.Validation);
+    expect(values).toContain(LIT_ERROR.INVALID_PARAM_TYPE.name);
   });
 
   it('should prepend [Lit-JS-SDK] in the console.log', () => {

--- a/packages/misc/src/lib/misc.spec.ts
+++ b/packages/misc/src/lib/misc.spec.ts
@@ -51,8 +51,8 @@ describe('utils', () => {
     try {
       err = utilsModule.throwError({
         message: 'Message!',
-        error_kind: 'hello',
-        error_code: 'world',
+        errorKind: 'hello',
+        errorCode: 'world',
       });
     } catch (e) {
       err = e as Error;
@@ -62,8 +62,8 @@ describe('utils', () => {
     const values = Object.values(err);
 
     expect(keys).toContain('message');
-    expect(keys).toContain('error_kind');
-    expect(keys).toContain('error_code');
+    expect(keys).toContain('errorKind');
+    expect(keys).toContain('errorCode');
     expect(values).toContain('Message!');
     expect(values).toContain('hello');
     expect(values).toContain('world');
@@ -75,8 +75,8 @@ describe('utils', () => {
     try {
       err = utilsModule.throwError({
         message: 'custom message',
-        error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
-        error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
+        errorKind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+        errorCode: LIT_ERROR.INVALID_PARAM_TYPE.name,
       });
     } catch (e) {
       err = e as Error;
@@ -86,8 +86,8 @@ describe('utils', () => {
     const values = Object.values(err);
 
     expect(keys).toContain('message');
-    expect(keys).toContain('error_kind');
-    expect(keys).toContain('error_code');
+    expect(keys).toContain('errorKind');
+    expect(keys).toContain('errorCode');
     expect(values).toContain('custom message');
     expect(values).toContain(LitErrorKind.Validation);
     expect(values).toContain(LIT_ERROR.INVALID_PARAM_TYPE.name);

--- a/packages/misc/src/lib/misc.ts
+++ b/packages/misc/src/lib/misc.ts
@@ -87,7 +87,7 @@ export const throwErrorV0 = ({
     this.name = name;
 
     // Map old error codes to new ones if possible.
-    this.error_code = oldErrorToNewErrorMap[errorCode] ?? errorCode;
+    this.errorCode = oldErrorToNewErrorMap[errorCode] ?? errorCode;
   };
 
   throw new (errConstructorFunc as any)(
@@ -109,41 +109,41 @@ const oldErrorToNewErrorMap: { [key: string]: string } = {
  *
  */
 export const throwErrorV1 = ({
-  error_kind,
+  errorKind,
   details,
   status,
   message,
-  error_code,
+  errorCode,
 }: NodeClientErrorV1): never => {
   const errConstructorFunc = function (
     this: any,
-    error_kind: string,
+    errorKind: string,
     status: number,
     details: string[],
     message?: string,
-    error_code?: string
+    errorCode?: string
   ) {
     this.message = message;
-    this.error_code = error_code;
-    this.error_kind = error_kind;
+    this.errorCode = errorCode;
+    this.errorKind = errorKind;
     this.status = status;
     this.details = details;
   };
 
   throw new (errConstructorFunc as any)(
-    error_kind,
+    errorKind,
     status,
     details,
     message,
-    error_code
+    errorCode
   );
 };
 
 export const throwGenericError = (e: any): never => {
   const errConstructorFunc = function (this: any, message: string) {
     this.message = message;
-    this.error_kind = LIT_ERROR.UNKNOWN_ERROR.name;
-    this.error_code = LIT_ERROR.UNKNOWN_ERROR.code;
+    this.errorKind = LIT_ERROR.UNKNOWN_ERROR.name;
+    this.errorCode = LIT_ERROR.UNKNOWN_ERROR.code;
   };
 
   throw new (errConstructorFunc as any)(e.message ?? 'Generic Error');
@@ -153,8 +153,8 @@ export const isNodeClientErrorV1 = (
   nodeError: NodeClientErrorV0 | NodeClientErrorV1
 ): nodeError is NodeClientErrorV1 => {
   return (
-    nodeError.hasOwnProperty('error_code') &&
-    nodeError.hasOwnProperty('error_kind')
+    nodeError.hasOwnProperty('errorCode') &&
+    nodeError.hasOwnProperty('errorKind')
   );
 };
 
@@ -168,8 +168,8 @@ export const isNodeErrorV1 = (
   nodeError: NodeErrorV0 | NodeErrorV1
 ): nodeError is NodeErrorV1 => {
   return (
-    nodeError.hasOwnProperty('error_code') &&
-    nodeError.hasOwnProperty('error_kind')
+    nodeError.hasOwnProperty('errorCode') &&
+    nodeError.hasOwnProperty('errorKind')
   );
 };
 
@@ -188,8 +188,8 @@ declare global {
 export const throwRemovedFunctionError = (functionName: string) => {
   throwError({
     message: `This function "${functionName}" has been removed. Please use the old SDK.`,
-    error_kind: LIT_ERROR.REMOVED_FUNCTION_ERROR.kind,
-    error_code: LIT_ERROR.REMOVED_FUNCTION_ERROR.name,
+    errorKind: LIT_ERROR.REMOVED_FUNCTION_ERROR.kind,
+    errorCode: LIT_ERROR.REMOVED_FUNCTION_ERROR.name,
   });
 };
 
@@ -285,8 +285,8 @@ export const checkType = ({
     if (throwOnError) {
       throwError({
         message,
-        error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
-        error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
+        errorKind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+        errorCode: LIT_ERROR.INVALID_PARAM_TYPE.name,
       });
     }
     return false;
@@ -394,8 +394,8 @@ export const is = (
     if (throwOnError) {
       throwError({
         message,
-        error_kind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
-        error_code: LIT_ERROR.INVALID_PARAM_TYPE.name,
+        errorKind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+        errorCode: LIT_ERROR.INVALID_PARAM_TYPE.name,
       });
     }
     return false;

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -459,11 +459,11 @@ export interface NodeErrorV0 {
 }
 
 export interface NodeErrorV1 {
-  error_kind: string;
+  errorKind: string;
   status: number;
   details: string[];
   message?: string;
-  error_code?: string;
+  errorCode?: string;
 }
 
 /**
@@ -480,8 +480,8 @@ export interface NodeClientErrorV0 {
 
 export interface NodeClientErrorV1 {
   message: string;
-  error_kind: string;
-  error_code: string;
+  errorKind: string;
+  errorCode: string;
   details?: string[];
   status?: number;
 }

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -439,7 +439,7 @@ export interface SuccessNodePromises {
 
 export interface RejectedNodePromises {
   success: boolean;
-  error: any;
+  error: NodeErrorV0 | NodeErrorV1;
 }
 
 export interface NodePromiseResponse {
@@ -448,10 +448,42 @@ export interface NodePromiseResponse {
   reason?: any;
 }
 
-export interface NodeError {
-  error: {
-    errorCode: string;
-  };
+/**
+ * The error object returned by the node.
+ *
+ * @deprecated - This is the old error object.  It will be removed in the future. Use NodeErrorV1 instead.
+ */
+export interface NodeErrorV0 {
+  errorCode: string;
+  message: string;
+}
+
+export interface NodeErrorV1 {
+  error_kind: string;
+  status: number;
+  details: string[];
+  message?: string;
+  error_code?: string;
+}
+
+/**
+ *
+ * @deprecated - This is the old error object.  It will be removed in the future. Use NodeClientErrorV1 instead.
+ *
+ */
+export interface NodeClientErrorV0 {
+  errorCode?: string;
+  message: string;
+  error: any;
+  name?: string;
+}
+
+export interface NodeClientErrorV1 {
+  message: string;
+  error_kind: string;
+  error_code: string;
+  details?: string[];
+  status?: number;
 }
 
 export interface SigShare {


### PR DESCRIPTION
# What 

Closes LIT-191. See issue for more details.

- This PR makes it so that old error codes (`storage_error`, `not_authorized`) from the node, as well as errors thrown from within the SDK (unrelated to node API calls) **are all unified into the new style of PascalCase codes, as well as the ability to parse new error response fields such as `errorKind`, `status` etc.**
  - If nodes return `errorCode: 'storage_error'`, SDK returns `errorCode: 'NodeStorageError'`
  - If nodes return `errorCode: 'NodeStorageError'`, SDK returns the same.

# Testing

Run `yarn build:packages`, then `yarn tools --dev --apps` to spin up `http://localhost:4002` which you can use for manual testing.

Manually tested using `http://localhost:4002/manual_tests.html` as an example, and the `Encrypt, set the conditions, then try to update the conditions with an unauthorized account` worked as expected:

![Screenshot 2023-04-04 at 11 50 09 PM](https://user-images.githubusercontent.com/9898215/230003052-0b5d3244-9dec-4fa1-ae4e-60a815ebfa7c.png)
