### PR TITLE
fix(nacl): react-native support

### DIFF
--- a/packages/nacl/src/lib/nacl.ts
+++ b/packages/nacl/src/lib/nacl.ts
@@ -1316,19 +1316,7 @@ _nacl.setPRNG = function (fn) {
       cleanup(v);
     });
   } else if (typeof require !== 'undefined') {
-    // Node.js.
-
-    // this nodeRequire hack was added by Chris Cassano
-    // because webpack was complaining that "you might try to require crypto and that's not bundled" by webpack automatically anymore.
-    // but this code path will only run on nodejs so it's a non-issue.
-    // thus we have this hack to make webpack happy.
-    const nodeVer = typeof process !== 'undefined' && process.versions?.node;
-    const nodeRequire = nodeVer
-      ? typeof __webpack_require__ === 'function'
-        ? __non_webpack_require__
-        : require
-      : undefined;
-    crypto = nodeRequire('crypto');
+    crypto = require('crypto');
     if (crypto && crypto.randomBytes) {
       _nacl.setPRNG(function (x, n) {
         var i,


### PR DESCRIPTION
A hack was added a year ago to suppress a webpack complaint. Other packages import crypto and don't seem to contain this hack. The metro bundler doesn't allow for conditional requires / substitutions, and as such causes react-native to fail loading the crypto library. This PR removes the hack.

I have not checked if webpack still complains but am hoping Chris can chime in.