### PR TITLE
Add/cheqd-specific cosmos ACC properties

### DIFF
--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -75,6 +75,8 @@ export interface AccsEVMParams extends AccsRegularParams {
 
 export interface AccsCOSMOSParams extends AccsRegularParams {
   path: string;
+  method?: string;
+  parameters?: string[];
 }
 
 /** ---------- Auth Sig ---------- */


### PR DESCRIPTION
- Adds required cheqd-specific explicit propertieson ACC types.
  - Utilises `parameters` as `string[]`, rather than generic `params` as `any[]`. Details are implementation specific.
  - Brings `method` as optional at ACC definition layer for consistency.

Implementation Reference: https://github.com/LIT-Protocol/lit-assets/pull/244 .