### PR TITLE
Add support for Leap & Cypher wallets for Cosmos

### DIFF
--- a/packages/auth-browser/src/lib/auth-browser.ts
+++ b/packages/auth-browser/src/lib/auth-browser.ts
@@ -21,6 +21,7 @@ export const checkAndSignAuthMessage = ({
   switchChain,
   expiration,
   uri,
+  cosmosWalletType,
 }: AuthCallbackParams): Promise<AuthSig> => {
   const chainInfo = ALL_LIT_CHAINS[chain];
 
@@ -52,7 +53,10 @@ export const checkAndSignAuthMessage = ({
   } else if (chainInfo.vmType === VMTYPE.SVM) {
     return checkAndSignSolAuthMessage();
   } else if (chainInfo.vmType === VMTYPE.CVM) {
-    return checkAndSignCosmosAuthMessage({ chain });
+    return checkAndSignCosmosAuthMessage({
+      chain,
+      walletType: cosmosWalletType || 'keplr',
+    }); // Keplr is defaulted here, being the Cosmos wallet with the highest market share
   } else {
     return throwError({
       message: `vmType not found for this chain: ${chain}.  This should not happen.  Unsupported chain selected.  Please select one of: ${Object.keys(

--- a/packages/auth-browser/src/lib/chains/cosmos.ts
+++ b/packages/auth-browser/src/lib/chains/cosmos.ts
@@ -10,13 +10,14 @@ import {
   LOCAL_STORAGE_KEYS,
 } from '@lit-protocol/constants';
 
-import { AuthSig } from '@lit-protocol/types';
+import { AuthSig, CosmosWalletType } from '@lit-protocol/types';
 import { log, sortedObject, throwError } from '@lit-protocol/misc';
 
 /** ---------- Declaration ---------- */
 declare global {
   interface Window {
     keplr?: any;
+    leap?: any;
     solana?: any;
   }
 }
@@ -53,10 +54,18 @@ interface CosmosSignDoc {
  *
  * @returns { object || never }
  */
-const getProvider = (): any => {
+const getProvider = (walletType: CosmosWalletType): any => {
   // -- validate
-  if ('keplr' in window) {
-    return window?.keplr;
+  switch (walletType) {
+    case 'keplr':
+      if ('keplr' in window) {
+        return window?.keplr;
+      }
+      break;
+    case 'leap':
+      if ('leap' in window) {
+        return window?.leap;
+      }
   }
 
   // -- finally
@@ -81,28 +90,30 @@ const getProvider = (): any => {
  */
 export const connectCosmosProvider = async ({
   chain,
+  walletType,
 }: {
   chain: string;
+  walletType: CosmosWalletType;
 }): Promise<CosmosProvider> => {
   const chainId = LIT_COSMOS_CHAINS[chain].chainId;
 
-  const keplr = getProvider();
+  const wallet = getProvider(walletType);
 
-  // Enabling before using the Keplr is recommended.
+  // Enabling before using the Cosmos wallet is recommended.
   // This method will ask the user whether to allow access if they haven't visited this website.
   // Also, it will request that the user unlock the wallet if the wallet is locked.
-  await keplr.enable(chainId);
+  await wallet.enable(chainId);
 
-  const offlineSigner = keplr.getOfflineSigner(chainId);
+  const offlineSigner = wallet.getOfflineSigner(chainId);
 
   // You can get the address/public keys by `getAccounts` method.
   // It can return the array of address/public key.
-  // But, currently, Keplr extension manages only one address/public key pair.
+  // But, currently, Keplr/Leap extension manages only one address/public key pair.
   // TODO: (Check if this is still the case 7 Sep 2022)
   // This line is needed to set the sender address for SigningCosmosClient.
   const accounts = await offlineSigner.getAccounts();
 
-  return { provider: keplr, account: accounts[0].address, chainId };
+  return { provider: wallet, account: accounts[0].address, chainId };
 };
 
 /**
@@ -115,10 +126,15 @@ export const connectCosmosProvider = async ({
  */
 export const checkAndSignCosmosAuthMessage = async ({
   chain,
+  walletType,
 }: {
   chain: string;
+  walletType: CosmosWalletType;
 }): Promise<AuthSig> => {
-  const connectedCosmosProvider = await connectCosmosProvider({ chain });
+  const connectedCosmosProvider = await connectCosmosProvider({
+    chain,
+    walletType,
+  });
 
   const storageKey = LOCAL_STORAGE_KEYS.AUTH_COSMOS_SIGNATURE;
 

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -81,6 +81,8 @@ export interface AuthSig {
   address: string;
 }
 
+export type CosmosWalletType = 'keplr' | 'leap';
+
 export interface AuthCallbackParams {
   // The chain you want to use.  Find the supported list of chains here: https://developer.litprotocol.com/docs/supportedChains
   chain: Chain;
@@ -95,6 +97,11 @@ export interface AuthCallbackParams {
   expiration?: string;
 
   uri?: string;
+
+  // Cosmos wallet type, to support mutliple popular cosmos wallets
+  // Keplr & Cypher -> window.keplr
+  // Leap -> window.leap
+  cosmosWalletType?: CosmosWalletType;
 }
 
 /** ---------- Web3 ---------- */


### PR DESCRIPTION
This PR replaces the previously hardcoded window.keplr with multiple wallet options for Cosmos (Keplr/Leap/Cypher) when using `checkAndSignAuthMessage`.

It does not interfere with the functionality of any other chain option except the Cosmos chains. It also defaults to Keplr when a specific wallet is not specified, meaning no changes to current implementation would be necessary.

Note: No `cypher` option is present as Cypher Wallet uses the `window.keplr` object.