### PR TITLE
Feature/lit 900 add function to js sdk to enable signing without lit actions

### DIFF
--- a/packages/lit-node-client/src/lib/lit-node-client.spec.ts
+++ b/packages/lit-node-client/src/lib/lit-node-client.spec.ts
@@ -1,6 +1,8 @@
 import { LitNodeClient } from './lit-node-client';
 import * as LITCONFIG from 'lit.config.json';
 import { processTx } from '../../../../tx-handler';
+import { AuthSig } from '@lit-protocol/types';
+import { ethers } from 'ethers';
 let client: LitNodeClient;
 
 jest.setTimeout(60000);
@@ -80,5 +82,25 @@ describe('Lit Actions', () => {
     expect(res.signatures['hello-world-sig'].publicKey).toEqual(
       LITCONFIG.PKP_PUBKEY
     );
+  });
+
+  it('pkp sign endpoint should sign message', async () => {
+    const data = {
+      // hello world in Uint8Array
+      toSign: [104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100],
+      publicKey: LITCONFIG.PKP_PUBKEY,
+      sigName: 'hello-world-sig',
+    };
+
+    let sig = await client.pkpSign({
+      toSign: data.toSign,
+      pubKey: data.publicKey,
+      authMethods: [],
+      authSig: LITCONFIG.CONTROLLER_AUTHSIG,
+    });
+
+    // add padding
+    sig.publicKey = sig.publicKey.length % 2 == 0 ? sig.publicKey : '0' + sig.publicKey;
+    expect(LITCONFIG.PKP_PUBKEY).toEqual(sig.publicKey);
   });
 });

--- a/packages/pkp-cosmos/src/lib/pkp-cosmos.ts
+++ b/packages/pkp-cosmos/src/lib/pkp-cosmos.ts
@@ -143,10 +143,15 @@ export class PKPCosmosWallet
     const hashedMessage = sha256(signBytes);
 
     // Run the LIT action to obtain the signature.
-    const signature = await this.runLitAction(
-      hashedMessage,
-      this.defaultSigName
-    );
+    let signature;
+    if (this.useAction) {
+      signature = await this.runLitAction(
+        hashedMessage,
+        this.defaultSigName
+      );
+    } else {
+      signature = await this.runSign(hashedMessage);
+    }
 
     // Create an ExtendedSecp256k1Signature from the signature components.
     const extendedSig = new ExtendedSecp256k1Signature(

--- a/packages/pkp-ethers/src/lib/pkp-ethers.ts
+++ b/packages/pkp-ethers/src/lib/pkp-ethers.ts
@@ -166,12 +166,16 @@ export class PKPEthersWallet
 
       // -- lit action --
       const toSign = arrayify(unsignedTxn);
+      let signature;
 
-      this.log('running lit action => sigName: pkp-eth-sign-tx');
-      const signature = (await this.runLitAction(toSign, 'pkp-eth-sign-tx'))
-        .signature;
-
-      this.log('signature', signature);
+      if (this.useAction) {
+        this.log('running lit action => sigName: pkp-eth-sign-tx');
+        signature = (await this.runLitAction(toSign, 'pkp-eth-sign-tx'))
+          .signature;
+      } else {
+        this.log("requesting signature from nodes");
+        signature = (await this.runSign(toSign)).signature;
+      }
 
       return serialize(<UnsignedTransaction>tx, signature);
     });
@@ -183,9 +187,14 @@ export class PKPEthersWallet
     }
 
     const toSign = arrayify(hashMessage(message));
-
-    this.log('running lit action => sigName: pkp-eth-sign-message');
-    const signature = await this.runLitAction(toSign, 'pkp-eth-sign-message');
+    let signature;
+    if (this.useAction) {
+      this.log('running lit action => sigName: pkp-eth-sign-message');
+      signature = await this.runLitAction(toSign, 'pkp-eth-sign-message');      
+    } else {
+      this.log("requesting signature from nodes");
+      signature = await this.runSign(toSign);
+    }
 
     return joinSignature({
       r: '0x' + signature.r,
@@ -231,10 +240,16 @@ export class PKPEthersWallet
       types,
       populated.value
     );
-    const signature = await this.runLitAction(
-      arrayify(toSign),
-      'pkp-eth-sign-typed-data'
-    );
+    const toSignBuffer = arrayify(toSign);
+    let signature;
+    if (this.useAction) {
+      this.log('running lit action => sigName: pkp-eth-sign-message');
+      signature = await this.runLitAction(toSignBuffer, 'pkp-eth-sign-message');      
+    } else { 
+      this.log("requesting signature from nodes");
+      signature = await this.runSign(toSignBuffer);
+    }
+
     return joinSignature({
       r: '0x' + signature.r,
       s: '0x' + signature.s,

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -19,6 +19,7 @@ import {
   ISessionCapabilityObject,
   LitResourceAbilityRequest,
 } from '@lit-protocol/auth-helpers';
+import { BytesLike } from 'ethers';
 
 export interface AccsOperatorParams {
   operator: string;
@@ -252,6 +253,25 @@ export interface WithSessionSigs extends BaseJsonExecutionRequest {
 }
 
 export type JsonExecutionRequest = WithAuthSig | WithSessionSigs;
+
+export interface BaseJsonPkpSignRequest {
+  toSign: ArrayLike<number>;
+  pubKey: string;
+  // auth methods to resolve
+  authMethods?: Array<Object>;
+}
+
+export interface WithSessionSigsSigning extends BaseJsonPkpSignRequest {
+  sessionSigs: any;
+  authSig?: AuthSig;
+}
+
+export interface WithAuthSigSigning extends BaseJsonPkpSignRequest {
+  authSig: AuthSig;
+  sessionSigs?: any;
+}
+
+export type JsonPkpSignRequest = WithSessionSigsSigning | WithAuthSigSigning;
 
 /**
  * Struct in rust
@@ -904,12 +924,13 @@ export interface PKPBaseProp {
   rpc?: string;
   rpcs?: RPCUrls;
   controllerAuthSig?: AuthSig;
+  controllerAuthMethods?: AuthMethod[];
   controllerSessionSigs?: SessionSigs;
   sessionSigsExpiration?: string;
   litNetwork?: any;
   debug?: boolean;
-  bootstrapUrls?: string[],
-  minNodeCount?: number,
+  bootstrapUrls?: string[];
+  minNodeCount?: number;
   litActionCode?: string;
   litActionIPFS?: string;
   litActionJsParams?: any;


### PR DESCRIPTION
# WHAT
- Removes the requirement of running a lit action when signing messages
- Creates a new `pkpSign` method on `LitNodeClientNodeJs`
- Support added to `pkip-base` to detect if default configuration is present and if so uses the `pkpSign` method over `executeJS`
    - `pkp-cosmos` `pkp-ethers`, have been upgraded to use the new utilities in `pkp-base`

# Testing
- Added   tests to `lit-node-client` and run all unit and ci tests to confirm new endpoints are working as expected with the existing features of effected packages.