### PR TITLE
[e2e test] add manzano & habanero relayer test

### DIFF
--- a/e2e-nodejs/0_manual-tests/test-relayer-mint.mjs
+++ b/e2e-nodejs/0_manual-tests/test-relayer-mint.mjs
@@ -47,9 +47,19 @@ async function getAuthSig(wallet, litNodeClient) {
 export async function main() {
   // ==================== Setup ====================
 
+  if (!process.env.NETWORK) {
+    return fail(`NETWORK env var not set.`);
+  }
+
+  if (!['cayenne', 'habanero', 'manzano'].includes(process.env.NETWORK)) {
+    return fail(
+      `Invalid NETWORK env var set. It has to be either 'manzano', 'habanero', or 'cayenne'`
+    );
+  }
+
   // -- setting up lit node client
   const litNodeClient = new LitNodeClient({
-    litNetwork: 'manzano',
+    litNetwork: process.env.NETWORK,
     debug: true,
     checkNodeAttestation: true,
     storageProvider: {
@@ -70,7 +80,6 @@ export async function main() {
   const litAuthClient = new LitAuthClient({
     litNodeClient,
     litRelayConfig: {
-      relayUrl: 'https://manzano-relayer.getlit.dev',
       relayApiKey: '...',
     },
     debug: true,

--- a/e2e-nodejs/0_manual-tests/test-relayer-mint.mjs
+++ b/e2e-nodejs/0_manual-tests/test-relayer-mint.mjs
@@ -70,7 +70,7 @@ export async function main() {
   const litAuthClient = new LitAuthClient({
     litNodeClient,
     litRelayConfig: {
-      relayUrl: 'https://habanero-relayer.getlit.dev',
+      relayUrl: 'https://manzano-relayer.getlit.dev',
       relayApiKey: '...',
     },
     debug: true,
@@ -98,17 +98,12 @@ export async function main() {
     addPkpEthAddressAsPermittedAddress: true,
   });
 
-  console.log('res', res);
-
-  process.exit();
-
+  if (!res) {
+    return fail(`Res is empty, expected a response from the relayer`);
+  }
 
   // ==================== Post-Validation ====================
-  return success('WORKS');
-
-  return fail(
-    `Failed to get proof from Recap Session Capability, it should be ${expectedResult} but is ${proof}`
-  );
+  return success(`Minted PKP via the relayer with auth methods`);
 }
 
 await testThis({ name: path.basename(import.meta.url), fn: main });

--- a/e2e-nodejs/0_manual-tests/test-relayer-mint.mjs
+++ b/e2e-nodejs/0_manual-tests/test-relayer-mint.mjs
@@ -1,0 +1,114 @@
+import path from 'path';
+import { success, fail, testThis } from '../../tools/scripts/utils.mjs';
+import LITCONFIG from '../../lit.config.json' assert { type: 'json' };
+import { LitNodeClient } from '@lit-protocol/lit-node-client';
+import { LitAuthClient } from '@lit-protocol/lit-auth-client';
+import { LocalStorage } from 'node-localstorage';
+import { ethers } from 'ethers';
+import * as siwe from 'siwe';
+import { AuthMethodScope } from '@lit-protocol/constants';
+
+async function getAuthSig(wallet, litNodeClient) {
+  const domain = 'localhost';
+  const origin = 'https://localhost/login';
+  const statement =
+    'This is a test statement.  You can put anything you want here.';
+
+  const address = await wallet.getAddress();
+
+  const nonce = await litNodeClient.getLatestBlockhash();
+
+  const siweMessage = new siwe.SiweMessage({
+    domain,
+    address,
+    statement,
+    uri: origin,
+    version: '1',
+    chainId: 1,
+    nonce,
+    expirationTime: new Date(Date.now() + 60_000 * 60).toISOString(),
+  });
+
+  const messageToSign = siweMessage.prepareMessage();
+
+  // Sign the message and format the authSig
+  const signature = await wallet.signMessage(messageToSign);
+
+  const authSig = {
+    sig: signature,
+    derivedVia: 'web3.eth.personal.sign',
+    signedMessage: messageToSign,
+    address: address,
+  };
+
+  return authSig;
+}
+
+export async function main() {
+  // ==================== Setup ====================
+
+  // -- setting up lit node client
+  const litNodeClient = new LitNodeClient({
+    litNetwork: 'manzano',
+    debug: true,
+    checkNodeAttestation: true,
+    storageProvider: {
+      provider: new LocalStorage('./storage.test.db'),
+    },
+  });
+
+  await litNodeClient.connect();
+
+  // -- controller wallet
+  const wallet = new ethers.Wallet(
+    LITCONFIG.CONTROLLER_PRIVATE_KEY,
+    new ethers.providers.JsonRpcProvider(LITCONFIG.CHRONICLE_RPC)
+  );
+
+  // -- setting up lit auth client, which uses
+  // the lit node client so that it knows which network to use
+  const litAuthClient = new LitAuthClient({
+    litNodeClient,
+    litRelayConfig: {
+      relayUrl: 'https://habanero-relayer.getlit.dev',
+      relayApiKey: '...',
+    },
+    debug: true,
+  });
+
+  console.log(
+    'litAuthClient.litNodeClient.config:',
+    litAuthClient.litNodeClient.config
+  );
+
+  // -- setting up auth provider
+  const authSig = await getAuthSig(wallet, litNodeClient);
+
+  const authMethod = {
+    authMethodType: 1,
+    accessToken: JSON.stringify(authSig),
+  };
+
+  console.log('authMethod', authMethod);
+
+  // ==================== Test Logic ====================
+  let res = await litAuthClient.mintPKPWithAuthMethods([authMethod], {
+    pkpPermissionScopes: [[AuthMethodScope.SignAnything]],
+    sendPkpToitself: true,
+    addPkpEthAddressAsPermittedAddress: true,
+  });
+
+  console.log('res', res);
+
+  process.exit();
+
+
+  // ==================== Post-Validation ====================
+  return success('WORKS');
+
+  return fail(
+    `Failed to get proof from Recap Session Capability, it should be ${expectedResult} but is ${proof}`
+  );
+}
+
+await testThis({ name: path.basename(import.meta.url), fn: main });

--- a/packages/lit-auth-client/src/lib/lit-auth-client.ts
+++ b/packages/lit-auth-client/src/lib/lit-auth-client.ts
@@ -62,6 +62,7 @@ export class LitAuthClient {
     this.providers = new Map();
     bootstrapLogManager('auth-client');
     this.debug = options?.debug ?? false;
+
     // Check if custom relay object is provided
     if (options?.customRelay) {
       this.relay = options?.customRelay;
@@ -84,6 +85,46 @@ export class LitAuthClient {
         litNetwork: 'cayenne',
         debug: options.debug ?? false,
       });
+    }
+
+    // -- choose the correct relayer based on litNodeClient
+    // and if litRelayConfig.relayUrl is not set
+    if (!options?.litRelayConfig?.relayUrl) {
+      if (!options?.litRelayConfig?.relayApiKey) {
+        throw new Error(
+          '2 An API key is required to use the default Lit Relay server. Please provide either an API key or a custom relay server.'
+        );
+      }
+
+      const supportedNetworks = ['cayenne', 'habanero', 'manzano'];
+
+      if (!supportedNetworks.includes(this.litNodeClient.config.litNetwork)) {
+        throw new Error(
+          `Unsupported litNetwork: ${
+            this.litNodeClient.config.litNetwork
+          }. Supported networks are: ${supportedNetworks.join(', ')}`
+        );
+      }
+
+      let url;
+
+      switch (this.litNodeClient.config.litNetwork) {
+        case 'cayenne':
+          url = 'https://relayer-server-staging-cayenne.getlit.dev';
+          break;
+        case 'habanero':
+          url = 'https://habanero-relayer.getlit.dev';
+          break;
+        case 'manzano':
+          url = 'https://manzano-relayer.getlit.dev';
+          break;
+      }
+
+      if (this.litNodeClient.config.litNetwork)
+        this.relay = new LitRelay({
+          relayUrl: url,
+          relayApiKey: options?.litRelayConfig?.relayApiKey,
+        });
     }
 
     // Set RPC URL


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

- [x] New e2e test

## How to run:

```
NETWORK=manzano node ./e2e-nodejs/0_manual-tests/test-relayer-mint.mjs
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
