### PR TITLE
add custom network options

### DIFF
--- a/packages/pkp-base/src/lib/pkp-base.ts
+++ b/packages/pkp-base/src/lib/pkp-base.ts
@@ -95,7 +95,9 @@ export class PKPBase<T = PKPBaseDefaultParams> {
     this.setLitActionJsParams(prop.litActionJsParams || {});
     this.litNodeClient = new LitNodeClient({
       litNetwork: prop.litNetwork ?? 'serrano',
+      bootstrapUrls: (prop.bootstrapUrls && prop.litNetwork == 'custom') ? prop.bootstrapUrls : undefined,
       debug: this.debug,
+      minNodeCount: prop.minNodeCount
     });
   }
 

--- a/packages/pkp-base/src/lib/pkp-base.ts
+++ b/packages/pkp-base/src/lib/pkp-base.ts
@@ -95,9 +95,15 @@ export class PKPBase<T = PKPBaseDefaultParams> {
     this.setLitActionJsParams(prop.litActionJsParams || {});
     this.litNodeClient = new LitNodeClient({
       litNetwork: prop.litNetwork ?? 'serrano',
-      bootstrapUrls: (prop.bootstrapUrls && prop.litNetwork === 'custom') ? prop.bootstrapUrls : undefined,
+      bootstrapUrls:
+        prop.bootstrapUrls && prop.litNetwork === 'custom'
+          ? prop.bootstrapUrls
+          : undefined,
       debug: this.debug,
-      minNodeCount: prop.minNodeCount
+      minNodeCount:
+        prop.bootstrapUrls && prop.litNetwork == 'custom'
+          ? prop.minNodeCount
+          : undefined,
     });
   }
 

--- a/packages/pkp-base/src/lib/pkp-base.ts
+++ b/packages/pkp-base/src/lib/pkp-base.ts
@@ -95,7 +95,7 @@ export class PKPBase<T = PKPBaseDefaultParams> {
     this.setLitActionJsParams(prop.litActionJsParams || {});
     this.litNodeClient = new LitNodeClient({
       litNetwork: prop.litNetwork ?? 'serrano',
-      bootstrapUrls: (prop.bootstrapUrls && prop.litNetwork == 'custom') ? prop.bootstrapUrls : undefined,
+      bootstrapUrls: (prop.bootstrapUrls && prop.litNetwork === 'custom') ? prop.bootstrapUrls : undefined,
       debug: this.debug,
       minNodeCount: prop.minNodeCount
     });

--- a/packages/pkp-base/src/lib/pkp-base.ts
+++ b/packages/pkp-base/src/lib/pkp-base.ts
@@ -95,15 +95,11 @@ export class PKPBase<T = PKPBaseDefaultParams> {
     this.setLitActionJsParams(prop.litActionJsParams || {});
     this.litNodeClient = new LitNodeClient({
       litNetwork: prop.litNetwork ?? 'serrano',
-      bootstrapUrls:
-        prop.bootstrapUrls && prop.litNetwork === 'custom'
-          ? prop.bootstrapUrls
-          : undefined,
+      ...(prop.bootstrapUrls &&
+        prop.litNetwork === 'custom' && { bootstrapUrls: prop.bootstrapUrls }),
+      ...(prop.bootstrapUrls &&
+        prop.litNetwork == 'custom' && { minNodeCount: prop.minNodeCount }),
       debug: this.debug,
-      minNodeCount:
-        prop.bootstrapUrls && prop.litNetwork == 'custom'
-          ? prop.minNodeCount
-          : undefined,
     });
   }
 

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -908,6 +908,8 @@ export interface PKPBaseProp {
   sessionSigsExpiration?: string;
   litNetwork?: any;
   debug?: boolean;
+  bootstrapUrls?: string[],
+  minNodeCount?: number,
   litActionCode?: string;
   litActionIPFS?: string;
   litActionJsParams?: any;


### PR DESCRIPTION
- Adds ability for the `pkp-base` to allow for configuring custom network options for the underlying `LitNodeClient` instance