### PR TITLE
add check for node runtime and import from node buffer for Blob

### DIFF
--- a/packages/crypto/polyfills.js
+++ b/packages/crypto/polyfills.js
@@ -1,0 +1,19 @@
+// This field will be automatically injected into the ./dist/packages/<package-name>/index.js file
+// between the autogen:polyfills:start/end comments
+
+try {
+  if (isNode()) {
+    try {
+      //@ts-ignore
+      let { Blob } = import('node:buffer').then((module) => {
+        globalThis.Blob = module.Blob;
+      });
+    } catch (e) {
+      log(
+        'Warn: could not resolve Blob from node api set, perhaps polyfil a Blob implementation of your choice'
+      );
+    }
+  }
+} catch (e) {
+  // swallow
+}

--- a/packages/crypto/src/lib/crypto.spec.ts
+++ b/packages/crypto/src/lib/crypto.spec.ts
@@ -64,6 +64,17 @@ describe('encryptWithSymmetricKey', () => {
   let symmetricKey: CryptoKey;
 
   beforeAll(async () => {
+      try {
+        //@ts-ignore
+        import('node:buffer').then((module) => {
+          //@ts-ignore
+          globalThis.Blob = module.Blob;
+        });
+      } catch (e) {
+        console.log(
+          'Warn: could not resolve Blob from node api set, perhaps polyfil a Blob implementation of your choice'
+        );
+      }
     symmetricKey = await generateSymmetricKey();
   });
 

--- a/packages/crypto/src/lib/crypto.spec.ts
+++ b/packages/crypto/src/lib/crypto.spec.ts
@@ -67,8 +67,9 @@ describe('encryptWithSymmetricKey', () => {
     symmetricKey = await generateSymmetricKey();
   });
 
-  testData.forEach((data, index) => {
+  testData.forEach(async (data, index) => {
     it(`should encrypt data (test case ${index + 1})`, async () => {
+      const { Blob } = await import("node:buffer");
       const encryptedBlob = await encryptWithSymmetricKey(symmetricKey, data);
 
       expect(encryptedBlob).toBeDefined();

--- a/packages/crypto/src/lib/crypto.ts
+++ b/packages/crypto/src/lib/crypto.ts
@@ -11,7 +11,7 @@ import {
 
 import * as wasmECDSA from '@lit-protocol/ecdsa-sdk';
 
-import { isBrowser, log, throwError } from '@lit-protocol/misc';
+import { isBrowser, isNode, log, throwError } from '@lit-protocol/misc';
 
 import {
   uint8arrayFromString,
@@ -101,12 +101,20 @@ export const encryptWithSymmetricKey = async (
     symmKey,
     data
   );
-
-  const encryptedZipBlob = new Blob([iv, new Uint8Array(encryptedZipData)], {
-    type: 'application/octet-stream',
-  });
-
-  return encryptedZipBlob;
+  if (isNode()) {
+    let { Blob } = await import("node:buffer");
+    const encryptedZipBlob = new Blob([iv, new Uint8Array(encryptedZipData)], {
+      type: 'application/octet-stream',
+    });
+  
+    return encryptedZipBlob; 
+  } else {
+    const encryptedZipBlob = new Blob([iv, new Uint8Array(encryptedZipData)], {
+      type: 'application/octet-stream',
+    });
+  
+    return encryptedZipBlob;
+  }
 };
 
 /**

--- a/packages/crypto/src/lib/crypto.ts
+++ b/packages/crypto/src/lib/crypto.ts
@@ -61,17 +61,7 @@ if (!globalThis.wasmECDSA) {
   });
 }
 
-if (isNode()) {
-  try {
-    let { Blob } = import('node:buffer').then((module) => {
-      globalThis.Blob = module.Blob;
-    });
-  } catch (e) {
-    log(
-      'Warn: could not resolve Blob from node api set, perhaps polyfil a Blob implementation of your choice'
-    );
-  }
-}
+
 /** ---------- Exports ---------- */
 
 /**
@@ -113,8 +103,7 @@ export const encryptWithSymmetricKey = async (
     symmKey,
     data
   );
-
-  let { Blob } = await import('node:buffer');
+  
   const encryptedZipBlob = new Blob([iv, new Uint8Array(encryptedZipData)], {
     type: 'application/octet-stream',
   });

--- a/packages/crypto/src/lib/crypto.ts
+++ b/packages/crypto/src/lib/crypto.ts
@@ -60,6 +60,18 @@ if (!globalThis.wasmECDSA) {
     }
   });
 }
+
+if (isNode()) {
+  try {
+    let { Blob } = import('node:buffer').then((module) => {
+      globalThis.Blob = module.Blob;
+    });
+  } catch (e) {
+    log(
+      'Warn: could not resolve Blob from node api set, perhaps polyfil a Blob implementation of your choice'
+    );
+  }
+}
 /** ---------- Exports ---------- */
 
 /**
@@ -101,20 +113,13 @@ export const encryptWithSymmetricKey = async (
     symmKey,
     data
   );
-  if (isNode()) {
-    let { Blob } = await import("node:buffer");
-    const encryptedZipBlob = new Blob([iv, new Uint8Array(encryptedZipData)], {
-      type: 'application/octet-stream',
-    });
-  
-    return encryptedZipBlob; 
-  } else {
-    const encryptedZipBlob = new Blob([iv, new Uint8Array(encryptedZipData)], {
-      type: 'application/octet-stream',
-    });
-  
-    return encryptedZipBlob;
-  }
+
+  let { Blob } = await import('node:buffer');
+  const encryptedZipBlob = new Blob([iv, new Uint8Array(encryptedZipData)], {
+    type: 'application/octet-stream',
+  });
+
+  return encryptedZipBlob;
 };
 
 /**


### PR DESCRIPTION
fixes an observed issue with `encryptWithSymmetricKey` which throws an error in NodeJS when attempting to use the `Blob` object as it is not available in global scope. 

refactors to check for if the env is `node` and then imports `node:buffer` to use the compatible `Blob` object