### PR TITLE
Add explicit permanent type

### DIFF
--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -314,8 +314,8 @@ export interface JsonSigningRetrieveRequest extends JsonAccsRequest {
 
 export interface JsonStoreSigningRequest extends JsonAccsRequest {
   // Whether or not the access control condition should be saved permanently.  If false, the access control conditions will be updateable by the creator.  If you don't pass this param, it's set to true by default.
-  permanant?: number;
-  permanent?: number;
+  permanant?: boolean | 0 | 1;
+  permanent?: boolean | 0 | 1;
   sessionSigs?: any;
 }
 
@@ -334,8 +334,8 @@ export interface JsonSigningStoreRequest {
   key: string;
   val: string;
   chain?: string;
-  permanant?: number;
-  permanent?: number;
+  permanant?: 0 | 1;
+  permanent?: 0 | 1;
   authSig?: AuthSig;
   sessionSigs?: object;
 }
@@ -377,8 +377,8 @@ export interface JsonSaveEncryptionKeyRequest {
   // The encrypted symmetric key of the item you with to update.  You must pass either symmetricKey or encryptedSymmetricKey.
   encryptedSymmetricKey?: EncryptedSymmetricKey;
 
-  permanant?: number;
-  permanent?: number;
+  permanant?: boolean | 0 | 1;
+  permanent?: boolean | 0 | 1;
 
   sessionSigs?: object;
 }


### PR DESCRIPTION
The `saveSigningCondition` and `saveEncryptionKey` functions in the `lit-node-client-nodejs` package already handles the logic to add the correct boolean value (`permanent ? 1 : 0`) to the correspondent functions (`storeSigningConditionWithNode` and `storeEncryptionConditionWithNode` respectively).

This way, users can either specify a boolean value to the `permanant` or `permanent` parameters, or directly a `0` or `1`.

```ts
const encryptedSymmetricKey = await this.litNodeClient.saveEncryptionKey({
  solRpcConditions,
  symmetricKey,
  authSig,
  chain,
  permanent: false // <--- or directly 0
})
```

This is easier for users to understand which value they can pass as parameters, by making the `permanent` type more explicit, accepting either `0` or `1` only, if not the boolean.

Here's an actual example of the typescript lint error:

![CleanShot 2023-05-06 at 11 11 07](https://user-images.githubusercontent.com/3136873/236637832-de4719b4-3042-4e18-8680-467cd112ecdd.png)

