### PR TITLE
fix case statement for jwt encoding resolve

### DIFF
--- a/packages/uint8arrays/src/lib/uint8arrays.ts
+++ b/packages/uint8arrays/src/lib/uint8arrays.ts
@@ -135,7 +135,7 @@ export function uint8arrayFromString(str: string, encoding = 'utf8') {
       return new Uint8Array(arr);
     case 'base64':
       return base64ToUint8Array(str);
-    case 'base64urlpad':
+    case 'base64urlpad' || 'base64url':
       return base64ToUint8Array(base64UrlPadToBase64(str));
     default:
       throw new Error(`Unsupported encoding "${encoding}"`);


### PR DESCRIPTION
- Adds option for `base64url` which can be converted to `base64` by the same implementation for `base64urlpad`