### PR TITLE
Fix logging tests in 3.1.2 staging

### DIFF
--- a/packages/logger/src/lib/logger.spec.ts
+++ b/packages/logger/src/lib/logger.spec.ts
@@ -34,6 +34,7 @@ describe('logger', () => {
       condenseLogs: true,
     });
     let logger = lm.get('category', 'bar');
+    logger.setLevel(LogLevel.INFO);
     expect(logger.Config?.['condenseLogs']).toEqual(true);
     logger.info('hello');
     logger.info('hello');
@@ -82,22 +83,26 @@ describe('logger', () => {
   it('should not persist logs if level set to OFF', () => {
     const count = 1_000;
     for (let i = 0; i < count; i++) {
-      const logger = lm.get('' + i, 'foo4');
+      const logger = lm.get('' + i, 'foo5');
       logger.setLevel(LogLevel.OFF);
       logger.debug(i + '');
     }
 
-    expect(lm.getLogsForId('foo4').length).toEqual(0);
+    expect(
+      lm.getLogsForId(
+        'foo5'
+      ).length
+    ).toEqual(0);
   });
 
   it('should persist logs across categories', async () => {
     const count = 1_000;
     for (let i = 0; i < count; i++) {
-      const logger = lm.get('' + i, 'foo4');
+      const logger = lm.get('' + i, 'foo6');
       logger.setLevel(LogLevel.DEBUG);
       logger.debug(i + '');
     }
 
-    expect(lm.getLogsForId('foo4').length).toEqual(count);
+    expect(lm.getLogsForId('foo6').length).toEqual(count);
   });
 });

--- a/packages/logger/src/lib/logger.spec.ts
+++ b/packages/logger/src/lib/logger.spec.ts
@@ -88,11 +88,7 @@ describe('logger', () => {
       logger.debug(i + '');
     }
 
-    expect(
-      lm.getLogsForId(
-        'foo5'
-      ).length
-    ).toEqual(0);
+    expect(lm.getLogsForId('foo5').length).toEqual(0);
   });
 
   it('should persist logs across categories', async () => {

--- a/packages/logger/src/lib/logger.ts
+++ b/packages/logger/src/lib/logger.ts
@@ -11,7 +11,7 @@ export enum LogLevel {
   FATAL = 4,
   TIMING_START = 5,
   TIMING_END = 6,
-  OFF = 7,
+  OFF = -1,
 }
 
 const colours = {
@@ -312,19 +312,19 @@ export class Logger {
 
     const arrayLog = log.toArray();
     if (this._config?.['condenseLogs'] && !this._checkHash(log)) {
-      (this._level <= level || level === LogLevel.ERROR) &&
+      (this._level >= level || level === LogLevel.ERROR) &&
         this._consoleHandler(...arrayLog);
-      (this._level <= level || level === LogLevel.ERROR) &&
+      (this._level >= level || level === LogLevel.ERROR) &&
         this._handler &&
         this._handler(log);
-      (this._level <= level || level === LogLevel.ERROR) && this._addLog(log);
+      (this._level >= level || level === LogLevel.ERROR) && this._addLog(log);
     } else if (!this._config?.['condenseLogs']) {
-      (this._level <= level || level === LogLevel.ERROR) &&
+      (this._level >= level || level === LogLevel.ERROR) &&
         this._consoleHandler(...arrayLog);
-      (this._level <= level || level === LogLevel.ERROR) &&
+      (this._level >= level || level === LogLevel.ERROR) &&
         this._handler &&
         this._handler(log);
-      (this._level <= level || level === LogLevel.ERROR) && this._addLog(log);
+      (this._level >= level || level === LogLevel.ERROR) && this._addLog(log);
     }
   }
 


### PR DESCRIPTION
fixes the `logger.spec.ts` tests where two tests where failing after a previous PR refactor to how the logger groups request identifiers when persisting to `Storage`
