### PR TITLE
fix: pass custom session key, clear wallet sig

### DIFF
--- a/packages/auth-browser/src/lib/chains/eth.ts
+++ b/packages/auth-browser/src/lib/chains/eth.ts
@@ -227,10 +227,12 @@ export const getChainId = async (
  */
 export function isSignedMessageExpired(signedMessage: string) {
   // Extract the Expiration Time from the signed message.
-  const dateStr = signedMessage.split('\n')[9]?.replace('Expiration Time: ', '');
+  const dateStr = signedMessage
+    .split('\n')[9]
+    ?.replace('Expiration Time: ', '');
   const expirationTime = new Date(dateStr);
   const currentTime = new Date();
-  
+
   // Compare the Expiration Time with the current time.
   return currentTime > expirationTime;
 }
@@ -427,6 +429,7 @@ export const disconnectWeb3 = (): void => {
   localStorage.removeItem(storage.AUTH_SOL_SIGNATURE);
   localStorage.removeItem(storage.AUTH_COSMOS_SIGNATURE);
   localStorage.removeItem(storage.WEB3_PROVIDER);
+  localStorage.removeItem(storage.WALLET_SIGNATURE);
 };
 
 /**

--- a/packages/lit-auth-client/src/lib/providers/BaseProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/BaseProvider.ts
@@ -133,6 +133,7 @@ export abstract class BaseProvider {
         if (params.authMethod.authMethodType === AuthMethodType.EthWallet) {
           const authSig = JSON.parse(params.authMethod.accessToken);
           response = await nodeClient.signSessionKey({
+            sessionKey: params.sessionSigsParams.sessionKey,
             authMethods: [],
             authSig: authSig,
             pkpPublicKey: params.pkpPublicKey,
@@ -142,6 +143,7 @@ export abstract class BaseProvider {
           });
         } else {
           response = await nodeClient.signSessionKey({
+            sessionKey: params.sessionSigsParams.sessionKey,
             authMethods: [params.authMethod],
             pkpPublicKey: params.pkpPublicKey,
             expiration: authCallbackParams.expiration,

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -1787,6 +1787,9 @@ export class LitNodeClientNodeJs extends LitCore {
    * 2. Generate or retrieve the wallet signature of the session key
    * 3. Sign the specific resources with the session key
    *
+   * Note: When generating session signatures for different PKPs or auth methods,
+   * be sure to call disconnectWeb3 to clear auth signatures stored in local storage
+   *
    * @param { GetSessionSigsProps } params
    */
   getSessionSigs = async (


### PR DESCRIPTION
**Summary**
- Use custom session key in lit-auth-client `getSessionSigs`
- Clear `WALLET_SIGNATURE` in `disconnectWeb3`
- Call out `disconnectWeb3` in comments

Tested in browser and node envs.