### PR TITLE
Add peerDependencies to dependencies regardless if any imports detected

### DIFF
--- a/tools/scripts/map-deps-to-dist.mjs
+++ b/tools/scripts/map-deps-to-dist.mjs
@@ -48,21 +48,23 @@ await asyncForEach(packagesDir, async (packageDir) => {
 
   const dependencies = [...new Set(imports.flat())];
 
-  if (dependencies.length) {
-    const packageJsonPath = DIST_DIR + '/' + packageDir + '/package.json';
+  // Add peerDependencies to dependencies
+  const packageJsonPath = DIST_DIR + '/' + packageDir + '/package.json';
 
-    const packageJson = await readJsonFile(packageJsonPath);
+  const packageJson = await readJsonFile(packageJsonPath);
 
-    // await asyncForEach((dependencies), async (dep) => {
-    //     packageJson.dependencies[dep] = packageJson.version;
-    // })
+  // await asyncForEach((dependencies), async (dep) => {
+  //     packageJson.dependencies[dep] = packageJson.version;
+  // })
 
-    packageJson.dependencies = packageJson.peerDependencies;
+  packageJson.dependencies = {
+    ...packageJson.dependencies,
+    ...packageJson.peerDependencies,
+  };
 
-    await writeJsonFile(packageJsonPath, packageJson);
+  await writeJsonFile(packageJsonPath, packageJson);
 
-    greenLog(`Added ${dependencies.length} dependencies to ${packageJsonPath}`);
-  }
+  greenLog(`Added ${dependencies.length} dependencies to ${packageJsonPath}`);
 });
 
 exit();


### PR DESCRIPTION
# What

This PR **adds** `peerDependencies` to `dependencies` regardless if any imports / dependencies have been detected. 

Sometimes we may want to specify a peerDependency for a library that does not even get imported - for example, `auth-helpers` specify `tslib` peer dependency but there is no explicit import for that in code that is detected by us.

