### PR TITLE
make capacityDelegationAuthSig optional

### DIFF
--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -1063,8 +1063,11 @@ export interface GetSessionSigsProps {
   sessionKey?: any;
 
   // rateLimitAuthSig: AuthSig;
-
-  capacityDelegationAuthSig: AuthSig;
+  
+  // Used for delegation of Capacity Credit. This signature will be checked for proof of capacity credit.
+  // on both manzano and habanero networks capacity credit proof is required.
+  // see more here: https://developer.litprotocol.com/v3/sdk/capacity-credits
+  capacityDelegationAuthSig?: AuthSig;
 }
 
 export interface AuthCallback {


### PR DESCRIPTION
- Makes `capacityDelegationAuthSig` optional on `SessionSigsParams` as we do not need to delegate capacity credit as the `authSig` will be used in place of the `capacityDelegationAuthSig` which is a valid use case as developers may either
   - Delegate usage through `capacityDelegationAuthSig`
   - Provide proof of Capacity Credit through a `authSig`
   