### PR TITLE
Fix/humanize acc

### DIFF
--- a/packages/access-control-conditions/src/lib/humanizer.spec.ts
+++ b/packages/access-control-conditions/src/lib/humanizer.spec.ts
@@ -22,6 +22,7 @@ Object.defineProperty(global.self, 'crypto', {
 });
 
 import * as humanizer from './humanizer';
+import { humanizeAccessControlConditions } from './humanizer';
 import {
   AccsCOSMOSParams,
   AccsEVMParams,
@@ -297,5 +298,25 @@ describe('humanizer.ts', () => {
     expect(OUTPUT).toBe(
       'Owns at least 0.00001 ETH or balanceOf(:userAddress, 8) on contract address 0x7C7757a9675f06F3BE4618bB68732c4aB25D2e88 should have a result of more than 0'
     );
+  });
+
+  it('should humanize acc', async () => {
+    const result = await humanizeAccessControlConditions({
+      unifiedAccessControlConditions: [
+        {
+          chain: 'goerli',
+          method: 'balanceOf',
+          parameters: [':userAddress'],
+          conditionType: 'evmBasic',
+          contractAddress: '0x5b8B8C9aD976aFCAd24fd6CF424294d372c190Ac',
+          returnValueTest: {
+            value: '100000000000000000000',
+            comparator: '>='
+          },
+          standardContractType: 'ERC20'
+        }
+      ]
+    });
+    console.log(result);
   });
 });

--- a/packages/access-control-conditions/src/lib/humanizer.spec.ts
+++ b/packages/access-control-conditions/src/lib/humanizer.spec.ts
@@ -317,6 +317,8 @@ describe('humanizer.ts', () => {
         }
       ]
     });
-    console.log(result);
+    expect(result).toContain("0x5b8B8C9aD976aFCAd24fd6CF424294d372c190Ac");
+    expect(result).toContain("100.0");
+    expect(result).toContain("at least");
   });
 });

--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -18,7 +18,7 @@ export * from './lib/errors';
 export * from './lib/utils/utils';
 
 // ----------- ABIs -----------
-const ABI_LIT = import('./lib/abis/LIT.json');
-const ABI_ERC20 = import('./lib/abis/ERC20.json');
+import * as ABI_LIT from './lib/abis/LIT.json';
+import * as  ABI_ERC20 from './lib/abis/ERC20.json';
 
 export { ABI_LIT, ABI_ERC20 };


### PR DESCRIPTION
# WHAT
Fixes issue #195 
The `ERC20` Contract ABI is imported as a `Promise` instead of an `Object` type. Changing import statements from using `import()` to module imports results in `ERC20` resolving to an `Object` when imported.