### PR TITLE
Feature/lit 719 expose custom sender properties from twillio to allow email

### DIFF
--- a/packages/lit-auth-client/src/lib/providers/OtpProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/OtpProvider.ts
@@ -62,6 +62,18 @@ export class OtpProvider extends BaseProvider {
       otp: this._params.userId,
       request_id: this._requestId,
     };
+
+    if (this._params.emailCustomizationOptions) {
+      body.email_configuration = {};
+      body.email_configuration.from_name =
+        this._params.emailCustomizationOptions.fromName;
+      if (this._params.emailCustomizationOptions.from)
+        body.email_configuration.from =
+          this._params.emailCustomizationOptions.from;
+    }
+
+    if (this._params.customName) body.custom_name = this._params.customName;
+
     body = JSON.stringify(body);
 
     const response = await fetch(url, {

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -1162,14 +1162,7 @@ export interface SignInWithOTPParams {
    * used as the user ID for the auth method
    */
   userId: string;
-  /**
-   * Origin of the sign in request
-   */
-  origin?: string;
-  /**
-   * when the generated JWT expires
-   */
-  expiration?: string;
+
   /**
    * tracking for the session
    */

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -1174,6 +1174,14 @@ export interface SignInWithOTPParams {
    * tracking for the session
    */
   requestId?: string;
+
+  /**
+   * Allows for specifying custom sender information
+   * Note: for most users the `from_name` is the configurable option and `from` should not be populated
+   */
+  emailCustomizationOptions: OtpEmailCustomizationOptions;
+
+  customName?: string;
 }
 
 export interface OtpProviderOptions {
@@ -1183,6 +1191,10 @@ export interface OtpProviderOptions {
   checkRoute?: string;
 }
 
+export interface OtpEmailCustomizationOptions {
+  from?: string;
+  fromName: string;
+}
 export interface BaseProviderSessionSigsParams {
   /**
    * Public key of PKP to auth with


### PR DESCRIPTION
# WHAT

- exposes options for email sender customization
- exposes options for configuring the service name
