### PR TITLE
Feature/lit 787 add captcha response check to lit auth client for otp

### DIFF
--- a/apps/demo-email-sms-auth/src/Otp.css
+++ b/apps/demo-email-sms-auth/src/Otp.css
@@ -9,6 +9,13 @@ span {
     justify-content: center;
 }
 
+.captcha {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+}
+
 .pkp-table {
     border-collapse: collapse;
     margin: 25px 0;

--- a/apps/demo-email-sms-auth/src/Otp.js
+++ b/apps/demo-email-sms-auth/src/Otp.js
@@ -18,10 +18,6 @@ export function Otp() {
         redirectUri: window.location.href.replace(/\/+$/, ''),
         litRelayConfig: {
             relayApiKey: '67e55044-10b1-426f-9247-bb680e5fe0c8_relayer',
-        },
-        litOtpConfig: {
-            baseUrl: "http://127.0.0.1",
-            port: "8080",
         }
     });
 

--- a/packages/lit-auth-client/src/lib/lit-auth-client.ts
+++ b/packages/lit-auth-client/src/lib/lit-auth-client.ts
@@ -41,6 +41,8 @@ export class LitAuthClient {
 
   private litOtpOptions: OtpProviderOptions | undefined;
 
+  private captcha_client_id: string =
+  '6Leij74mAAAAACKVnvdxENwTxZguNhcHMqzeNLXY';
 
   /**
    * Create a LitAuthClient instance
@@ -168,4 +170,42 @@ export class LitAuthClient {
   getProvider(type: ProviderType): BaseProvider | undefined {
     return this.providers.get(type);
   }
+
+  /**
+   * 
+    */
+  embeddCaptchaInElement(elementId: string, headTag: HTMLHeadElement) {
+    const captchaLoader = document.createElement("script");
+    captchaLoader.src = "https://www.google.com/recaptcha/api.js?onload=litReCaptchaOnLoad&render=explicit";
+    captchaLoader.async = true;
+    captchaLoader.defer = true;
+
+    headTag.appendChild(captchaLoader);
+
+    const loadedScript = document.createElement("script");
+    loadedScript.type = "text/javascript";
+    const textNode = document.createTextNode(`
+        console.log("[LitJsSdk] captcha script loaded rendering component");
+        var litReCaptchaOnLoad = function() {
+          grecaptcha.render('${elementId}', {
+            'sitekey': '${this.captcha_client_id}',
+            'callback': (response) => {
+                window.LIT_AUTH_CLIENT_CAPTCHA_RES = response;
+            }
+          });
+        };
+    `);
+    loadedScript.appendChild(textNode);
+
+    headTag.appendChild(loadedScript);
+  }
+
+  /**
+   * 
+   * @returns the clientId of the reCaptcha required for
+   */
+  getCaptchaClientId(): string {
+    return this.captcha_client_id;
+  }
+
 }

