### PR TITLE
Add Backpack wallet support

### DIFF
--- a/packages/auth-browser/src/lib/chains/sol.ts
+++ b/packages/auth-browser/src/lib/chains/sol.ts
@@ -28,9 +28,11 @@ const getProvider = (): IEither => {
   let resultOrError: IEither;
 
   // -- validate
-  if ('solana' in window) {
+  // The Backpack wallet does not inject a solana object into the window, so we need to check for the backpack object as well.
+  if ('solana' in window || 'backpack' in window) {
     // only check for the solana object on the window, as keplr does not have the same client interface injected into the window.
-    resultOrError = ERight(window?.solana);
+    // @ts-ignore
+    resultOrError = ERight(window?.solana ?? window?.backpack);
   } else {
     // -- finally
     const message =


### PR DESCRIPTION
The [Backpack wallet 🎒](https://www.backpack.app/) extension does not inject a `solana` object into the window, so at this moment, it's incompatible with Lit Protocol.

This checks for the presence of the `backpack` object into the window to support backpack users.

Here's the signature of the `window.solana` object using the Phantom wallet:

```ts
isConnected: boolean;
isPhantom: boolean;
publicKey: PublicKey | null;
```

Here's the signature of the `window.backpack` object using the Backpack wallet:

```ts
connection: Connection;
isBackpack: boolean;
isConnected: boolean;
isXnft: boolean;
publicKey: PublicKey | null;
```