### PR TITLE
fix: add accs-validator to ignoreList

### DIFF
--- a/tools/scripts/tools.mjs
+++ b/tools/scripts/tools.mjs
@@ -1386,7 +1386,7 @@ async function versionFunc() {
 
 async function validateDependencyVersions() {
   const PREFIX = '@lit-protocol';
-  const ignoreList = [''];
+  const ignoreList = ['@lit-protocol/accs-validator'];
 
   const packageList = (await listDirsRecursive('./packages', false)).map(
     (item) => {


### PR DESCRIPTION
# Description

We have this small script that checks if all the dependencies are on the same version in the built package.json. However, it was checking any packages starting with `@lit-protocol`. Since `@lit-protocol/accs-validator` is outside of the monorepo and does not share the same version, I'm adding it to the `ignoreList`, which was previously created to handle such cases.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
 yarn node ./tools/scripts/tools.mjs --verify      
```

## Related PR(s) & comment(s)
- https://github.com/LIT-Protocol/js-sdk/pull/320#pullrequestreview-1868693437

# Before
<img width="674" alt="image" src="https://github.com/LIT-Protocol/js-sdk/assets/4049673/dc9f9766-2212-4561-80ae-922d8915793b">

# After 
<img width="685" alt="image" src="https://github.com/LIT-Protocol/js-sdk/assets/4049673/288fa84d-d48c-44eb-9622-06274cdf569c">
