### PR TITLE
Feature/lit 1863 js sdk add custom args to verifyandmintpkpthroughrelayer

### DIFF
--- a/packages/lit-auth-client/src/lib/providers/WebAuthnProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/WebAuthnProvider.ts
@@ -1,6 +1,7 @@
 import {
   AuthMethod,
   BaseProviderOptions,
+  MintRequestBody,
   WebAuthnProviderOptions,
 } from '@lit-protocol/types';
 import { AuthMethodType } from '@lit-protocol/constants';
@@ -46,7 +47,8 @@ export default class WebAuthnProvider extends BaseProvider {
    * @returns {Promise<string>} - Mint transaction hash
    */
   public async verifyAndMintPKPThroughRelayer(
-    options: PublicKeyCredentialCreationOptionsJSON
+    options: PublicKeyCredentialCreationOptionsJSON,
+    customArgs?: MintRequestBody
   ): Promise<string> {
     // Submit registration options to the authenticator
     const { startRegistration } = await import('@simplewebauthn/browser');
@@ -62,7 +64,7 @@ export default class WebAuthnProvider extends BaseProvider {
     const authMethodPubkey = this.getPublicKeyFromRegistration(attResp);
 
     // Format args for relay server
-    const args = {
+    const defaultArgs = {
       keyType: 2,
       permittedAuthMethodTypes: [AuthMethodType.WebAuthn],
       permittedAuthMethodIds: [authMethodId],
@@ -71,6 +73,12 @@ export default class WebAuthnProvider extends BaseProvider {
       addPkpEthAddressAsPermittedAddress: true,
       sendPkpToItself: true,
     };
+
+    const args = {
+      ...defaultArgs,
+      ...customArgs
+    }
+
     const body = JSON.stringify(args);
 
     // Mint PKP

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -1258,13 +1258,13 @@ export interface LitRelayConfig {
 }
 
 export interface MintRequestBody {
-  keyType: number;
-  permittedAuthMethodTypes: number[];
-  permittedAuthMethodIds: string[];
-  permittedAuthMethodPubkeys: string[];
-  permittedAuthMethodScopes: any[][] // ethers.BigNumber;
-  addPkpEthAddressAsPermittedAddress: boolean;
-  sendPkpToItself: boolean;
+  keyType?: number;
+  permittedAuthMethodTypes?: number[];
+  permittedAuthMethodIds?: string[];
+  permittedAuthMethodPubkeys?: string[];
+  permittedAuthMethodScopes?: any[][] // ethers.BigNumber;
+  addPkpEthAddressAsPermittedAddress?: boolean;
+  sendPkpToItself?: boolean;
 };
 
 export interface IRelayRequestData {


### PR DESCRIPTION
Allowing custom args to be passed to `verifyAndMintPKPThroughRelayer` body just like `mintThroughRelayer` 