### PR TITLE
remove lit-siwe

### DIFF
--- a/apps/nodejs/manual-test.ts
+++ b/apps/nodejs/manual-test.ts
@@ -3,7 +3,7 @@ import * as LitJsSdk from '@lit-protocol/lit-node-client';
 // import { LitContracts } from '@lit-protocol/contracts-sdk';
 import { ethers } from 'ethers';
 import { PKPEthersWallet } from '@lit-protocol/pkp-ethers';
-import { SiweMessage } from 'lit-siwe';
+import { SiweMessage } from 'siwe';
 import { LIT_EVM_CHAINS } from '@lit-protocol/constants';
 
 
@@ -206,30 +206,30 @@ const runLogic = async (contract: LitContracts) => {
 // };
 
 const pkpSign = async (client, pkpPubkey, authSig) => {
-     // try and sign something
-     let sig = await client.pkpSign({
-      toSign:  ethers.utils.arrayify(ethers.utils.keccak256([104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100])), // hello world in Uint8Array
-      pubKey: pkpPubkey,
-      authSig,
-    });
+  // try and sign something
+  let sig = await client.pkpSign({
+    toSign: ethers.utils.arrayify(ethers.utils.keccak256([104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100])), // hello world in Uint8Array
+    pubKey: pkpPubkey,
+    authSig,
+  });
 
-    // console.log("sig: ", sig);
+  // console.log("sig: ", sig);
 
-    const recoveredPk = ethers.utils.recoverPublicKey("0x" + sig.dataSigned, sig.signature);
-    const addr = ethers.utils.computeAddress('0x' + sig.publicKey);
-    const recoveredAddr = ethers.utils.computeAddress(recoveredPk);
-    const claimedAddr = ethers.utils.computeAddress(pkpPubkey);
+  const recoveredPk = ethers.utils.recoverPublicKey("0x" + sig.dataSigned, sig.signature);
+  const addr = ethers.utils.computeAddress('0x' + sig.publicKey);
+  const recoveredAddr = ethers.utils.computeAddress(recoveredPk);
+  const claimedAddr = ethers.utils.computeAddress(pkpPubkey);
 
-    const allGood = addr === recoveredAddr && addr === claimedAddr;
+  const allGood = addr === recoveredAddr && addr === claimedAddr;
 
-    console.log('all addresses match: ', allGood);
-    return allGood;
+  console.log('all addresses match: ', allGood);
+  return allGood;
 }
 
-const litActionSign = async(client, pkpPubkey, authSig) => {
-    console.log('testing sig with lit actions...');
-    // this code will be run on the node
-    const litActionCode = `
+const litActionSign = async (client, pkpPubkey, authSig) => {
+  console.log('testing sig with lit actions...');
+  // this code will be run on the node
+  const litActionCode = `
     const go = async () => {  
       // this requests a signature share from the Lit Node
       // the signature share will be automatically returned in the HTTP response from the node
@@ -241,40 +241,40 @@ const litActionSign = async(client, pkpPubkey, authSig) => {
     go();
     `;
 
-    const signatures = await client.executeJs({
-      code: litActionCode,
-      authSig,
-      // all jsParams can be used anywhere in your litActionCode
-      jsParams: {
-        // this is the string "Hello World" for testing
-        toSign: ethers.utils.arrayify(ethers.utils.keccak256([104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100])),
-        publicKey: pkpPubkey,
-        sigName: "sig1",
-      },
-    });
-    // console.log("signatures: ", signatures);
-    const { sig1, sig2 } = signatures.signatures
-    const sigKeys = {
-      sig1: {
-        recovered: ethers.utils.computeAddress(ethers.utils.recoverPublicKey("0x" + sig1.dataSigned, sig1.signature)),
-        reported: ethers.utils.computeAddress('0x' + sig1.publicKey)
-      },
-      sig2: {
-        recovered: ethers.utils.computeAddress(ethers.utils.recoverPublicKey("0x" + sig2.dataSigned, sig2.signature)),
-        reported: ethers.utils.computeAddress('0x' + sig2.publicKey)
-      },
-    }
-
-    // console.log(`sigKeys: ${JSON.stringify(sigKeys, null, 2)}`)
-
-    const pkpAddr = ethers.utils.computeAddress(pkpPubkey);
-    // console.log('pkpAddr:', pkpAddr)
-
-
-    let allGood = sigKeys.sig1.recovered == sigKeys.sig1.reported && sigKeys.sig2.recovered == sigKeys.sig2.reported && sigKeys.sig1.recovered == sigKeys.sig2.recovered && sigKeys.sig1.recovered == pkpAddr;
-    console.log('all addresses match: ', allGood);
-    return allGood;
+  const signatures = await client.executeJs({
+    code: litActionCode,
+    authSig,
+    // all jsParams can be used anywhere in your litActionCode
+    jsParams: {
+      // this is the string "Hello World" for testing
+      toSign: ethers.utils.arrayify(ethers.utils.keccak256([104, 101, 108, 108, 111, 32, 119, 111, 114, 108, 100])),
+      publicKey: pkpPubkey,
+      sigName: "sig1",
+    },
+  });
+  // console.log("signatures: ", signatures);
+  const { sig1, sig2 } = signatures.signatures
+  const sigKeys = {
+    sig1: {
+      recovered: ethers.utils.computeAddress(ethers.utils.recoverPublicKey("0x" + sig1.dataSigned, sig1.signature)),
+      reported: ethers.utils.computeAddress('0x' + sig1.publicKey)
+    },
+    sig2: {
+      recovered: ethers.utils.computeAddress(ethers.utils.recoverPublicKey("0x" + sig2.dataSigned, sig2.signature)),
+      reported: ethers.utils.computeAddress('0x' + sig2.publicKey)
+    },
   }
+
+  // console.log(`sigKeys: ${JSON.stringify(sigKeys, null, 2)}`)
+
+  const pkpAddr = ethers.utils.computeAddress(pkpPubkey);
+  // console.log('pkpAddr:', pkpAddr)
+
+
+  let allGood = sigKeys.sig1.recovered == sigKeys.sig1.reported && sigKeys.sig2.recovered == sigKeys.sig2.reported && sigKeys.sig1.recovered == sigKeys.sig2.recovered && sigKeys.sig1.recovered == pkpAddr;
+  console.log('all addresses match: ', allGood);
+  return allGood;
+}
 
 const mintPkpAndSign = async () => {
   let client;
@@ -321,37 +321,37 @@ const mintPkpAndSign = async () => {
 
   await client.connect();
 
-    const litContracts = new LitContracts({
-      privateKey: TEST_FUNDED_PRIVATE_KEY,
-    });
-    const pkpPubkey = await runLogic(litContracts);
-    console.log('pkpPubkey:', pkpPubkey);
+  const litContracts = new LitContracts({
+    privateKey: TEST_FUNDED_PRIVATE_KEY,
+  });
+  const pkpPubkey = await runLogic(litContracts);
+  console.log('pkpPubkey:', pkpPubkey);
 
-    const privateKey = TEST_FUNDED_PRIVATE_KEY;
-    const provider = new ethers.providers.JsonRpcProvider(
-      LIT_EVM_CHAINS['chronicleTestnet'].rpcUrls[0]
-    );
-    const wallet = new ethers.Wallet(privateKey, provider);
-    const authSig = await getAuthSig(wallet);
+  const privateKey = TEST_FUNDED_PRIVATE_KEY;
+  const provider = new ethers.providers.JsonRpcProvider(
+    LIT_EVM_CHAINS['chronicleTestnet'].rpcUrls[0]
+  );
+  const wallet = new ethers.Wallet(privateKey, provider);
+  const authSig = await getAuthSig(wallet);
 
-    // console.log('Sleeping for 5 seconds so that the chronicle node replica can sync up');
-    // Sleep for 5 seconds
-    // await new Promise(resolve => setTimeout(resolve, 5000));
+  // console.log('Sleeping for 5 seconds so that the chronicle node replica can sync up');
+  // Sleep for 5 seconds
+  // await new Promise(resolve => setTimeout(resolve, 5000));
 
 
-    let startTime = Date.now();
-    let allGood = true;
-    const testCount = 1;
-    for(let i = 0; i < testCount; i++){
-      console.log(`testing ${i + 1} of ${testCount}`);
-      let result = await pkpSign(client, pkpPubkey, authSig);
-      if (!result) {
-        allGood = false;
-      }
+  let startTime = Date.now();
+  let allGood = true;
+  const testCount = 1;
+  for (let i = 0; i < testCount; i++) {
+    console.log(`testing ${i + 1} of ${testCount}`);
+    let result = await pkpSign(client, pkpPubkey, authSig);
+    if (!result) {
+      allGood = false;
     }
-    console.log(`it took ${(Date.now() - startTime) / 1000}s to run ${testCount} tests`)
-    console.log('all tests were good', allGood);
-    // await litActionSign(client, pkpPubkey, authSig);
+  }
+  console.log(`it took ${(Date.now() - startTime) / 1000}s to run ${testCount} tests`)
+  console.log('all tests were good', allGood);
+  // await litActionSign(client, pkpPubkey, authSig);
 }
 
 const getAuthSig = async (wallet) => {

--- a/e2e-nodejs/group-rli/test-rli-pkp-as-delegatee.mjs
+++ b/e2e-nodejs/group-rli/test-rli-pkp-as-delegatee.mjs
@@ -214,7 +214,7 @@ export async function main() {
       resources: resources,
       chainId: 1,
 
-      // optional (this would use normal siwe lib, without it, it would use lit-siwe)
+      // optional (this would use normal siwe lib, without it, it would use siwe-recap)
       resourceAbilityRequests: resourceAbilityRequests,
     });
 

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "ipfs-unixfs-importer": "^12.0.0",
     "jose": "^4.14.4",
     "jszip": "^3.10.1",
-    "lit-siwe": "^1.1.8",
     "micromodal": "^0.4.10",
     "multiformats": "^12.1.3",
     "nanoid": "3.3.4",

--- a/packages/auth-browser/package.json
+++ b/packages/auth-browser/package.json
@@ -21,7 +21,7 @@
   "peerDependencies": {
     "@walletconnect/ethereum-provider": "2.9.2",
     "@walletconnect/modal": "2.6.1",
-    "lit-siwe": "^1.1.8",
+    "siwe": "^2.0.5",
     "tweetnacl": "^1.0.3",
     "tweetnacl-util": "^0.13.3",
     "util": "^0.12.4",

--- a/packages/auth-browser/src/lib/chains/eth.ts
+++ b/packages/auth-browser/src/lib/chains/eth.ts
@@ -22,7 +22,7 @@ import LitConnectModal from '../connect-modal/modal';
 
 import { Web3Provider, JsonRpcSigner } from '@ethersproject/providers';
 
-import { SiweMessage } from 'lit-siwe';
+import { SiweMessage } from 'siwe';
 import { getAddress } from 'ethers/lib/utils';
 
 // @ts-ignore: If importing 'nacl' directly, the built files will use .default instead

--- a/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
@@ -6,7 +6,7 @@ import {
   EthWalletAuthenticateOptions,
 } from '@lit-protocol/types';
 import { LIT_CHAINS, AuthMethodType, LIT_ERROR } from '@lit-protocol/constants';
-import { SiweMessage } from 'lit-siwe';
+import { SiweMessage } from 'siwe';
 import { ethers } from 'ethers';
 import { BaseProvider } from './BaseProvider';
 import { checkAndSignAuthMessage } from '@lit-protocol/lit-node-client';

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -89,8 +89,7 @@ import {
 
 import { computeAddress } from '@ethersproject/transactions';
 import { joinSignature, sha256 } from 'ethers/lib/utils';
-import { SiweMessage } from 'lit-siwe';
-import * as siweNormal from 'siwe';
+import * as from 'siwe';
 
 import { LitCore } from '@lit-protocol/core';
 import { IPFSBundledSDK } from '@lit-protocol/lit-third-party-libs';
@@ -113,7 +112,7 @@ import {
 } from '@lit-protocol/misc-browser';
 import { nacl } from '@lit-protocol/nacl';
 import { BigNumber, ethers, utils } from 'ethers';
-import * as siwe from 'siwe';
+import { SiweMessage } from 'siwe';
 
 // TODO: move this to auth-helper for next patch
 interface CapacityCreditsReq {
@@ -2533,7 +2532,7 @@ export class LitNodeClientNodeJs extends LitCore {
       });
 
       // regular siwe
-      siweMessage = new siweNormal.SiweMessage({
+      siweMessage = new SiweMessage({
         domain:
           params?.domain || globalThis.location?.host || 'litprotocol.com',
         address: pkpEthAddress,
@@ -2548,7 +2547,7 @@ export class LitNodeClientNodeJs extends LitCore {
 
       siweMessage = recapObject.addToSiweMessage(siweMessage);
     } else {
-      // lit-siwe (NOT regular siwe)
+      // regular siwe without recap
       siweMessage = new SiweMessage({
         domain:
           params?.domain || globalThis.location?.host || 'litprotocol.com',
@@ -2771,8 +2770,8 @@ export class LitNodeClientNodeJs extends LitCore {
     const sessionCapabilityObject = params.sessionCapabilityObject
       ? params.sessionCapabilityObject
       : await this.generateSessionCapabilityObjectWithWildcards(
-          params.resourceAbilityRequests.map((r) => r.resource)
-        );
+        params.resourceAbilityRequests.map((r) => r.resource)
+      );
     let expiration = params.expiration || LitNodeClientNodeJs.getExpiration();
 
     if (!this.latestBlockhash) {

--- a/tools/scripts/utils.mjs
+++ b/tools/scripts/utils.mjs
@@ -10,7 +10,7 @@ import util from 'util';
 import { toBech32 } from '@cosmjs/encoding';
 import { Secp256k1 } from '@cosmjs/crypto';
 import { rawSecp256k1PubkeyToRawAddress } from '@cosmjs/amino';
-import siwe from 'lit-siwe';
+import siwe from 'siwe';
 import { ethers } from 'ethers';
 
 const eventsEmitter = new events.EventEmitter();
@@ -160,7 +160,7 @@ export const spawnCommand = (
   options = {},
   options2 = {
     logExit: true,
-    exitCallback: () => {},
+    exitCallback: () => { },
   }
 ) => {
   // Use the spawn() function to run the command in a child process

--- a/yarn.lock
+++ b/yarn.lock
@@ -5116,13 +5116,6 @@
     uri-js "^4.4.1"
     valid-url "^1.0.9"
 
-"@spruceid/siwe-parser@1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@spruceid/siwe-parser/-/siwe-parser-1.1.3.tgz#0eebe8bbd63c6de89cb44c06b6329b00b305df65"
-  integrity sha512-oQ8PcwDqjGWJvLmvAF2yzd6iniiWxK0Qtz+Dw+gLD/W5zOQJiKIUXwslHOm8VB8OOOKW9vfR3dnPBhHaZDvRsw==
-  dependencies:
-    apg-js "^4.1.1"
-
 "@stablelib/aead@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@stablelib/aead/-/aead-1.0.1.tgz#c4b1106df9c23d1b867eb9b276d8f42d5fc4c0c3"
@@ -18531,15 +18524,6 @@ lit-html@^2.7.0, lit-html@^2.8.0:
   integrity sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==
   dependencies:
     "@types/trusted-types" "^2.0.2"
-
-lit-siwe@^1.1.8:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/lit-siwe/-/lit-siwe-1.1.8.tgz#6a393069012816d629c518bb8aa410f1e4a78bd7"
-  integrity sha512-gXI8GG0GAClw6G7T9p4p6Kn9ywDo8j2d90ShaYArJdsqqO9gwXfzxF84SMeY+bpsNqqQ3FahrhEwTCHd6w7wNw==
-  dependencies:
-    "@spruceid/siwe-parser" "1.1.3"
-    "@stablelib/random" "^1.0.1"
-    apg-js "^4.1.1"
 
 lit@2.7.6:
   version "2.7.6"


### PR DESCRIPTION
lit-siwe was created to shrink the size of the siwe lib.  but we're importing the new version of the siwe lib anyway, so lit-siwe actually just makes everything bigger.  we need the new siwe to be compatible with siwe-recap, so we can't really avoid importing the normal siwe.  

so this PR just removes lit-siwe and replaces it with normal siwe