### PR TITLE
change session exp default to 1 day

### DIFF
--- a/e2e-nodejs/group-pkp-session-sigs/test-pkp-sign-with-session-sigs-eth-wallet-auth-method.mjs
+++ b/e2e-nodejs/group-pkp-session-sigs/test-pkp-sign-with-session-sigs-eth-wallet-auth-method.mjs
@@ -43,7 +43,6 @@ export async function main() {
 
   const sessionSigs = await client.getSessionSigs({
     chain: 'ethereum',
-    expiration: new Date(Date.now() + 60 * 60).toISOString(),
     resourceAbilityRequests: resourceAbilities,
     sessionKey: sessionKeyPair,
     authNeededCallback,

--- a/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
@@ -64,7 +64,8 @@ export default class EthWalletProvider extends BaseProvider {
       // Get expiration or default to 24 hours
       const expiration =
         options?.expiration ||
-        new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString();
+        this.litNodeClient.getExpiration() ||
+        new Date(Date.now() + 60_000 * 60 * 24).toISOString();
 
       // Prepare Sign in with Ethereum message
       const preparedMessage: Partial<SiweMessage> = {

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -305,7 +305,8 @@ export class LitNodeClientNodeJs extends LitCore {
    *
    */
   static getExpiration = () => {
-    return new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString();
+    // set the default exp to one day
+    return new Date(Date.now()  + (60_000 * 60) * 24).toISOString();
   };
 
   // backward compatibility

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -306,7 +306,7 @@ export class LitNodeClientNodeJs extends LitCore {
    */
   static getExpiration = () => {
     // set the default exp to one day
-    return new Date(Date.now()  + (60_000 * 60) * 24).toISOString();
+    return new Date(Date.now() + 60_000 * 60 * 24).toISOString();
   };
 
   // backward compatibility


### PR DESCRIPTION
# Description

Lowers the default session exp to `1 day`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
testing has been added by removing an explicit `expiration` property when generating session signatures through `getSessionSigs`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
