### PR TITLE
Pass in statement from authCallbackParams to signSessionKey

### DIFF
--- a/packages/lit-auth-client/src/lib/providers/BaseProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/BaseProvider.ts
@@ -134,6 +134,7 @@ export abstract class BaseProvider {
           const authSig = JSON.parse(params.authMethod.accessToken);
           response = await nodeClient.signSessionKey({
             sessionKey: params.sessionSigsParams.sessionKey,
+            statement: authCallbackParams.statement,
             authMethods: [],
             authSig: authSig,
             pkpPublicKey: params.pkpPublicKey,
@@ -144,6 +145,7 @@ export abstract class BaseProvider {
         } else {
           response = await nodeClient.signSessionKey({
             sessionKey: params.sessionSigsParams.sessionKey,
+            statement: authCallbackParams.statement,
             authMethods: [params.authMethod],
             pkpPublicKey: params.pkpPublicKey,
             expiration: authCallbackParams.expiration,


### PR DESCRIPTION
# What

This PR:
- Fixes SDK bug where the SIWE statement is malformed, thus causing server-side verification of the SIWE message to fail.