### PR TITLE
Fix/executeJS array normalizing

### DIFF
--- a/e2e-nodejs/group-lit-actions/test-lit-action-1-sig.mjs
+++ b/e2e-nodejs/group-lit-actions/test-lit-action-1-sig.mjs
@@ -14,14 +14,14 @@ export async function main() {
     authSig: LITCONFIG.CONTROLLER_AUTHSIG,
     code: `(async () => {
       const sigShare = await LitActions.signEcdsa({
-        toSign,
+        toSign: dataToSign,
         publicKey,
         sigName: "sig",
       });
     })();`,
     authMethods: [],
     jsParams: {
-      toSign: TO_SIGN,
+      dataToSign: TO_SIGN,
       publicKey: LITCONFIG.PKP_PUBKEY,
     },
   });

--- a/e2e-nodejs/group-lit-actions/test-lit-action-2-sigs.mjs
+++ b/e2e-nodejs/group-lit-actions/test-lit-action-2-sigs.mjs
@@ -28,13 +28,13 @@ export async function main() {
         return sigShares;
       }
 
-      const sigShares = await signMultipleSigs(numberOfSigs, toSign, publicKey);
+      const sigShares = await signMultipleSigs(numberOfSigs, signatureData, publicKey);
 
     })();`,
     authMethods: [],
     jsParams: {
       numberOfSigs: 2,
-      toSign: TO_SIGN,
+      signatureData: TO_SIGN,
       publicKey: LITCONFIG.PKP_PUBKEY,
       sigName: 'fooSig',
     },

--- a/e2e-nodejs/group-lit-actions/test-lit-action-no-params.mjs
+++ b/e2e-nodejs/group-lit-actions/test-lit-action-no-params.mjs
@@ -1,0 +1,42 @@
+import path from 'path';
+import { success, fail, testThis } from '../../tools/scripts/utils.mjs';
+import LITCONFIG from '../../lit.config.json' assert { type: 'json' };
+import { client } from '../00-setup.mjs';
+import { ethers } from 'ethers';
+
+// NOTE: you need to hash data before you send it in.
+// If you send something that isn't 32 bytes, the nodes will return an error.
+const TO_SIGN = ethers.utils.arrayify(ethers.utils.keccak256([1, 2, 3, 4, 5]));
+
+export async function main() {
+  // ==================== Test Logic ====================
+  const res = await client.executeJs({
+    authSig: LITCONFIG.CONTROLLER_AUTHSIG,
+    code: `(async () => {
+        LitActions.setResponse({
+            response: JSON.stringify({success: true})
+          });
+    })();`,
+    authMethods: [],
+  });
+
+  // ==================== Post-Validation ====================
+  let jsonRes;
+
+  try {
+    jsonRes = JSON.parse(res.response);
+  } catch (e) {
+    return fail(`response should be a valid JSON`);
+  }
+
+  if (jsonRes.success !== true) {
+    return fail(
+      `jsonRes.success should be true but received "${jsonRes.success}"`
+    );
+  }
+
+  // ==================== Success ====================
+  return success('Lit action should return response with no params given');
+}
+
+await testThis({ name: path.basename(import.meta.url), fn: main });

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.spec.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.spec.ts
@@ -73,4 +73,67 @@ describe('LitNodeClientNodeJs', () => {
 
     expect(expiration).toContain('T');
   });
+
+  describe('normalizeParams', () => {
+    it('should normalise params', () => {
+      // Setup
+      const buffer = new ArrayBuffer(2);
+      const view = new Uint8Array(buffer);
+      view[0] = 1;
+      view[1] = 2;
+      let params = { jsParams: { bufferArray: view } };
+
+      // Action
+      params = LitNodeClientNodeJs.normalizeParams(params);
+
+      // Assert
+      expect(params.jsParams.bufferArray).toEqual([1, 2]);
+    })
+
+    it('should leave normal arrays unchanged', () => {
+      // Setup
+      let params = { jsParams: { normalArray: [1, 2, 3] } };
+
+      // Action
+      params = LitNodeClientNodeJs.normalizeParams(params);
+
+      // Assert
+      expect(params.jsParams.normalArray).toEqual([1, 2, 3]);
+    });
+
+    it('should ignore non-array and non-ArrayBuffer properties', () => {
+      // Setup
+      let params = { jsParams: { number: 123, string: 'test' } };
+
+      // Action
+      params = LitNodeClientNodeJs.normalizeParams(params);
+
+      // Assert
+      expect(params.jsParams.number).toEqual(123);
+      expect(params.jsParams.string).toEqual('test');
+    });
+
+    it('should handle multiple properties', () => {
+      // Setup
+      const buffer = new ArrayBuffer(2);
+      const view = new Uint8Array(buffer);
+      view[0] = 1;
+      view[1] = 2;
+      let params = {
+        jsParams: {
+          bufferArray: view,
+          normalArray: [3, 4, 5]
+        }
+      };
+
+      // Action
+      params = LitNodeClientNodeJs.normalizeParams(params);
+
+      // Assert
+      expect(params.jsParams.bufferArray).toEqual([1, 2]);
+      expect(params.jsParams.normalArray).toEqual([3, 4, 5]);
+    });
+
+  });
+
 });

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -1335,13 +1335,15 @@ export class LitNodeClientNodeJs extends LitCore {
 
     // the nodes will only accept a normal array type as a paramater due to serizalization issues with ArrayBuffer type.
     // this loop below is to normalize the data to a basic array.
-    if (jsParams.toSign) {
-      let arr = [];
-      for (let i = 0; i < jsParams.toSign.length; i++) {
-        arr.push((jsParams.toSign as Buffer)[i]);
+    for (const key of Object.keys(params.jsParams)) {
+      if (Array.isArray(params.jsParams[key]) || ArrayBuffer.isView(params.jsParams[key])) {
+          let arr = [];
+          for (let i = 0; i < jsParams[key].length; i++) {
+            arr.push((jsParams[key] as Buffer)[i]);
+          }
+          params.jsParams[key] = arr;
       }
-      jsParams.toSign = arr;
-    }
+    } 
 
     let res;
     // -- only run on a single node

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -1285,6 +1285,20 @@ export class LitNodeClientNodeJs extends LitCore {
 
   // ========== Scoped Business Logics ==========
 
+  // Normalize the data to a basic array
+  public static normalizeParams(params: ExecuteJsProps): ExecuteJsProps {
+    for (const key of Object.keys(params.jsParams)) {
+      if (Array.isArray(params.jsParams[key]) || ArrayBuffer.isView(params.jsParams[key])) {
+        let arr = [];
+        for (let i = 0; i < params.jsParams[key].length; i++) {
+          arr.push((params.jsParams[key] as Buffer)[i]);
+        }
+        params.jsParams[key] = arr;
+      }
+    }
+    return params;
+  }
+
   /**
    *
    * Execute JS on the nodes and combine and return any resulting signatures
@@ -1333,17 +1347,19 @@ export class LitNodeClientNodeJs extends LitCore {
       });
     }
 
-    // the nodes will only accept a normal array type as a paramater due to serizalization issues with ArrayBuffer type.
-    // this loop below is to normalize the data to a basic array.
+
+    // Call the normalizeParams function to normalize the parameters
+    params = LitNodeClientNodeJs.normalizeParams(params);
+
     for (const key of Object.keys(params.jsParams)) {
       if (Array.isArray(params.jsParams[key]) || ArrayBuffer.isView(params.jsParams[key])) {
-          let arr = [];
-          for (let i = 0; i < jsParams[key].length; i++) {
-            arr.push((jsParams[key] as Buffer)[i]);
-          }
-          params.jsParams[key] = arr;
+        let arr = [];
+        for (let i = 0; i < jsParams[key].length; i++) {
+          arr.push((jsParams[key] as Buffer)[i]);
+        }
+        params.jsParams[key] = arr;
       }
-    } 
+    }
 
     let res;
     // -- only run on a single node
@@ -2311,8 +2327,8 @@ export class LitNodeClientNodeJs extends LitCore {
     const sessionCapabilityObject = params.sessionCapabilityObject
       ? params.sessionCapabilityObject
       : this.generateSessionCapabilityObjectWithWildcards(
-          params.resourceAbilityRequests.map((r) => r.resource)
-        );
+        params.resourceAbilityRequests.map((r) => r.resource)
+      );
     let expiration = params.expiration || LitNodeClientNodeJs.getExpiration();
 
     // -- (TRY) to get the wallet signature

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -1287,6 +1287,11 @@ export class LitNodeClientNodeJs extends LitCore {
 
   // Normalize the data to a basic array
   public static normalizeParams(params: ExecuteJsProps): ExecuteJsProps {
+    if (!params.jsParams) {
+      params.jsParams = {};
+      return params;
+    }
+
     for (const key of Object.keys(params.jsParams)) {
       if (Array.isArray(params.jsParams[key]) || ArrayBuffer.isView(params.jsParams[key])) {
         let arr = [];
@@ -1350,16 +1355,6 @@ export class LitNodeClientNodeJs extends LitCore {
 
     // Call the normalizeParams function to normalize the parameters
     params = LitNodeClientNodeJs.normalizeParams(params);
-
-    for (const key of Object.keys(params.jsParams)) {
-      if (Array.isArray(params.jsParams[key]) || ArrayBuffer.isView(params.jsParams[key])) {
-        let arr = [];
-        for (let i = 0; i < jsParams[key].length; i++) {
-          arr.push((jsParams[key] as Buffer)[i]);
-        }
-        params.jsParams[key] = arr;
-      }
-    }
 
     let res;
     // -- only run on a single node


### PR DESCRIPTION
Fixes an issue with field normalizing to a generic `Array` type where `jsParams` might contain a different property than `toSign` for passing data for signature requests.
Will now loop through keys on the `jsParam` object checking for `Array` and `TypedArray` instance types to determine if the property should be normalized to a basic `Array` instance