### PR TITLE
enable signing without lit actions

### DIFF
--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -1273,7 +1273,7 @@ export class LitNodeClientNodeJs extends LitCore {
       const snakeToCamel = (s: string) =>
         s.replace(/(_\w)/g, (k) => k[1].toUpperCase());
       //@ts-ignore
-      const convertShare: any = (share: any): SigShare => {
+      const convertShare: any = (share: any) => {
         const keys = Object.keys(share);
         let convertedShare = {};
         for (const key of keys) {
@@ -1284,27 +1284,20 @@ export class LitNodeClientNodeJs extends LitCore {
           );
         }
 
-        return convertShare;
+        return convertedShare;
       };
       const convertedShare: SigShare = convertShare(r.signatureShare);
 
       convertedShare.dataSigned = r.signedData;
       return {
-        sig: r.signatureShare,
+        signature: convertedShare,
       };
     });
 
-    const signatures = this.getSignatures(signedDataList);
+    const signatures =  this.getSignatures(signedDataList);
     log(`signature combination`, signatures);
 
-    // -- 3. combine responses as a string, and get parse it as JSON
-    let response: string = mostCommonString(
-      responseData.map((r: NodeResponse) => r.response)
-    );
-
-    response = this.parseResponses(response);
-
-    return signatures;
+    return signatures.signature; // only a single signature is ever present, so we just return it.
   };
 
   /**

--- a/packages/lit-node-client/src/lib/lit-node-client.spec.ts
+++ b/packages/lit-node-client/src/lib/lit-node-client.spec.ts
@@ -93,7 +93,7 @@ describe('Lit Actions', () => {
     };
 
     let sig = await client.pkpSign({
-      toSign: data.toSign as unknown as ArrayBufferLike,
+      toSign: data.toSign,
       pubKey: data.publicKey,
       authMethods: [],
       authSig: LITCONFIG.CONTROLLER_AUTHSIG,

--- a/packages/lit-node-client/src/lib/lit-node-client.spec.ts
+++ b/packages/lit-node-client/src/lib/lit-node-client.spec.ts
@@ -96,10 +96,11 @@ describe('Lit Actions', () => {
       toSign: data.toSign as unknown as ArrayBufferLike,
       pubKey: data.publicKey,
       authMethods: [],
-      authSig: LITCONFIG.CONTROLLER_AUTHSIG
+      authSig: LITCONFIG.CONTROLLER_AUTHSIG,
     });
-    
-    // add padding 
-    expect(LITCONFIG.PKP_PUBKEY).toEqual('0' + sig.publicKey);
+
+    // add padding
+    sig.publicKey = sig.publicKey.length % 2 == 0 ? sig.publicKey : '0' + sig.publicKey;
+    expect(LITCONFIG.PKP_PUBKEY).toEqual(sig.publicKey);
   });
 });

--- a/packages/lit-node-client/src/lib/lit-node-client.spec.ts
+++ b/packages/lit-node-client/src/lib/lit-node-client.spec.ts
@@ -1,6 +1,7 @@
 import { LitNodeClient } from './lit-node-client';
 import * as LITCONFIG from 'lit.config.json';
 import { processTx } from '../../../../tx-handler';
+import { AuthSig } from '@lit-protocol/types';
 let client: LitNodeClient;
 
 jest.setTimeout(60000);
@@ -80,5 +81,22 @@ describe('Lit Actions', () => {
     expect(res.signatures['hello-world-sig'].publicKey).toEqual(
       LITCONFIG.PKP_PUBKEY
     );
+  });
+
+  it('pkp sign endpoint should sign message', async () => {
+    const data = {
+      // hello world in Uint8Array
+      toSign: [104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100],
+      publicKey: LITCONFIG.PKP_PUBKEY,
+      sigName: 'hello-world-sig',
+    };
+
+    let res = await client.pkpSign({
+      toSign: data.toSign as unknown as ArrayBufferLike,
+      pubKey: data.publicKey,
+      authMethods: [],
+      authSig: LITCONFIG.CONTROLLER_AUTHSIG
+    });
+    console.log(res);
   });
 });

--- a/packages/lit-node-client/src/lib/lit-node-client.spec.ts
+++ b/packages/lit-node-client/src/lib/lit-node-client.spec.ts
@@ -2,6 +2,7 @@ import { LitNodeClient } from './lit-node-client';
 import * as LITCONFIG from 'lit.config.json';
 import { processTx } from '../../../../tx-handler';
 import { AuthSig } from '@lit-protocol/types';
+import { ethers } from 'ethers';
 let client: LitNodeClient;
 
 jest.setTimeout(60000);
@@ -91,12 +92,14 @@ describe('Lit Actions', () => {
       sigName: 'hello-world-sig',
     };
 
-    let res = await client.pkpSign({
+    let sig = await client.pkpSign({
       toSign: data.toSign as unknown as ArrayBufferLike,
       pubKey: data.publicKey,
       authMethods: [],
       authSig: LITCONFIG.CONTROLLER_AUTHSIG
     });
-    console.log(res);
+    
+    // add padding 
+    expect(LITCONFIG.PKP_PUBKEY).toEqual('0' + sig.publicKey);
   });
 });

--- a/packages/pkp-base/src/lib/pkp-base.ts
+++ b/packages/pkp-base/src/lib/pkp-base.ts
@@ -95,7 +95,9 @@ export class PKPBase<T = PKPBaseDefaultParams> {
     this.setLitActionJsParams(prop.litActionJsParams || {});
     this.litNodeClient = new LitNodeClient({
       litNetwork: prop.litNetwork ?? 'serrano',
+      bootstrapUrls: (prop.bootstrapUrls && prop.litNetwork == 'custom') ? prop.bootstrapUrls : undefined,
       debug: this.debug,
+      minNodeCount: prop.minNodeCount
     });
   }
 

--- a/packages/pkp-base/src/lib/pkp-base.ts
+++ b/packages/pkp-base/src/lib/pkp-base.ts
@@ -95,9 +95,15 @@ export class PKPBase<T = PKPBaseDefaultParams> {
     this.setLitActionJsParams(prop.litActionJsParams || {});
     this.litNodeClient = new LitNodeClient({
       litNetwork: prop.litNetwork ?? 'serrano',
-      bootstrapUrls: (prop.bootstrapUrls && prop.litNetwork === 'custom') ? prop.bootstrapUrls : undefined,
+      bootstrapUrls:
+        prop.bootstrapUrls && prop.litNetwork === 'custom'
+          ? prop.bootstrapUrls
+          : undefined,
       debug: this.debug,
-      minNodeCount: prop.minNodeCount
+      minNodeCount:
+        prop.bootstrapUrls && prop.litNetwork == 'custom'
+          ? prop.minNodeCount
+          : undefined,
     });
   }
 

--- a/packages/pkp-base/src/lib/pkp-base.ts
+++ b/packages/pkp-base/src/lib/pkp-base.ts
@@ -95,7 +95,7 @@ export class PKPBase<T = PKPBaseDefaultParams> {
     this.setLitActionJsParams(prop.litActionJsParams || {});
     this.litNodeClient = new LitNodeClient({
       litNetwork: prop.litNetwork ?? 'serrano',
-      bootstrapUrls: (prop.bootstrapUrls && prop.litNetwork == 'custom') ? prop.bootstrapUrls : undefined,
+      bootstrapUrls: (prop.bootstrapUrls && prop.litNetwork === 'custom') ? prop.bootstrapUrls : undefined,
       debug: this.debug,
       minNodeCount: prop.minNodeCount
     });

--- a/packages/pkp-base/src/lib/pkp-base.ts
+++ b/packages/pkp-base/src/lib/pkp-base.ts
@@ -59,6 +59,7 @@ export class PKPBase<T = PKPBaseDefaultParams> {
   litActionIPFS?: string;
   litActionJsParams!: T;
   debug: boolean;
+  useAction: boolean | undefined;
 
   readonly defaultLitActionCode: string = `
   (async () => {
@@ -160,6 +161,7 @@ export class PKPBase<T = PKPBaseDefaultParams> {
         'No lit action code or IPFS hash provided. Using default action.'
       );
       this.litActionCode = this.defaultLitActionCode;
+      this.useAction = false;
     }
   }
 

--- a/packages/pkp-cosmos/src/lib/pkp-cosmos.ts
+++ b/packages/pkp-cosmos/src/lib/pkp-cosmos.ts
@@ -143,10 +143,15 @@ export class PKPCosmosWallet
     const hashedMessage = sha256(signBytes);
 
     // Run the LIT action to obtain the signature.
-    const signature = await this.runLitAction(
-      hashedMessage,
-      this.defaultSigName
-    );
+    let signature;
+    if (this.useAction) {
+      signature = await this.runLitAction(
+        hashedMessage,
+        this.defaultSigName
+      );
+    } else {
+      signature = await this.runSign(hashedMessage);
+    }
 
     // Create an ExtendedSecp256k1Signature from the signature components.
     const extendedSig = new ExtendedSecp256k1Signature(

--- a/packages/pkp-ethers/src/lib/pkp-ethers.ts
+++ b/packages/pkp-ethers/src/lib/pkp-ethers.ts
@@ -167,16 +167,15 @@ export class PKPEthersWallet
       // -- lit action --
       const toSign = arrayify(unsignedTxn);
       let signature;
+
       if (this.useAction) {
         this.log('running lit action => sigName: pkp-eth-sign-tx');
         signature = (await this.runLitAction(toSign, 'pkp-eth-sign-tx'))
           .signature;
       } else {
         this.log("requesting signature from nodes");
-        signature = this.sign(toSign);
+        signature = (await this.runSign(toSign)).signature;
       }
-
-      this.log('signature', signature);
 
       return serialize(<UnsignedTransaction>tx, signature);
     });
@@ -192,9 +191,9 @@ export class PKPEthersWallet
     if (this.useAction) {
       this.log('running lit action => sigName: pkp-eth-sign-message');
       signature = await this.runLitAction(toSign, 'pkp-eth-sign-message');      
-    } else { 
+    } else {
       this.log("requesting signature from nodes");
-      signature = await this.sign(toSign);
+      signature = await this.runSign(toSign);
     }
 
     return joinSignature({
@@ -248,7 +247,7 @@ export class PKPEthersWallet
       signature = await this.runLitAction(toSignBuffer, 'pkp-eth-sign-message');      
     } else { 
       this.log("requesting signature from nodes");
-      signature = await this.sign(toSignBuffer);
+      signature = await this.runSign(toSignBuffer);
     }
 
     return joinSignature({

--- a/packages/pkp-ethers/src/lib/pkp-ethers.ts
+++ b/packages/pkp-ethers/src/lib/pkp-ethers.ts
@@ -166,10 +166,15 @@ export class PKPEthersWallet
 
       // -- lit action --
       const toSign = arrayify(unsignedTxn);
-
-      this.log('running lit action => sigName: pkp-eth-sign-tx');
-      const signature = (await this.runLitAction(toSign, 'pkp-eth-sign-tx'))
-        .signature;
+      let signature;
+      if (this.useAction) {
+        this.log('running lit action => sigName: pkp-eth-sign-tx');
+        signature = (await this.runLitAction(toSign, 'pkp-eth-sign-tx'))
+          .signature;
+      } else {
+        this.log("requesting signature from nodes");
+        signature = this.sign(toSign);
+      }
 
       this.log('signature', signature);
 
@@ -183,9 +188,14 @@ export class PKPEthersWallet
     }
 
     const toSign = arrayify(hashMessage(message));
-
-    this.log('running lit action => sigName: pkp-eth-sign-message');
-    const signature = await this.runLitAction(toSign, 'pkp-eth-sign-message');
+    let signature;
+    if (this.useAction) {
+      this.log('running lit action => sigName: pkp-eth-sign-message');
+      signature = await this.runLitAction(toSign, 'pkp-eth-sign-message');      
+    } else { 
+      this.log("requesting signature from nodes");
+      signature = await this.sign(toSign);
+    }
 
     return joinSignature({
       r: '0x' + signature.r,
@@ -231,10 +241,16 @@ export class PKPEthersWallet
       types,
       populated.value
     );
-    const signature = await this.runLitAction(
-      arrayify(toSign),
-      'pkp-eth-sign-typed-data'
-    );
+    const toSignBuffer = arrayify(toSign);
+    let signature;
+    if (this.useAction) {
+      this.log('running lit action => sigName: pkp-eth-sign-message');
+      signature = await this.runLitAction(toSignBuffer, 'pkp-eth-sign-message');      
+    } else { 
+      this.log("requesting signature from nodes");
+      signature = await this.sign(toSignBuffer);
+    }
+
     return joinSignature({
       r: '0x' + signature.r,
       s: '0x' + signature.s,

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -253,6 +253,25 @@ export interface WithSessionSigs extends BaseJsonExecutionRequest {
 
 export type JsonExecutionRequest = WithAuthSig | WithSessionSigs;
 
+export interface BaseJsonPkpSignRequest {
+  toSign: ArrayBufferLike;
+  pubKey: string;
+  // auth methods to resolve
+  authMethods?: Array<Object>;
+}
+
+export interface WithSessionSigsSigning extends BaseJsonPkpSignRequest {
+  sessionSigs: any;
+  authSig?: AuthSig;
+}
+
+export interface WithAuthSigSigning extends BaseJsonPkpSignRequest {
+  authSig: AuthSig;
+  sessionSigs?: any;
+}
+
+export type JsonPkpSignRequest = WithSessionSigsSigning | WithAuthSigSigning;
+
 /**
  * Struct in rust
  * -----
@@ -908,8 +927,8 @@ export interface PKPBaseProp {
   sessionSigsExpiration?: string;
   litNetwork?: any;
   debug?: boolean;
-  bootstrapUrls?: string[],
-  minNodeCount?: number,
+  bootstrapUrls?: string[];
+  minNodeCount?: number;
   litActionCode?: string;
   litActionIPFS?: string;
   litActionJsParams?: any;

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -908,6 +908,8 @@ export interface PKPBaseProp {
   sessionSigsExpiration?: string;
   litNetwork?: any;
   debug?: boolean;
+  bootstrapUrls?: string[],
+  minNodeCount?: number,
   litActionCode?: string;
   litActionIPFS?: string;
   litActionJsParams?: any;

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -19,6 +19,7 @@ import {
   ISessionCapabilityObject,
   LitResourceAbilityRequest,
 } from '@lit-protocol/auth-helpers';
+import { BytesLike } from 'ethers';
 
 export interface AccsOperatorParams {
   operator: string;
@@ -254,7 +255,7 @@ export interface WithSessionSigs extends BaseJsonExecutionRequest {
 export type JsonExecutionRequest = WithAuthSig | WithSessionSigs;
 
 export interface BaseJsonPkpSignRequest {
-  toSign: ArrayBufferLike;
+  toSign: ArrayLike<number>;
   pubKey: string;
   // auth methods to resolve
   authMethods?: Array<Object>;
@@ -923,6 +924,7 @@ export interface PKPBaseProp {
   rpc?: string;
   rpcs?: RPCUrls;
   controllerAuthSig?: AuthSig;
+  controllerAuthMethods?: AuthMethod[];
   controllerSessionSigs?: SessionSigs;
   sessionSigsExpiration?: string;
   litNetwork?: any;


### PR DESCRIPTION
# WHAT
- Removes the requirement of running a lit action when signing messages
- Creates a new `pkpSign` method on `LitNodeClientNodeJs`
- Support added to `pkip-base` to detect if default configuration is present and if so uses the `pkpSign` method over `executeJS`
    - `pkp-cosmos` `pkp-ethers`, have been upgraded to use the new utilities in `pkp-base`

# Testing
- added   tests to `lit-node-client` and run all unit and ci tests to confirm new endpoints are working as expected with the existing features of effected packages.