### PR TITLE
Fix/default crypto bug

### DIFF
--- a/packages/crypto/src/lib/crypto.ts
+++ b/packages/crypto/src/lib/crypto.ts
@@ -298,8 +298,12 @@ export const computeHDPubKey = (
   try {
     switch (sigType) {
       case SIGTYPE.EcdsaCaitSith:
+        pubkeys = pubkeys.map((value: string) => {
+          return value.replace('0x', '');
+        });
         return ecdsaSdk.compute_public_key(keyId, pubkeys, 2);
-        defualt: throw new Error('Non supported signature type');
+      default:
+        throw new Error('Non supported signature type');
     }
   } catch (e) {
     log('Failed to derive public key', e);

--- a/packages/crypto/src/lib/crypto.ts
+++ b/packages/crypto/src/lib/crypto.ts
@@ -298,9 +298,11 @@ export const computeHDPubKey = (
   try {
     switch (sigType) {
       case SIGTYPE.EcdsaCaitSith:
+        // a bit of pre processing to remove characters which will cause our wasm module to reject the values.
         pubkeys = pubkeys.map((value: string) => {
           return value.replace('0x', '');
         });
+        keyId = keyId.replace('0x', '');
         return ecdsaSdk.compute_public_key(keyId, pubkeys, 2);
       default:
         throw new Error('Non supported signature type');


### PR DESCRIPTION
- fixes a small typeo in the `default` case for a switch statement in `computeHDPubkey`
- adds helpers to `computeHDPubkey` to remove `0x` from hex values represented as strings if found in the input parameters.