### PR TITLE
fix to solana auth signature generation

### DIFF
--- a/packages/auth-browser/src/lib/chains/sol.ts
+++ b/packages/auth-browser/src/lib/chains/sol.ts
@@ -29,7 +29,8 @@ const getProvider = (): IEither => {
 
   // -- validate
   if ('solana' in window) {
-    resultOrError = ERight(window?.keplr ?? window?.solana);
+    // only check for the solana object on the window, as keplr does not have the same client interface injected into the window.
+    resultOrError = ERight(window?.solana);
   } else {
     // -- finally
     const message =


### PR DESCRIPTION
# WHAT
- fixes bug with Solana auth signature generation throwing an exception `provider.connect is not as function`

# HOW
- The provider resolver would check for the `keplr and solana` on the global window. checking keplr first and falling back to Solana. However, `keplr` does not have `connect` on its api screen show below showing the difference in the two api's 
- We now only check for `solana` on the global window which does correctly sign with solana wallets
![Screen Shot 2023-05-16 at 4 25 03 PM](https://github.com/LIT-Protocol/js-sdk/assets/17501037/3d75b7f0-9f92-4d20-a133-86d7da6eb71c)

# TESTING
- tested using phantom wallet with `lit-node-client` can correctly generate auth signatures and store in local storage