### PR TITLE
Add/claim props e2e

### DIFF
--- a/e2e-nodejs/group-lit-actions/test-lit-action-claim-key.mjs
+++ b/e2e-nodejs/group-lit-actions/test-lit-action-claim-key.mjs
@@ -30,19 +30,19 @@ export async function main() {
 
   // -- should have claimData
   if (
-    res.claimData === undefined ||
-    res.claimData === null ||
-    Object.keys(res.claimData).length === 0
+    res.claims === undefined ||
+    res.claims === null ||
+    Object.keys(res.claims).length === 0
   ) {
     return fail(`claimData should not be empty`);
   }
 
-  if (res.claimData['foo'] === undefined) {
+  if (res.claims['foo'] === undefined) {
     return fail(`claimData should have "foo" key`);
   }
 
   ['signature', 'derivedKeyId'].forEach((key) => {
-    if (!res.claimData.foo[key]) {
+    if (!res.claims.foo[key]) {
       return fail(`claimData.foo should have ${key}`);
     }
   });

--- a/e2e-nodejs/group-lit-actions/test-lit-action-claim-key.mjs
+++ b/e2e-nodejs/group-lit-actions/test-lit-action-claim-key.mjs
@@ -47,6 +47,12 @@ export async function main() {
     }
   });
 
+  for (let i = 0; i < res.claims[key].signatures.length; i++) {
+    if (!res.claims[key].signatures[i].r || !res.claims[key].signatures[i].s || res.claims[key].signatures[i].v) {
+      return fail(`signature data misformed, should be of ethers signature format`);
+    }
+  }
+
   // ==================== Success ====================
   return success('Lit Action should return claim');
 }

--- a/e2e-nodejs/group-lit-actions/test-lit-action-grouped-claims.mjs
+++ b/e2e-nodejs/group-lit-actions/test-lit-action-grouped-claims.mjs
@@ -29,38 +29,44 @@ export async function main() {
     return fail(`decryptedData should be empty`);
   }
 
-  // -- should have claimData
-  Object.entries(res.claimData).forEach(([key, value]) => {
+  // -- should have claims
+  Object.entries(res.claims).forEach(([key, value]) => {
     if (key !== 'foo' || key !== 'bar') {
-      return fail(`claimData should have "foo" or "bar" key`);
+      return fail(`claims should have "foo" or "bar" key`);
     }
 
     if (
-      res.claimData === undefined ||
-      res.claimData === null ||
-      Object.keys(res.claimData).length === 0
+      res.claims === undefined ||
+      res.claims === null ||
+      Object.keys(res.claims).length === 0
     ) {
-      return fail(`claimData should not be empty`);
+      return fail(`claims should not be empty`);
     }
 
-    if (res.claimData[key] === undefined) {
-      return fail(`claimData should have "${key}" key`);
-    }
-
-    if (
-      res.claimData[key].signature === undefined ||
-      res.claimData[key].signature === null ||
-      res.claimData[key].signature === ''
-    ) {
-      return fail(`claimData[${key}] should have signature`);
+    if (res.claims[key] === undefined) {
+      return fail(`claims should have "${key}" key`);
     }
 
     if (
-      res.claimData[key].derivedKeyId === undefined ||
-      res.claimData[key].derivedKeyId === null ||
-      res.claimData[key].derivedKeyId === ''
+      res.claims[key].signature === undefined ||
+      res.claims[key].signature === null ||
+      res.claims[key].signature.length < 1
     ) {
-      return fail(`claimData[${key}] should have derivedKeyId`);
+      return fail(`claims[${key}] should have signature`);
+    }
+
+    if (
+      res.claims[key].derivedKeyId === undefined ||
+      res.claims[key].derivedKeyId === null ||
+      res.claims[key].derivedKeyId === ''
+    ) {
+      return fail(`claims[${key}] should have derivedKeyId`);
+    }
+
+    for (let i = 0; i < res.claims[key].signatures.length; i++) {
+      if (!res.claims[key].signatures[i].r || !res.claims[key].signatures[i].s || res.claims[key].signatures[i].v) {
+        return fail(`signature data mis formed, should be of ethers signature format`);
+      }
     }
   });
 


### PR DESCRIPTION
- Fixes claim tests where `claimData` property was used instead of `claims` causing false test positives for claim tests through actions
- Adds checks for ethers signature structure to be correct on `claims` returned from actions.