### PR TITLE
feat: Store blockhash from handshake + use it in SIWE

### DIFF
--- a/apps/html/manual_tests.html
+++ b/apps/html/manual_tests.html
@@ -21,22 +21,47 @@
 
       //var authSig = JSON.parse("{\"sig\":\"0x18a173d68d2f78cc5c13da0dfe36eec2a293285bee6d42547b9577bf26cdc985660ed3dddc4e75d422366cac07e8a9fc77669b10373bef9c7b8e4280252dfddf1b\",\"derivedVia\":\"web3.eth.personal.sign\",\"signedMessage\":\"I am creating an account to use LITs at 2021-08-04T20:14:04.918Z\",\"address\":\"0xdbd360f30097fb6d938dcc8b7b62854b36160b45\"}")
 
-      var CheckAndSignAuthMessageWorksWithoutBlockhash = async() => {
+      var CheckAndSignAuthMessageWithoutBlockhash = async() => {
         const authSig = await LitJsSdk.checkAndSignAuthMessage({
             chain: "ethereum",
         });
+        let nonceLine = authSig.signedMessage.match(/^Nonce: (.+)$/m);
+
+        if (nonceLine[1].length ===  17) {
+          document.getElementById(
+            'status'
+          ).innerText = "CheckAndSignAuthMessageWithoutBlockhash passed!";
+          return true;
+        } else {
+          document.getElementById('status').innerText = "CheckAndSignAuthMessageWithoutBlockhash failed!";
+          return false;
+        }
+
+        await LitJsSdk.disconnectWeb3();
       }
 
       // The nonce should be we the below blockhash
-      var CheckAndSignAuthMessageWorksWithBlockhash = async() => {
+      var CheckAndSignAuthMessageWithBlockhash = async() => {
         // Currently this will be undefined but later we should replace it with the hardcoded blockhash
-        const nonce = litNodeClient.getLatestBlockhash() 
-        || "0xfe88c94d860f01a17f961bf4bdfb6e0c6cd10d3fda5cc861e805ca1240c58553";
+        const TEST_BLOCKHASH = "0xfe88c94d860f01a17f961bf4bdfb6e0c6cd10d3fda5cc861e805ca1240c58553";
+        const nonce = litNodeClient.getLatestBlockhash() || TEST_BLOCKHASH;
 
         const authSig = await LitJsSdk.checkAndSignAuthMessage({
             chain: "ethereum",
             nonce,
         });
+
+        if (authSig.signedMessage.includes(TEST_BLOCKHASH)) {
+          document.getElementById(
+            'status'
+          ).innerText = "CheckAndSignAuthMessageWithBlockhash passed!";
+          return true;
+        } else {
+          document.getElementById('status').innerText = "CheckAndSignAuthMessageWithBlockhash failed!";
+          return false;
+        }
+
+        await LitJsSdk.disconnectWeb3();
       }
 
       var testEncryptingFileAndZipWithMetadata = async ({
@@ -1582,10 +1607,10 @@
     <div id="networkStatus">Connecting to Lit Protocol Network...</div>
     <br />
     <br />
-    <button onclick="CheckAndSignAuthMessageWorksWithoutBlockhash()">checkAndSignAuthMessage without blockhash nonce</button>
+    <button onclick="CheckAndSignAuthMessageWithoutBlockhash()">checkAndSignAuthMessage without blockhash</button>
     <br />
     <br />
-    <button onclick="CheckAndSignAuthMessageWorksWithBlockhash()">checkAndSignAuthMessage with blockhash nonce</button>
+    <button onclick="CheckAndSignAuthMessageWithBlockhash()">checkAndSignAuthMessage with blockhash</button>
     <br />
     <br />
     <button onclick="ETHEmptyWallet()">ETH (Empty Wallet)</button>

--- a/apps/html/manual_tests.html
+++ b/apps/html/manual_tests.html
@@ -21,6 +21,24 @@
 
       //var authSig = JSON.parse("{\"sig\":\"0x18a173d68d2f78cc5c13da0dfe36eec2a293285bee6d42547b9577bf26cdc985660ed3dddc4e75d422366cac07e8a9fc77669b10373bef9c7b8e4280252dfddf1b\",\"derivedVia\":\"web3.eth.personal.sign\",\"signedMessage\":\"I am creating an account to use LITs at 2021-08-04T20:14:04.918Z\",\"address\":\"0xdbd360f30097fb6d938dcc8b7b62854b36160b45\"}")
 
+      var CheckAndSignAuthMessageWorksWithoutBlockhash = async() => {
+        const authSig = await LitJsSdk.checkAndSignAuthMessage({
+            chain: "ethereum",
+        });
+      }
+
+      // The nonce should be we the below blockhash
+      var CheckAndSignAuthMessageWorksWithBlockhash = async() => {
+        // Currently this will be undefined but later we should replace it with the hardcoded blockhash
+        const nonce = litNodeClient.getLatestBlockhash() 
+        || "0xfe88c94d860f01a17f961bf4bdfb6e0c6cd10d3fda5cc861e805ca1240c58553";
+
+        const authSig = await LitJsSdk.checkAndSignAuthMessage({
+            chain: "ethereum",
+            nonce,
+        });
+      }
+
       var testEncryptingFileAndZipWithMetadata = async ({
         accessControlConditions,
         evmContractConditions,
@@ -1562,6 +1580,12 @@
     <br />
     <br />
     <div id="networkStatus">Connecting to Lit Protocol Network...</div>
+    <br />
+    <br />
+    <button onclick="CheckAndSignAuthMessageWorksWithoutBlockhash()">checkAndSignAuthMessage without blockhash nonce</button>
+    <br />
+    <br />
+    <button onclick="CheckAndSignAuthMessageWorksWithBlockhash()">checkAndSignAuthMessage with blockhash nonce</button>
     <br />
     <br />
     <button onclick="ETHEmptyWallet()">ETH (Empty Wallet)</button>

--- a/e2e-nodejs/group-hotwallet-with-blockhash/test-hotwallet-with-blockhash.mjs
+++ b/e2e-nodejs/group-hotwallet-with-blockhash/test-hotwallet-with-blockhash.mjs
@@ -1,0 +1,70 @@
+import path from 'path';
+import { success, fail, testThis } from '../../tools/scripts/utils.mjs';
+
+import * as LitJsSdk from '@lit-protocol/lit-node-client';
+import { fromString as uint8arrayFromString } from "uint8arrays/from-string";
+import ethers from "ethers";
+import siwe from "siwe";
+
+export async function main() {
+  // ==================== Setup ====================
+
+  const privKey = "3dfb4f70b15b6fccc786347aaea445f439a7f10fd10c55dd50cafc3d5a0abac1";
+  const privKeyBuffer = uint8arrayFromString(privKey, "base16");
+  const wallet = new ethers.Wallet(privKeyBuffer);
+
+  const domain = "localhost";
+  const origin = "https://localhost/login";
+  const statement = "This is a test statement. You can put anything you want here.";
+
+  const TEST_BLOCKHASH = "0xfe88c94d860f01a17f961bf4bdfb6e0c6cd10d3fda5cc861e805ca1240c58553";
+
+  // ==================== Test Logic ====================
+
+  const litNodeClient = new LitJsSdk.LitNodeClient({
+    litNetwork: "cayenne",
+  });
+  await litNodeClient.connect();
+  let nonce = litNodeClient.getLatestBlockhash();
+
+  if (!nonce) {
+    console.log("Latest blockhash is undefined as the corr node changes hasn't been deployed");
+    nonce =  TEST_BLOCKHASH;
+  }
+
+  const siweMessage = new siwe.SiweMessage({
+    domain,
+    address: wallet.address,
+    statement,
+    uri: origin,
+    version: "1",
+    chainId: "1",
+    nonce,
+  });
+
+  const messageToSign = siweMessage.prepareMessage();
+  const signature = await wallet.signMessage(messageToSign);
+
+  // ==================== Post-Validation ====================
+
+  const recoveredAddress = ethers.utils.verifyMessage(messageToSign, signature);
+
+  const authSig = {
+    sig: signature,
+    derivedVia: "web3.eth.personal.sign",
+    signedMessage: messageToSign,
+    address: recoveredAddress,
+  };
+
+  console.log(authSig);
+
+  if (!authSig.signedMessage.includes(TEST_BLOCKHASH)) {
+    return fail("authSig doesn't contain the blockhash");
+  }
+
+  // ==================== Success ====================
+
+  return success('Can create an authSig with the latest blockhash as its nonce');
+}
+
+await testThis({ name: path.basename(import.meta.url), fn: main });

--- a/packages/auth-browser/src/lib/auth-browser.ts
+++ b/packages/auth-browser/src/lib/auth-browser.ts
@@ -12,7 +12,6 @@ import { checkAndSignSolAuthMessage } from './chains/sol';
  * Check for an existing cryptographic authentication signature and create one of it does not exist.  This is used to prove ownership of a given crypto wallet address to the Lit nodes.  The result is stored in LocalStorage so the user doesn't have to sign every time they perform an operation.
  *
  * @param { AuthCallbackParams }
- * @param { ILitNodeClient } litNodeClient - The Lit Node Client
  *
  *  @returns { AuthSig } The AuthSig created or retrieved
  */

--- a/packages/auth-browser/src/lib/auth-browser.ts
+++ b/packages/auth-browser/src/lib/auth-browser.ts
@@ -25,7 +25,6 @@ export const checkAndSignAuthMessage = ({
   walletConnectProjectId,
   nonce,
 }: AuthCallbackParams): Promise<AuthSig> => {
-  console.log("checkAndSignAuthMessage- ", nonce);
   const chainInfo = ALL_LIT_CHAINS[chain];
 
   // -- validate: if chain info not found

--- a/packages/auth-browser/src/lib/auth-browser.ts
+++ b/packages/auth-browser/src/lib/auth-browser.ts
@@ -1,6 +1,6 @@
 import { ALL_LIT_CHAINS, LIT_ERROR, VMTYPE } from '@lit-protocol/constants';
 
-import { AuthCallbackParams, AuthSig, ILitNodeClient } from '@lit-protocol/types';
+import { AuthCallbackParams, AuthSig } from '@lit-protocol/types';
 
 import { throwError } from '@lit-protocol/misc';
 import { checkAndSignCosmosAuthMessage } from './chains/cosmos';
@@ -24,8 +24,9 @@ export const checkAndSignAuthMessage = ({
   uri,
   cosmosWalletType,
   walletConnectProjectId,
-}: AuthCallbackParams,
-litNodeClient?: ILitNodeClient): Promise<AuthSig> => {
+  nonce,
+}: AuthCallbackParams): Promise<AuthSig> => {
+  console.log("checkAndSignAuthMessage- ", nonce);
   const chainInfo = ALL_LIT_CHAINS[chain];
 
   // -- validate: if chain info not found
@@ -46,15 +47,6 @@ litNodeClient?: ILitNodeClient): Promise<AuthSig> => {
 
   // -- check and sign auth message based on chain
   if (chainInfo.vmType === VMTYPE.EVM) {
-    // TODO: Uncomment below after the new node changes are deployed
-    // if (!litNodeClient) {
-    //   throwError({
-    //     message: 'litNodeClient not provided for EVM signing',
-    //     errorKind: LIT_ERROR.LIT_NODE_CLIENT_NOT_PROVIDED.kind,
-    //     errorCode: LIT_ERROR.LIT_NODE_CLIENT_NOT_PROVIDED.name,
-    //   });
-    // }
-
     return checkAndSignEVMAuthMessage({
       chain,
       resources,
@@ -62,7 +54,8 @@ litNodeClient?: ILitNodeClient): Promise<AuthSig> => {
       expiration,
       uri,
       walletConnectProjectId,
-    }, litNodeClient);
+      nonce,
+    });
   } else if (chainInfo.vmType === VMTYPE.SVM) {
     return checkAndSignSolAuthMessage();
   } else if (chainInfo.vmType === VMTYPE.CVM) {

--- a/packages/auth-browser/src/lib/auth-browser.ts
+++ b/packages/auth-browser/src/lib/auth-browser.ts
@@ -1,6 +1,6 @@
 import { ALL_LIT_CHAINS, LIT_ERROR, VMTYPE } from '@lit-protocol/constants';
 
-import { AuthCallbackParams, AuthSig } from '@lit-protocol/types';
+import { AuthCallbackParams, AuthSig, ILitNodeClient } from '@lit-protocol/types';
 
 import { throwError } from '@lit-protocol/misc';
 import { checkAndSignCosmosAuthMessage } from './chains/cosmos';
@@ -12,6 +12,7 @@ import { checkAndSignSolAuthMessage } from './chains/sol';
  * Check for an existing cryptographic authentication signature and create one of it does not exist.  This is used to prove ownership of a given crypto wallet address to the Lit nodes.  The result is stored in LocalStorage so the user doesn't have to sign every time they perform an operation.
  *
  * @param { AuthCallbackParams }
+ * @param { ILitNodeClient } litNodeClient - The Lit Node Client
  *
  *  @returns { AuthSig } The AuthSig created or retrieved
  */
@@ -23,7 +24,8 @@ export const checkAndSignAuthMessage = ({
   uri,
   cosmosWalletType,
   walletConnectProjectId,
-}: AuthCallbackParams): Promise<AuthSig> => {
+}: AuthCallbackParams,
+litNodeClient?: ILitNodeClient): Promise<AuthSig> => {
   const chainInfo = ALL_LIT_CHAINS[chain];
 
   // -- validate: if chain info not found
@@ -44,6 +46,15 @@ export const checkAndSignAuthMessage = ({
 
   // -- check and sign auth message based on chain
   if (chainInfo.vmType === VMTYPE.EVM) {
+    // TODO: Uncomment below after the new node changes are deployed
+    // if (!litNodeClient) {
+    //   throwError({
+    //     message: 'litNodeClient not provided for EVM signing',
+    //     errorKind: LIT_ERROR.LIT_NODE_CLIENT_NOT_PROVIDED.kind,
+    //     errorCode: LIT_ERROR.LIT_NODE_CLIENT_NOT_PROVIDED.name,
+    //   });
+    // }
+
     return checkAndSignEVMAuthMessage({
       chain,
       resources,
@@ -51,7 +62,7 @@ export const checkAndSignAuthMessage = ({
       expiration,
       uri,
       walletConnectProjectId,
-    });
+    }, litNodeClient);
   } else if (chainInfo.vmType === VMTYPE.SVM) {
     return checkAndSignSolAuthMessage();
   } else if (chainInfo.vmType === VMTYPE.CVM) {

--- a/packages/auth-browser/src/lib/chains/eth.ts
+++ b/packages/auth-browser/src/lib/chains/eth.ts
@@ -22,7 +22,7 @@ import LitConnectModal from '../connect-modal/modal';
 
 import { Web3Provider, JsonRpcSigner } from '@ethersproject/providers';
 
-import { generateNonce, SiweMessage } from 'lit-siwe';
+import { SiweMessage } from 'lit-siwe';
 import { getAddress } from 'ethers/lib/utils';
 
 // @ts-ignore: If importing 'nacl' directly, the built files will use .default instead
@@ -458,7 +458,6 @@ export const disconnectWeb3 = (): void => {
  * Check and sign EVM auth message
  *
  * @param { CheckAndSignAuthParams }
- * @param { ILitNodeClient } litNodeClient - The Lit Node Client
  * @returns
  */
 export const checkAndSignEVMAuthMessage = async ({
@@ -728,7 +727,6 @@ const _signAndGetAuth = async ({
  * Called by checkAndSignAuthMessage if the user does not have a signature stored.
  *
  * @param { signAndSaveAuthParams }
- * @param { ILitNodeClient } litNodeClient - The Lit Node Client
  * @returns { AuthSig }
  */
 export const signAndSaveAuthMessage = async ({

--- a/packages/auth-browser/src/lib/chains/eth.ts
+++ b/packages/auth-browser/src/lib/chains/eth.ts
@@ -470,7 +470,6 @@ export const checkAndSignEVMAuthMessage = async ({
   nonce,
 }: AuthCallbackParams): Promise<AuthSig> => {
   // -- check if it's nodejs
-  log("checkAndSignEVMAuthMessage- ", nonce);
   if (isNode()) {
     log(
       'checkAndSignEVMAuthMessage is not supported in nodejs.  You can create a SIWE on your own using the SIWE package.'
@@ -692,7 +691,6 @@ const _signAndGetAuth = async ({
   uri,
   nonce,
 }: signAndSaveAuthParams): Promise<AuthSig> => {
-  log("_signAndGetAuth- ", nonce);
   await signAndSaveAuthMessage({
     web3,
     account,
@@ -738,7 +736,6 @@ export const signAndSaveAuthMessage = async ({
   uri,
   nonce,
 }: signAndSaveAuthParams): Promise<AuthSig> => {
-  log("signAndSaveAuthMessage- ", nonce);
   // check if it's nodejs
   if (isNode()) {
     log('checkAndSignEVMAuthMessage is not supported in nodejs.');

--- a/packages/auth-browser/src/lib/chains/eth.ts
+++ b/packages/auth-browser/src/lib/chains/eth.ts
@@ -8,7 +8,7 @@ import {
   LOCAL_STORAGE_KEYS,
 } from '@lit-protocol/constants';
 
-import { AuthSig, AuthCallbackParams, ILitNodeClient } from '@lit-protocol/types';
+import { AuthSig, AuthCallbackParams } from '@lit-protocol/types';
 
 import { ethers } from 'ethers';
 // import WalletConnectProvider from '@walletconnect/ethereum-provider';
@@ -89,6 +89,7 @@ interface signAndSaveAuthParams {
   resources: any;
   expiration: string;
   uri?: string;
+  nonce: string,
 }
 
 interface IABI {
@@ -467,9 +468,10 @@ export const checkAndSignEVMAuthMessage = async ({
   expiration,
   uri,
   walletConnectProjectId,
-}: AuthCallbackParams,
-litNodeClient?: ILitNodeClient): Promise<AuthSig> => {
+  nonce,
+}: AuthCallbackParams): Promise<AuthSig> => {
   // -- check if it's nodejs
+  log("checkAndSignEVMAuthMessage- ", nonce);
   if (isNode()) {
     log(
       'checkAndSignEVMAuthMessage is not supported in nodejs.  You can create a SIWE on your own using the SIWE package.'
@@ -603,7 +605,8 @@ litNodeClient?: ILitNodeClient): Promise<AuthSig> => {
         resources,
         expiration: expirationString,
         uri,
-      }, litNodeClient);
+        nonce,
+      });
     } catch (e: any) {
       log(e);
       return throwError({
@@ -636,7 +639,8 @@ litNodeClient?: ILitNodeClient): Promise<AuthSig> => {
       resources,
       expiration: expirationString,
       uri,
-    }, litNodeClient);
+      nonce,
+    });
     log('7. authSig:', authSig);
 
     // -- 8. case: we are on the right wallet, but need to check the resources of the sig and re-sign if they don't match
@@ -651,7 +655,8 @@ litNodeClient?: ILitNodeClient): Promise<AuthSig> => {
         resources,
         expiration: expirationString,
         uri,
-      }, litNodeClient);
+        nonce,
+      });
     }
     log('8. mustResign:', mustResign);
   }
@@ -668,7 +673,8 @@ litNodeClient?: ILitNodeClient): Promise<AuthSig> => {
       resources,
       expiration: expirationString,
       uri,
-    }, litNodeClient);
+      nonce,
+    });
   }
 
   return authSig;
@@ -685,8 +691,9 @@ const _signAndGetAuth = async ({
   resources,
   expiration,
   uri,
-}: signAndSaveAuthParams,
-litNodeClient?: ILitNodeClient): Promise<AuthSig> => {
+  nonce,
+}: signAndSaveAuthParams): Promise<AuthSig> => {
+  log("_signAndGetAuth- ", nonce);
   await signAndSaveAuthMessage({
     web3,
     account,
@@ -694,7 +701,8 @@ litNodeClient?: ILitNodeClient): Promise<AuthSig> => {
     resources,
     expiration,
     uri,
-  }, litNodeClient);
+    nonce,
+  });
 
   let authSigOrError = getStorageItem(LOCAL_STORAGE_KEYS.AUTH_SIGNATURE);
 
@@ -730,8 +738,9 @@ export const signAndSaveAuthMessage = async ({
   resources,
   expiration,
   uri,
-}: signAndSaveAuthParams,
-litNodeClient?: ILitNodeClient): Promise<AuthSig> => {
+  nonce,
+}: signAndSaveAuthParams): Promise<AuthSig> => {
+  log("signAndSaveAuthMessage- ", nonce);
   // check if it's nodejs
   if (isNode()) {
     log('checkAndSignEVMAuthMessage is not supported in nodejs.');
@@ -750,7 +759,7 @@ litNodeClient?: ILitNodeClient): Promise<AuthSig> => {
     version: '1',
     chainId,
     expirationTime: expiration,
-    nonce: litNodeClient?.latest_blockhash || generateNonce()
+    nonce,
   };
 
   if (resources && resources.length > 0) {

--- a/packages/constants/src/lib/errors.ts
+++ b/packages/constants/src/lib/errors.ts
@@ -46,11 +46,6 @@ export const LIT_ERROR = {
     code: 'lit_node_client_not_ready_error',
     kind: LitErrorKind.Unexpected,
   },
-  LIT_NODE_CLIENT_NOT_PROVIDED: {
-    name: 'LitNodeClientNotProvidedError',
-    code: 'lit_node_client_not_provided_error',
-    kind: LitErrorKind.Unexpected,
-  },
   UNAUTHROZIED_EXCEPTION: {
     name: 'UnauthroziedException',
     code: 'unauthrozied_exception',

--- a/packages/constants/src/lib/errors.ts
+++ b/packages/constants/src/lib/errors.ts
@@ -46,6 +46,11 @@ export const LIT_ERROR = {
     code: 'lit_node_client_not_ready_error',
     kind: LitErrorKind.Unexpected,
   },
+  LIT_NODE_CLIENT_NOT_PROVIDED: {
+    name: 'LitNodeClientNotProvidedError',
+    code: 'lit_node_client_not_provided_error',
+    kind: LitErrorKind.Unexpected,
+  },
   UNAUTHROZIED_EXCEPTION: {
     name: 'UnauthroziedException',
     code: 'unauthrozied_exception',

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -63,7 +63,7 @@ export class LitCore {
   networkPubKey: string | null;
   networkPubKeySet: string | null;
   hdRootPubkeys: string[] | null;
-  latest_blockhash: string | null;
+  latestBlockhash: string | null;
 
   // ========== Constructor ==========
   constructor(args: any[LitNodeClientConfig | CustomNetwork | any]) {
@@ -89,7 +89,7 @@ export class LitCore {
     this.networkPubKey = null;
     this.networkPubKeySet = null;
     this.hdRootPubkeys = null;
-    this.latest_blockhash = null;
+    this.latestBlockhash = null;
     // -- set bootstrapUrls to match the network litNetwork unless it's set to custom
     this.setCustomBootstrapUrls();
 
@@ -148,7 +148,7 @@ export class LitCore {
             networkPubKey: resp.networkPublicKey,
             networkPubKeySet: resp.networkPublicKeySet,
             hdRootPubkeys: resp.hdRootPubkeys,
-            latest_blockhash: resp.latest_blockhash,
+            latestBlockhash: resp.latestBlockhash,
           };
 
           // -- validate returned keys
@@ -161,7 +161,7 @@ export class LitCore {
             log('Error connecting to node. Detected "ERR" in keys', url, keys);
           }
 
-          if (!keys.latest_blockhash) {
+          if (!keys.latestBlockhash) {
             log('Error getting latest blockhash from the node.');
           }
 
@@ -200,9 +200,9 @@ export class LitCore {
               (keysFromSingleNode: any) => keysFromSingleNode.hdRootPubkeys
             )
           );
-          this.latest_blockhash = mostCommonString(
+          this.latestBlockhash = mostCommonString(
             Object.values(this.serverKeys).map(
-              (keysFromSingleNode: any) => keysFromSingleNode.latest_blockhash
+              (keysFromSingleNode: any) => keysFromSingleNode.latestBlockhash
             )
           );
           this.ready = true;

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -63,6 +63,7 @@ export class LitCore {
   networkPubKey: string | null;
   networkPubKeySet: string | null;
   hdRootPubkeys: string[] | null;
+  latest_blockhash: string | null;
 
   // ========== Constructor ==========
   constructor(args: any[LitNodeClientConfig | CustomNetwork | any]) {
@@ -88,6 +89,7 @@ export class LitCore {
     this.networkPubKey = null;
     this.networkPubKeySet = null;
     this.hdRootPubkeys = null;
+    this.latest_blockhash = null;
     // -- set bootstrapUrls to match the network litNetwork unless it's set to custom
     this.setCustomBootstrapUrls();
 
@@ -146,6 +148,7 @@ export class LitCore {
             networkPubKey: resp.networkPublicKey,
             networkPubKeySet: resp.networkPublicKeySet,
             hdRootPubkeys: resp.hdRootPubkeys,
+            latest_blockhash: resp.latest_blockhash,
           };
 
           // -- validate returned keys
@@ -156,6 +159,10 @@ export class LitCore {
             keys.networkPubKeySet === 'ERR'
           ) {
             log('Error connecting to node. Detected "ERR" in keys', url, keys);
+          }
+
+          if (keys.latest_blockhash === "0x") {
+            log('Error getting latest blockhash from the node.');
           }
 
           this.serverKeys[url] = keys;
@@ -191,6 +198,11 @@ export class LitCore {
           this.hdRootPubkeys = mostCommonString(
             Object.values(this.serverKeys).map(
               (keysFromSingleNode: any) => keysFromSingleNode.hdRootPubkeys
+            )
+          );
+          this.latest_blockhash = mostCommonString(
+            Object.values(this.serverKeys).map(
+              (keysFromSingleNode: any) => keysFromSingleNode.latest_blockhash
             )
           );
           this.ready = true;

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -161,8 +161,6 @@ export class LitCore {
             log('Error connecting to node. Detected "ERR" in keys', url, keys);
           }
 
-          log("keys.latest_blockhash- ", keys.latest_blockhash);
-
           if (!keys.latest_blockhash) {
             log('Error getting latest blockhash from the node.');
           }

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -161,7 +161,9 @@ export class LitCore {
             log('Error connecting to node. Detected "ERR" in keys', url, keys);
           }
 
-          if (keys.latest_blockhash === "0x") {
+          log("keys.latest_blockhash- ", keys.latest_blockhash);
+
+          if (!keys.latest_blockhash) {
             log('Error getting latest blockhash from the node.');
           }
 

--- a/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
@@ -6,7 +6,7 @@ import {
   EthWalletAuthenticateOptions,
 } from '@lit-protocol/types';
 import { LIT_CHAINS, AuthMethodType } from '@lit-protocol/constants';
-import { SiweMessage } from 'lit-siwe';
+import { generateNonce, SiweMessage } from 'lit-siwe';
 import { ethers } from 'ethers';
 import { BaseProvider } from './BaseProvider';
 import { checkAndSignAuthMessage } from '@lit-protocol/lit-node-client';
@@ -74,6 +74,7 @@ export default class EthWalletProvider extends BaseProvider {
         version: '1',
         chainId,
         expirationTime: expiration,
+        nonce: this.litNodeClient.latest_blockhash || generateNonce()
       };
 
       const message: SiweMessage = new SiweMessage(preparedMessage);

--- a/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
@@ -74,7 +74,7 @@ export default class EthWalletProvider extends BaseProvider {
         version: '1',
         chainId,
         expirationTime: expiration,
-        nonce: this.litNodeClient.latest_blockhash || generateNonce()
+        nonce: this.litNodeClient.latest_blockhash || generateNonce(),
       };
 
       const message: SiweMessage = new SiweMessage(preparedMessage);

--- a/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
@@ -90,8 +90,10 @@ export default class EthWalletProvider extends BaseProvider {
         address: address,
       };
     } else {
+      log("authenticate latest_blockhash- ", this.litNodeClient.latest_blockhash);
       authSig = await checkAndSignAuthMessage({
         chain,
+        nonce: this.litNodeClient.latest_blockhash || generateNonce(),
       });
     }
 

--- a/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
@@ -74,7 +74,7 @@ export default class EthWalletProvider extends BaseProvider {
         version: '1',
         chainId,
         expirationTime: expiration,
-        nonce: this.litNodeClient.latest_blockhash || generateNonce(),
+        nonce: this.litNodeClient.latestBlockhash || generateNonce(),
       };
 
       const message: SiweMessage = new SiweMessage(preparedMessage);
@@ -92,7 +92,7 @@ export default class EthWalletProvider extends BaseProvider {
     } else {
       authSig = await checkAndSignAuthMessage({
         chain,
-        nonce: this.litNodeClient.latest_blockhash || generateNonce(),
+        nonce: this.litNodeClient.latestBlockhash || generateNonce(),
       });
     }
 

--- a/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
@@ -90,7 +90,6 @@ export default class EthWalletProvider extends BaseProvider {
         address: address,
       };
     } else {
-      log("authenticate latest_blockhash- ", this.litNodeClient.latest_blockhash);
       authSig = await checkAndSignAuthMessage({
         chain,
         nonce: this.litNodeClient.latest_blockhash || generateNonce(),

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -320,8 +320,6 @@ export class LitNodeClientNodeJs extends LitCore {
     sessionKeyUri,
     nonce,
   }: GetWalletSigProps): Promise<AuthSig> => {
-    log("getWalletSig- ", nonce);
-
     let walletSig: AuthSig;
 
     const storageKey = LOCAL_STORAGE_KEYS.WALLET_SIGNATURE;
@@ -2283,9 +2281,6 @@ export class LitNodeClientNodeJs extends LitCore {
       );
     let expiration = params.expiration || LitNodeClientNodeJs.getExpiration();
     let nonce = this.latest_blockhash || generateNonce();
-
-    log("getSessionSigs latest_blockhash- ", this.latest_blockhash);
-    log("getSessionSigs- ", nonce);
 
     // -- (TRY) to get the wallet signature
     let authSig = await this.getWalletSig({

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -303,7 +303,7 @@ export class LitNodeClientNodeJs extends LitCore {
   }
 
   getLatestBlockhash = () => {
-    return this.latest_blockhash;
+    return this.latestBlockhash;
   }
 
   /**
@@ -2109,7 +2109,7 @@ export class LitNodeClientNodeJs extends LitCore {
       chainId: params.chainId ?? 1,
       expirationTime: _expiration,
       resources: params.resources,
-      nonce: this.latest_blockhash || generateNonce(),
+      nonce: this.latestBlockhash || generateNonce(),
     });
 
     let siweMessageStr: string = siweMessage.prepareMessage();
@@ -2280,7 +2280,7 @@ export class LitNodeClientNodeJs extends LitCore {
         params.resourceAbilityRequests.map((r) => r.resource)
       );
     let expiration = params.expiration || LitNodeClientNodeJs.getExpiration();
-    let nonce = this.latest_blockhash || generateNonce();
+    let nonce = this.latestBlockhash || generateNonce();
 
     // -- (TRY) to get the wallet signature
     let authSig = await this.getWalletSig({

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -302,6 +302,10 @@ export class LitNodeClientNodeJs extends LitCore {
     return LitNodeClientNodeJs.getExpiration();
   }
 
+  getLatestBlockhash = () => {
+    return this.latest_blockhash;
+  }
+
   /**
    *
    * Get the signature from local storage, if not, generates one

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -79,7 +79,7 @@ import {
 
 import { computeAddress } from '@ethersproject/transactions';
 import { joinSignature, sha256 } from 'ethers/lib/utils';
-import { SiweMessage } from 'lit-siwe';
+import { generateNonce, SiweMessage } from 'lit-siwe';
 
 import { LitCore } from '@lit-protocol/core';
 import { IPFSBundledSDK } from '@lit-protocol/lit-third-party-libs';
@@ -103,7 +103,7 @@ import { BigNumber, ethers, utils } from 'ethers';
 /** ---------- Main Export Class ---------- */
 
 export class LitNodeClientNodeJs extends LitCore {
-  defaultAuthCallback?: (authSigParams: AuthCallbackParams) => Promise<AuthSig>;
+  defaultAuthCallback?: (authSigParams: AuthCallbackParams, litNodeClient?: this) => Promise<AuthSig>;
 
   // ========== Constructor ==========
   constructor(args: any[LitNodeClientConfig | CustomNetwork | any]) {
@@ -377,7 +377,7 @@ export class LitNodeClientNodeJs extends LitCore {
           switchChain,
           expiration,
           uri: sessionKeyUri,
-        });
+        }, this);
       }
 
       log("getWalletSig - flow 1.3")
@@ -427,7 +427,7 @@ export class LitNodeClientNodeJs extends LitCore {
           errorCode: LIT_ERROR.PARAMS_MISSING_ERROR.name,
         });
       }
-      authSig = await this.defaultAuthCallback(authCallbackParams);
+      authSig = await this.defaultAuthCallback(authCallbackParams, this);
     }
 
     // (TRY) to set walletSig to local storage
@@ -2103,6 +2103,7 @@ export class LitNodeClientNodeJs extends LitCore {
       chainId: params.chainId ?? 1,
       expirationTime: _expiration,
       resources: params.resources,
+      nonce: this.latest_blockhash || generateNonce()
     });
 
     let siweMessageStr: string = siweMessage.prepareMessage();

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -2107,7 +2107,7 @@ export class LitNodeClientNodeJs extends LitCore {
       chainId: params.chainId ?? 1,
       expirationTime: _expiration,
       resources: params.resources,
-      nonce: this.latest_blockhash || generateNonce()
+      nonce: this.latest_blockhash || generateNonce(),
     });
 
     let siweMessageStr: string = siweMessage.prepareMessage();

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -103,7 +103,7 @@ import { BigNumber, ethers, utils } from 'ethers';
 /** ---------- Main Export Class ---------- */
 
 export class LitNodeClientNodeJs extends LitCore {
-  defaultAuthCallback?: (authSigParams: AuthCallbackParams, litNodeClient?: this) => Promise<AuthSig>;
+  defaultAuthCallback?: (authSigParams: AuthCallbackParams) => Promise<AuthSig>;
 
   // ========== Constructor ==========
   constructor(args: any[LitNodeClientConfig | CustomNetwork | any]) {
@@ -314,7 +314,9 @@ export class LitNodeClientNodeJs extends LitCore {
     switchChain,
     expiration,
     sessionKeyUri,
+    nonce,
   }: GetWalletSigProps): Promise<AuthSig> => {
+    log("getWalletSig- ", nonce);
 
     let walletSig: AuthSig;
 
@@ -351,6 +353,7 @@ export class LitNodeClientNodeJs extends LitCore {
           ...(switchChain && { switchChain }),
           expiration,
           uri: sessionKeyUri,
+          nonce,
         };
 
         log("callback body:", body);
@@ -377,7 +380,8 @@ export class LitNodeClientNodeJs extends LitCore {
           switchChain,
           expiration,
           uri: sessionKeyUri,
-        }, this);
+          nonce,
+        });
       }
 
       log("getWalletSig - flow 1.3")
@@ -427,7 +431,7 @@ export class LitNodeClientNodeJs extends LitCore {
           errorCode: LIT_ERROR.PARAMS_MISSING_ERROR.name,
         });
       }
-      authSig = await this.defaultAuthCallback(authCallbackParams, this);
+      authSig = await this.defaultAuthCallback(authCallbackParams);
     }
 
     // (TRY) to set walletSig to local storage
@@ -2274,6 +2278,10 @@ export class LitNodeClientNodeJs extends LitCore {
         params.resourceAbilityRequests.map((r) => r.resource)
       );
     let expiration = params.expiration || LitNodeClientNodeJs.getExpiration();
+    let nonce = this.latest_blockhash || generateNonce();
+
+    log("getSessionSigs latest_blockhash- ", this.latest_blockhash);
+    log("getSessionSigs- ", nonce);
 
     // -- (TRY) to get the wallet signature
     let authSig = await this.getWalletSig({
@@ -2283,6 +2291,7 @@ export class LitNodeClientNodeJs extends LitCore {
       switchChain: params.switchChain,
       expiration: expiration,
       sessionKeyUri: sessionKeyUri,
+      nonce,
     });
 
     let needToResignSessionKey = await this.checkNeedToResignSessionKey({
@@ -2303,6 +2312,7 @@ export class LitNodeClientNodeJs extends LitCore {
           switchChain: params.switchChain,
           expiration,
           uri: sessionKeyUri,
+          nonce,
         },
       });
     }

--- a/packages/types/src/lib/ILitNodeClient.ts
+++ b/packages/types/src/lib/ILitNodeClient.ts
@@ -33,6 +33,7 @@ export interface ILitNodeClient {
   subnetPubKey: string | null;
   networkPubKey: string | null;
   networkPubKeySet: string | null;
+  latest_blockhash: string | null;
 
   // ========== Constructor ==========
   // ** IMPORTANT !! You have to create your constructor when implementing this class **

--- a/packages/types/src/lib/ILitNodeClient.ts
+++ b/packages/types/src/lib/ILitNodeClient.ts
@@ -33,7 +33,7 @@ export interface ILitNodeClient {
   subnetPubKey: string | null;
   networkPubKey: string | null;
   networkPubKeySet: string | null;
-  latest_blockhash: string | null;
+  latestBlockhash: string | null;
 
   // ========== Constructor ==========
   // ** IMPORTANT !! You have to create your constructor when implementing this class **

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -735,7 +735,7 @@ export interface NodeCommandServerKeysResponse {
   subnetPublicKey: any;
   networkPublicKey: any;
   networkPublicKeySet: any;
-  latest_blockhash?: string;
+  latestBlockhash?: string;
 }
 
 export interface FormattedMultipleAccs {
@@ -778,7 +778,7 @@ export interface JsonHandshakeResponse {
   networkPubKey: string;
   networkPubKeySet: string;
   hdRootPubkeys: string[];
-  latest_blockhash?: string,
+  latestBlockhash?: string,
 }
 
 export interface EncryptToIpfsProps {

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -107,6 +107,9 @@ export interface AuthCallbackParams {
   // statement.
   statement?: string;
 
+  // Either the blockhash that the nodes return during the handshake or a randomly generated nonce with lit-siwe's `generateNonce()` function
+  nonce: string;
+
   // Optional and only used with EVM chains.  A list of resources to be passed to Sign In with Ethereum.  These resources will be part of the Sign in with Ethereum signed message presented to the user.
   resources?: string[];
 
@@ -1068,6 +1071,7 @@ export interface GetWalletSigProps {
   switchChain?: boolean;
   expiration: string;
   sessionKeyUri: string;
+  nonce: string,
 }
 
 export interface SessionSigningTemplate {

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -732,6 +732,7 @@ export interface NodeCommandServerKeysResponse {
   subnetPublicKey: any;
   networkPublicKey: any;
   networkPublicKeySet: any;
+  latest_blockhash?: string;
 }
 
 export interface FormattedMultipleAccs {
@@ -774,6 +775,7 @@ export interface JsonHandshakeResponse {
   networkPubKey: string;
   networkPubKeySet: string;
   hdRootPubkeys: string[];
+  latest_blockhash?: string,
 }
 
 export interface EncryptToIpfsProps {


### PR DESCRIPTION
# What

Stores `latest_blockhash` returned by the nodes in the handshake to the `litNodeClient` instance. This is used as the nonce when crafting the SIWE message for signing in both `AuthSig` & `SessionSigs`.

This PR is **backwards-compatible** i.e. devs can still choose not to provide the `nonce` in the updated signing functions and I've also taken care of the fact the node currently don't return `latest_blockhash`.

# How

Updated the following functions to accept the nonce which can be fetched from stored in the client using the `getLatestBlockhash()`:

- `checkAndSignAuthMessage`
- `checkAndSignEVMAuthMessage`
- `signAndSaveAuthMessage`
- `_signAndGetAuth`

```
const litNodeClient = new LitJsSdk.LitNodeClient({
  litNetwork: "cayenne",
});
await litNodeClient.connect();
const nonce = litNodeClient.getLatestBlockhash();
const authSig = await LitJsSdk.checkAndSignAuthMessage({ chain, nonce });
```

Since the SDK receives the `latest_blockhash` from all the nodes they could be different. Hence the final one to be stored is determined by using `mostCommonString()` on all the returned hashes. This is similar to all the other node returned values in the handshake like `hdRootPubkeys`.

**Note:** When the client is not provided in the above functions or if the `latest_blockhash` is undefined (since the corresponding node PR will be merged after this one) then a random nonce is generated by `generateNonce()`.

## LitAuthClient

Have also updated `authenticate()` to use the `latest_blockhash` for `EthWalletProvider` nonce.

## Expiry

Have verified that we use `Date.now()` in the expiry instead of `issueAt`

# Tests

Added manual tests for both the scenarios when the nonce is provided and when it isn't.