### PR TITLE
refactor: improve getSessionKey

### DIFF
--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -295,7 +295,10 @@ export class LitNodeClientNodeJs {
         if (this.isSessionKeyPair(keyPair)) {
           return keyPair;
         } else {
-          throw new Error('Invalid session key pair provided');
+          return throwError({
+            message: 'Invalid session key pair provided',
+            error: LIT_ERROR.PARAMS_MISSING_ERROR,
+          });
         }
       } catch (err) {
         log(
@@ -1215,7 +1218,7 @@ export class LitNodeClientNodeJs {
    * @returns { void }
    *
    */
-  throwNodeError = (res: RejectedNodePromises): void => {
+  _throwNodeError = (res: RejectedNodePromises): void => {
     if (res.error && res.error.errorCode) {
       if (
         (res.error.errorCode === LIT_ERROR_CODE.NODE_NOT_AUTHORIZED ||
@@ -1580,7 +1583,7 @@ export class LitNodeClientNodeJs {
 
     // -- case: promises rejected
     if (res.success === false) {
-      this.throwNodeError(res as RejectedNodePromises);
+      this._throwNodeError(res as RejectedNodePromises);
     }
 
     // -- case: promises success (TODO: check the keys of "values")
@@ -1841,7 +1844,7 @@ export class LitNodeClientNodeJs {
 
     // -- case: promises rejected
     if (res.success === false) {
-      this.throwNodeError(res as RejectedNodePromises);
+      this._throwNodeError(res as RejectedNodePromises);
     }
 
     const signatureShares: Array<NodeShare> = (res as SuccessNodePromises)
@@ -1959,7 +1962,7 @@ export class LitNodeClientNodeJs {
 
     // -- case: promises rejected
     if (res.success === false) {
-      this.throwNodeError(res as RejectedNodePromises);
+      this._throwNodeError(res as RejectedNodePromises);
     }
 
     return true;
@@ -2059,7 +2062,7 @@ export class LitNodeClientNodeJs {
 
     // -- case: promises rejected
     if (res.success === false) {
-      this.throwNodeError(res as RejectedNodePromises);
+      this._throwNodeError(res as RejectedNodePromises);
     }
 
     const decryptionShares: Array<NodeShare> = (res as SuccessNodePromises)
@@ -2206,7 +2209,7 @@ export class LitNodeClientNodeJs {
 
     // -- case: promises rejected
     if (res.success === false) {
-      this.throwNodeError(res as RejectedNodePromises);
+      this._throwNodeError(res as RejectedNodePromises);
     }
 
     return encryptedKey;
@@ -2466,7 +2469,7 @@ export class LitNodeClientNodeJs {
 
     // -- case: promises rejected
     if (!this.#isSuccessNodePromises(res)) {
-      this.throwNodeError(res);
+      this._throwNodeError(res);
       return {} as SignSessionKeyResponse;
     }
 

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -365,9 +365,9 @@ export class LitNodeClientNodeJs {
     return (
       typeof obj === 'object' &&
       'publicKey' in obj &&
-      'privateKey' in obj &&
+      'secretKey' in obj &&
       typeof obj.publicKey === 'string' &&
-      typeof obj.privateKey === 'string'
+      typeof obj.secretKey === 'string'
     );
   }
 

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -292,7 +292,11 @@ export class LitNodeClientNodeJs {
     if (serializedSessionKeyPair) {
       try {
         const keyPair = JSON.parse(serializedSessionKeyPair);
-        return keyPair;
+        if (this.isSessionKeyPair(keyPair)) {
+          return keyPair;
+        } else {
+          throw new Error('Invalid session key pair provided');
+        }
       } catch (err) {
         log(
           `Error when parsing provided session keypair ${serializedSessionKeyPair}: ${err}`
@@ -316,7 +320,11 @@ export class LitNodeClientNodeJs {
       if (storedSessionKey) {
         try {
           const keyPair = JSON.parse(storedSessionKey);
-          return keyPair;
+          if (this.isSessionKeyPair(keyPair)) {
+            return keyPair;
+          } else {
+            throw new Error('Invalid session key pair stored');
+          }
         } catch (err) {
           log(
             `Error when parsing stored session keypair ${storedSessionKey}. Continuing to generate a new one...`
@@ -343,6 +351,22 @@ export class LitNodeClientNodeJs {
 
     return sessionKey;
   };
+
+  /**
+   * Check if a given object is of type SessionKeyPair.
+   *
+   * @param obj - The object to check.
+   * @returns True if the object is of type SessionKeyPair.
+   */
+  isSessionKeyPair(obj: any): obj is SessionKeyPair {
+    return (
+      typeof obj === 'object' &&
+      'publicKey' in obj &&
+      'privateKey' in obj &&
+      typeof obj.publicKey === 'string' &&
+      typeof obj.privateKey === 'string'
+    );
+  }
 
   /**
    *

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -281,51 +281,67 @@ export class LitNodeClientNodeJs {
 
   // ==================== SESSIONS ====================
   /**
-   *
    * Try to get the session key in the local storage,
    * if not, generates one.
-   * @param { string } supposedSessionKey
-   * @return { }
+   *
+   * @param {string} [serializedSessionKeyPair] - Serialized session key pair
+   * @return {SessionKeyPair} - Session key pair
    */
-  getSessionKey = (supposedSessionKey?: string): SessionKeyPair => {
-    let sessionKey: any = supposedSessionKey ?? '';
-
-    const storageKey = LOCAL_STORAGE_KEYS.SESSION_KEY;
-    const storedSessionKeyOrError = getStorageItem(storageKey);
-
-    if (sessionKey === '') {
-      // check if we already have a session key + signature for this chain
-      // let storedSessionKey;
-      let storedSessionKey: any;
-
-      // -- (TRY) to get it in the local storage
-      if (storedSessionKeyOrError.type === 'ERROR') {
-        console.warn(
-          `Storage key "${storageKey}" is missing. Not a problem. Contiune...`
+  getSessionKey = (serializedSessionKeyPair?: string): SessionKeyPair => {
+    // If a session key pair is provided, parse it and return it
+    if (serializedSessionKeyPair) {
+      try {
+        const keyPair = JSON.parse(serializedSessionKeyPair);
+        return keyPair;
+      } catch (err) {
+        log(
+          `Error when parsing provided session keypair ${serializedSessionKeyPair}: ${err}`
         );
-      } else {
-        storedSessionKey = storedSessionKeyOrError.result;
-      }
-
-      // -- IF NOT: Generates one
-      if (!storedSessionKey || storedSessionKey == '') {
-        sessionKey = generateSessionKeyPair();
-
-        // (TRY) to set to local storage
-        try {
-          localStorage.setItem(storageKey, JSON.stringify(sessionKey));
-        } catch (e) {
-          console.warn(
-            `Localstorage not available. Not a problem. Contiune...`
-          );
-        }
-      } else {
-        log('storedSessionKeyOrError');
-        sessionKey = JSON.parse(storedSessionKeyOrError.result);
+        throw err;
       }
     }
 
-    return sessionKey as SessionKeyPair;
+    // If no session key pair is provided, try to get it from the local storage
+    const storageKey = LOCAL_STORAGE_KEYS.SESSION_KEY;
+    const storedSessionKeyOrError = getStorageItem(storageKey);
+
+    // Check for errors
+    if (storedSessionKeyOrError.type === 'ERROR') {
+      console.warn(
+        `Storage key "${storageKey}" is missing. Not a problem. Continue...`
+      );
+    } else {
+      // If no errors, get the stored session key
+      const storedSessionKey = storedSessionKeyOrError.result;
+      if (storedSessionKey) {
+        try {
+          const keyPair = JSON.parse(storedSessionKey);
+          return keyPair;
+        } catch (err) {
+          log(
+            `Error when parsing stored session keypair ${storedSessionKey}. Continuing to generate a new one...`
+          );
+        }
+      }
+    }
+
+    // If no session key is stored, generate one
+    let sessionKey: SessionKeyPair;
+    try {
+      sessionKey = generateSessionKeyPair();
+    } catch (err) {
+      log(`Error when generating session keypair: ${err}`);
+      throw err;
+    }
+
+    // Store session key in local storage
+    try {
+      localStorage.setItem(storageKey, JSON.stringify(sessionKey));
+    } catch (e) {
+      console.warn(`Local storage not available. Not a problem. Continue...`);
+    }
+
+    return sessionKey;
   };
 
   /**

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -729,7 +729,7 @@ export interface AuthMethod {
 //     pub siwe_message: String,
 // }
 export interface SignSessionKeyProp {
-  // The session key to sign
+  // The serialized session key pair to sign. If not provided, a session key pair will be fetched from localStorge or generated.
   sessionKey?: string;
 
   // The auth methods to use to sign the session key
@@ -782,6 +782,8 @@ export interface GetSessionSigsProps {
 
   //   This is a callback that will be called if the user needs to authenticate using a PKP.  For example, if the user has no wallet, but owns a Lit PKP though something like Google Oauth, then you can use this callback to prompt the user to authenticate with their PKP.  This callback should use the LitNodeClient.signSessionKey function to get a session signature for the user from their PKP.  If you don't pass this callback, then the user will be prompted to authenticate with their wallet, like metamask.
   authNeededCallback?: AuthCallback;
+
+  // The serialized session key pair to sign. If not provided, a session key pair will be fetched from localStorge or generated.
   sessionKey?: any;
 }
 


### PR DESCRIPTION
**Summary**
- Be more explicit that one can pass in a serialized session key pair
- Enforce that `getSessionKey` returns a valid `SessionKeyPair`