### PR TITLE
make a change to claim and mint to add in tx options

### DIFF
--- a/packages/contracts-sdk/src/lib/contracts-sdk.ts
+++ b/packages/contracts-sdk/src/lib/contracts-sdk.ts
@@ -898,14 +898,15 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
 
       claimAndMint: async (
         derivedKeyId: BytesLike,
-        signatures: IPubkeyRouter.SignatureStruct[]
+        signatures: IPubkeyRouter.SignatureStruct[],
+        txOpts?: any
       ) => {
         let cost = await this.pkpNftContract.read.mintCost();
         const tx = await this.pkpNftContract.write.claimAndMint(
           2,
           derivedKeyId,
           signatures,
-          { value: cost }
+          txOpts ?? { value: cost }
         );
         let txRec = await tx.wait();
         let events: any = 'events' in txRec ? txRec.events : txRec.logs;


### PR DESCRIPTION
I came into this as a roadblock and not being able to get my claim through. I figure the tx object should still be available in the helper function and should overwrite the cost to mint, but could probably figure out a way to make cost to mint as the default in the object. Either way. Would appreciate a look and a merge. 