### PR TITLE
change http to https for verification url in OTP Provider

### DIFF
--- a/packages/lit-auth-client/src/lib/providers/OtpProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/OtpProvider.ts
@@ -23,7 +23,7 @@ export class OtpProvider extends BaseProvider {
   ) {
     super(params);
     this._params = params;
-    this._baseUrl = config?.baseUrl || 'http://auth-api.litgateway.com';
+    this._baseUrl = config?.baseUrl || 'https://auth-api.litgateway.com';
     this._port = config?.port || '80';
     this._startRoute = config?.startRoute || '/api/otp/start';
     this._checkRoute = config?.checkRoute || '/api/otp/check';


### PR DESCRIPTION
- configures verification url for api requests from `http` to `https`