### PR TITLE
fix encryptFileAndZipWithMetadata node

### DIFF
--- a/packages/encryption/src/lib/encryption.ts
+++ b/packages/encryption/src/lib/encryption.ts
@@ -571,7 +571,12 @@ export const encryptFileAndZipWithMetadata = async (
 
   folder.file(file.name, uint8arrayFromString(ciphertext, 'base64'));
 
-  const zipBlob = await zip.generateAsync({ type: 'blob' });
+  let zipBlob;
+  if (isBrowser()) {
+    zipBlob = await zip.generateAsync({ type: 'blob' });
+  } else {
+    zipBlob = await zip.generateAsync({ type: 'nodebuffer' });
+  }
 
   return zipBlob;
 };

--- a/packages/encryption/src/lib/params-validators.ts
+++ b/packages/encryption/src/lib/params-validators.ts
@@ -351,7 +351,7 @@ class FileValidator implements ParamsValidator {
     if (
       !checkType({
         value: this.file,
-        allowedTypes: ['Blob', 'File'],
+        allowedTypes: ['Blob', 'File', 'Uint8Array'],
         paramName: 'file',
         functionName: this.fnName,
       })


### PR DESCRIPTION
`encryptFileAndZipWithMetadata` was not working for the @lit-protocol/lit-node-client-nodejs version of the sdk.

Presumably the `zipBlob = await zip.generateAsync({ type: 'blob' })` works properly only in browser env.

- The function now returns a `nodebuffer` instead of `blob` when not on browser env.
- The file validation function now accepts a 'Uint8array' and not only the client side 'Blob','File' obj

Node v18.16, tested both on next.js and standalone script