### PR TITLE
only polyfill node's global fetch when it's definitely undefined

### DIFF
--- a/packages/lit-node-client-nodejs/src/index.ts
+++ b/packages/lit-node-client-nodejs/src/index.ts
@@ -4,8 +4,12 @@ import * as _LitNodeClientNodeJs from './lib/lit-node-client-nodejs';
 // ==================== Environment ====================
 if (isNode()) {
   log('Oh hey you are running in Node.js!');
-  const fetch = require('node-fetch');
-  globalThis.fetch = fetch;
+  // @ts-ignore
+  if (typeof (fetch) === "undefined") {
+    log("fetch is undefined");
+    const fetch = require('node-fetch');
+    globalThis.fetch = fetch;
+  } 
 }
 
 declare global {

--- a/packages/lit-node-client/src/index.ts
+++ b/packages/lit-node-client/src/index.ts
@@ -4,8 +4,12 @@ import * as _LitNodeClient from './lib/lit-node-client';
 // ==================== Environment ====================
 if (isNode()) {
   log('Oh hey you are running in Node.js!');
-  const fetch = require('node-fetch');
-  globalThis.fetch = fetch;
+   // @ts-ignore
+   if (typeof (fetch) === "undefined") {
+    log("fetch is undefined");
+    const fetch = require('node-fetch');
+    globalThis.fetch = fetch;
+  }
 }
 
 const LitNodeClient = _LitNodeClient.LitNodeClient;


### PR DESCRIPTION
# Description

When you're using the Lit SDK in combination with packages that load WASM modules, the global `node-fetch` override breaks local / data-url file imports. We noticed this when running lit along the new [web3.storage SDK](@web3-storage/w3up-client).  Its wasm-bindgen generated code actually loads the binaries using a `data:` url (see https://github.com/web3-storage/fr32-sha2-256-trunc254-padded-binary-tree-multihash/blame/main/gen/wasm.js#L284C32-L284C32) which works fine with any fetch in node and browser environments but that's not supported by node-fetch < version 3.

Here's a project that uses both libraries: https://github.com/elmariachi111/w3up-next-sample. yarn & yarn build this to see the error messages.

 -> alternatively we'd suggest to bump your node-fetch version. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [o] New feature (non-breaking change which adds functionality)
- [o] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [o] This change requires a documentation update

# How Has This Been Tested?

- [x] yarn test:unit (fails 4 suites on my box, same as the branch's base)
- [o] yarn test:e2e doesnt run out of the box, had to skip it

tested this with a compiled version on a demo project of ours (based on Next 13.5.6 & @web3-storage/w3up-client ^12.0.0)

# Checklist:

- [?] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [o] I have commented my code, particularly in hard-to-understand areas
- [o] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [o] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [o] Any dependent changes have been merged and published in downstream modules