--- a/packages/lit-auth-client/src/lib/lit-auth-client.ts
+++ b/packages/lit-auth-client/src/lib/lit-auth-client.ts
@@ -172,8 +172,14 @@ export class LitAuthClient {
   }
 
   /**
+   * Embedds a ReCaptcha instance within the specified tag.
    * 
-    */
+   * **note** ReCaptcha is required for Email/SMS authentication only
+   * If injection is not compatible the ReCaptcha client Id is available through {@link getSiteKey}
+   * The response from your ReCaptcha can be passed through with {@link OtpProvider#setCaptchaResponse}
+   * @param elementId {string} id of the html element to inject the captcha view into
+   * @param headTag {HTMLHeadElement} head element of DOM for injecting ReCaptcha.
+   */
   embeddCaptchaInElement(elementId: string, headTag: HTMLHeadElement) {
     const captchaLoader = document.createElement("script");
     captchaLoader.src = "https://www.google.com/recaptcha/api.js?onload=litReCaptchaOnLoad&render=explicit";
@@ -202,9 +208,10 @@ export class LitAuthClient {
 
   /**
    * 
-   * @returns the clientId of the reCaptcha required for
+   * @returns {string} Client identifier of the ReCaptcha required for sending OTP codes for email / sms authentication
+   * Should be used in ReCaptcha implementations not included in this package.
    */
-  getCaptchaClientId(): string {
+  getSiteKey(): string {
     return this.captcha_client_id;
   }
 

--- a/packages/lit-auth-client/src/lib/lit-auth-client.ts
+++ b/packages/lit-auth-client/src/lib/lit-auth-client.ts
@@ -174,7 +174,8 @@ export class LitAuthClient {
   /**
    * Embedds a ReCaptcha instance within the specified tag.
    * 
-   * **note** ReCaptcha is required for Email/SMS authentication only
+   * **note** ReCaptcha is required for Email/SMS authentication only.
+   * 
    * If injection is not compatible the ReCaptcha client Id is available through {@link getSiteKey}
    * The response from your ReCaptcha can be passed through with {@link OtpProvider#setCaptchaResponse}
    * @param elementId {string} id of the html element to inject the captcha view into

--- a/packages/lit-auth-client/src/lib/providers/OtpProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/OtpProvider.ts
@@ -16,7 +16,7 @@ export class OtpProvider extends BaseProvider {
   private _startRoute: string;
   private _checkRoute: string;
   private _requestId: string = '';
-  private _captchaRoute: string = "/api/captcha/siteverify";
+  private _captchaRoute: string = '/api/captcha/siteverify';
   private _captchaResponse: string | undefined;
 
   constructor(
@@ -29,7 +29,7 @@ export class OtpProvider extends BaseProvider {
     this._port = config?.port || '443';
     this._startRoute = config?.startRoute || '/api/otp/start';
     this._checkRoute = config?.checkRoute || '/api/otp/check';
-    this._captchaRoute = "/api/captcha/siteverify";
+    this._captchaRoute = '/api/captcha/siteverify';
     this._captchaResponse = config?.captchaResponse;
 
     if (
@@ -70,6 +70,11 @@ export class OtpProvider extends BaseProvider {
    * @returns {Promise<string>} returns a callback to check status of the verification session if successful
    */
   public async sendOtpCode(): Promise<string> {
+    if (!this._captchaResponse) {
+      throw new Error(
+        'Could not find ReCaptcha response, please use the embeddCaptchaInElement or use the site key through getSiteKey() to use your own ReCaptcha Library'
+      );
+    }
     const url = this._buildUrl('start');
     this._requestId =
       this._params.requestId ??
@@ -78,7 +83,7 @@ export class OtpProvider extends BaseProvider {
     let body: any = {
       otp: this._params.userId,
       request_id: this._requestId,
-      captcha_response: this._captchaResponse 
+      captcha_response: this._captchaResponse,
     };
 
     if (this._params.emailCustomizationOptions) {
@@ -116,16 +121,14 @@ export class OtpProvider extends BaseProvider {
   public setCaptchaResponse(response: string): void {
     this._captchaResponse = response;
   }
-  
+
   /**
    * Validates otp code from {@link sendOtpCode}
    *
    * @param code {string} - OTP code sent to the user, should be retrieved from user input.
    * @returns {Promise<AuthMethod>} - Auth method that contains Json Web Token
    */
-  private async checkOtpCode(
-    code: string,
-  ): Promise<AuthMethod> {
+  private async checkOtpCode(code: string): Promise<AuthMethod> {
     const url = this._buildUrl('check');
 
     /**
@@ -177,7 +180,7 @@ export class OtpProvider extends BaseProvider {
       case 'check':
         return `${this._baseUrl}:${this._port}${this._checkRoute}`;
       case 'captcha':
-          return `${this._baseUrl}:${this._port}${this._captchaRoute}`;
+        return `${this._baseUrl}:${this._port}${this._captchaRoute}`;
       default:
         return '';
     }

--- a/packages/lit-auth-client/src/lib/providers/OtpProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/OtpProvider.ts
@@ -16,6 +16,8 @@ export class OtpProvider extends BaseProvider {
   private _startRoute: string;
   private _checkRoute: string;
   private _requestId: string = '';
+  private _captchaRoute: string = "/api/captcha/siteverify";
+  private _captchaResponse: string | undefined;
 
   constructor(
     params: BaseProviderOptions & SignInWithOTPParams,
@@ -27,6 +29,21 @@ export class OtpProvider extends BaseProvider {
     this._port = config?.port || '443';
     this._startRoute = config?.startRoute || '/api/otp/start';
     this._checkRoute = config?.checkRoute || '/api/otp/check';
+    this._captchaRoute = "/api/captcha/siteverify";
+    this._captchaResponse = config?.captchaResponse;
+
+    if (
+      !config?.captchaResponse &&
+      window &&
+      (window as any).LIT_AUTH_CLIENT_CAPTCHA_RES
+    ) {
+      console.info('[LitJsSdk] Found captcha challenge');
+      this._captchaResponse = (window as any).LIT_AUTH_CLIENT_CAPTCHA_RES;
+    } else {
+      console.warn(
+        '[LitJsSdk] Could not find captcha challenge. use the SetCaptchaResponse function to include a response'
+      );
+    }
   }
 
   /**
@@ -61,6 +78,7 @@ export class OtpProvider extends BaseProvider {
     let body: any = {
       otp: this._params.userId,
       request_id: this._requestId,
+      captcha_response: this._captchaResponse 
     };
 
     if (this._params.emailCustomizationOptions) {
@@ -95,13 +113,19 @@ export class OtpProvider extends BaseProvider {
     return respBody.callback;
   }
 
+  public setCaptchaResponse(response: string): void {
+    this._captchaResponse = response;
+  }
+  
   /**
    * Validates otp code from {@link sendOtpCode}
    *
    * @param code {string} - OTP code sent to the user, should be retrieved from user input.
-   * @returns {Promise<AuthMethod} - Auth method that contains Json Web Token
+   * @returns {Promise<AuthMethod>} - Auth method that contains Json Web Token
    */
-  private async checkOtpCode(code: string): Promise<AuthMethod> {
+  private async checkOtpCode(
+    code: string,
+  ): Promise<AuthMethod> {
     const url = this._buildUrl('check');
 
     /**
@@ -115,7 +139,9 @@ export class OtpProvider extends BaseProvider {
       otp: this._params.userId,
       code,
       request_id: this._requestId,
+      captchaResponse: this._captchaResponse,
     };
+
     body = JSON.stringify(body);
     const response = await fetch(url, {
       method: 'POST',
@@ -150,6 +176,8 @@ export class OtpProvider extends BaseProvider {
         return `${this._baseUrl}:${this._port}${this._startRoute}`;
       case 'check':
         return `${this._baseUrl}:${this._port}${this._checkRoute}`;
+      case 'captcha':
+          return `${this._baseUrl}:${this._port}${this._captchaRoute}`;
       default:
         return '';
     }

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -962,6 +962,13 @@ export interface LitAuthClientOptions {
   litNodeClient?: any;
 
   litOtpConfig?: OtpProviderOptions;
+
+  /**
+   * ReCaptcha reponse from external catpcha response for use with
+   * {@link OtpProvider} if not provided will look at the global var
+   * LIT_AUTH_CLIENT_CAPTCHA_RES object for challenege response from injected captcha view
+   */
+  captchaResponse?: string;
 }
 
 export interface OtpSessionResult {
@@ -1173,7 +1180,12 @@ export interface SignInWithOTPParams {
    * Note: for most users the `from_name` is the configurable option and `from` should not be populated
    */
   emailCustomizationOptions: OtpEmailCustomizationOptions;
-
+  
+  /**
+   * ReCaptcha reponse from external catpcha response for use with
+   * {@link OtpProvider} if not provided will look at the global var
+   * LIT_AUTH_CLIENT_CAPTCHA_RES object for challenege response from injected captcha view
+   */
   customName?: string;
 }
 
@@ -1182,6 +1194,8 @@ export interface OtpProviderOptions {
   port?: string;
   startRoute?: string;
   checkRoute?: string;
+
+  captchaResponse?: string;
 }
 
 export interface OtpEmailCustomizationOptions {
@@ -1233,6 +1247,7 @@ export interface LoginUrlParams {
 export interface BaseAuthenticateOptions {}
 
 export interface OtpAuthenticateOptions {
+  captchaResponse: string;
   code: string;
 }
 


### PR DESCRIPTION
- Adds ReCaptcha to `lit-auth-client` for `OtpProvider`
   - Adds support for inject ReCaptcha scripts into the DOM with anchor tag injection, and script injection into provided `head` node.
- Adds ReCaptcha response to `sendOtp` request
- Allows for passing ReCaptcha `response` as init params to `lit-auth-client`