### PR TITLE
fix: export OtpProvider

### DIFF
--- a/packages/lit-auth-client/src/index.ts
+++ b/packages/lit-auth-client/src/index.ts
@@ -5,6 +5,7 @@ import EthWalletProvider from './lib/providers/EthWalletProvider';
 import GoogleProvider from './lib/providers/GoogleProvider';
 import AppleProvider from './lib/providers/AppleProvider';
 import WebAuthnProvider from './lib/providers/WebAuthnProvider';
+import { OtpProvider } from './lib/providers/OtpProvider';
 import { isSignInRedirect, getProviderFromUrl } from './lib/utils';
 
 declare global {
@@ -25,6 +26,7 @@ export {
   GoogleProvider,
   AppleProvider,
   WebAuthnProvider,
+  OtpProvider,
   isSignInRedirect,
   getProviderFromUrl,
 };

--- a/packages/lit-auth-client/src/lib/lit-auth-client.spec.ts
+++ b/packages/lit-auth-client/src/lib/lit-auth-client.spec.ts
@@ -14,6 +14,7 @@ import DiscordProvider from './providers/DiscordProvider';
 import WebAuthnProvider from './providers/WebAuthnProvider';
 import EthWalletProvider from './providers/EthWalletProvider';
 import AppleProvider from './providers/AppleProvider';
+import { OtpProvider } from './providers/OtpProvider';
 
 const isClass = (v: unknown) => {
   return typeof v === 'function' && /^\s*class\s+/.test(v.toString());
@@ -89,6 +90,11 @@ describe('initProvider', () => {
       ProviderType.WebAuthn
     );
     expect(provider).toBeInstanceOf(WebAuthnProvider);
+  });
+
+  it('should return an instance of OtpProvider', () => {
+    const provider = client.initProvider<OtpProvider>(ProviderType.Otp);
+    expect(provider).toBeInstanceOf(OtpProvider);
   });
 });
 

--- a/packages/lit-auth-client/src/lib/providers/OtpProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/OtpProvider.ts
@@ -24,7 +24,7 @@ export class OtpProvider extends BaseProvider {
     super(params);
     this._params = params;
     this._baseUrl = config?.baseUrl || 'https://auth-api.litgateway.com';
-    this._port = config?.port || '80';
+    this._port = config?.port || '443';
     this._startRoute = config?.startRoute || '/api/otp/start';
     this._checkRoute = config?.checkRoute || '/api/otp/check';
   }
@@ -68,7 +68,7 @@ export class OtpProvider extends BaseProvider {
       method: 'POST',
       headers: {
         'Content-type': 'application/json',
-        'api-key': '67e55044-10b1-426f-9247-bb680e5fe0c8_JsSdk'
+        'api-key': '67e55044-10b1-426f-9247-bb680e5fe0c8_JsSdk',
       },
       body,
     });
@@ -109,7 +109,7 @@ export class OtpProvider extends BaseProvider {
       method: 'POST',
       headers: {
         'Content-type': 'application/json',
-        'api-key': '67e55044-10b1-426f-9247-bb680e5fe0c8_JsSdk'
+        'api-key': '67e55044-10b1-426f-9247-bb680e5fe0c8_JsSdk',
       },
       body,
     });

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -1177,10 +1177,10 @@ export interface SignInWithOTPParams {
 }
 
 export interface OtpProviderOptions {
-  baseUrl: string;
-  port: string;
-  startRoute: string;
-  checkRoute: string;
+  baseUrl?: string;
+  port?: string;
+  startRoute?: string;
+  checkRoute?: string;
 }
 
 export interface BaseProviderSessionSigsParams {


### PR DESCRIPTION
**Summary**
- Export `OtpProvider` from `lit-auth-client`
- Made properties in `OtpProviderOptions` type optional
- Update port to `443`

**Tests**
Tested in React TS.