### PR TITLE
ref: Remove ethers in logger

### DIFF
--- a/packages/logger/src/lib/logger.ts
+++ b/packages/logger/src/lib/logger.ts
@@ -358,7 +358,7 @@ export class Logger {
     if (str.length === 0) return hash;
     for (i = 0; i < str.length; i++) {
       chr = str.charCodeAt(i);
-      hash = ((hash << 5) - hash) + chr;
+      hash = (hash << 5) - hash + chr;
       hash |= 0; // Convert to 32bit integer
     }
     return hash;

--- a/packages/logger/src/lib/logger.ts
+++ b/packages/logger/src/lib/logger.ts
@@ -1,6 +1,4 @@
 import { version } from '@lit-protocol/constants';
-import { hashMessage } from 'ethers/lib/utils';
-import { encode } from 'punycode';
 import { toString as uint8arrayToString } from 'uint8arrays';
 
 export enum LogLevel {
@@ -329,7 +327,7 @@ export class Logger {
   }
 
   private _checkHash(log: Log): boolean {
-    const digest = hashMessage(log.message);
+    const digest = this.hashCode(log.message);
     const hash = digest.toString();
     let item = this._logHashes.get(hash);
     if (item) {
@@ -348,6 +346,22 @@ export class Logger {
     // this implementation assumes that serialization / deserialization from `localStorage` keeps the same key ordering in each `category` object as we will asssume the array produced from `Object.keys` will always be the same ordering.
     // which then allows us to start at the front of the array and do `delete` operation on each key we wish to delete from the object.
     //log.id && this._addToLocalStorage(log);
+  }
+
+  /**
+    simple non secure 32 bit hashing function.
+
+  */
+  hashCode(str: string, seed: number = 0) {
+    var hash = 0;
+    var i, chr;
+    if (str.length === 0) return hash;
+    for (i = 0; i < str.length; i++) {
+      chr = str.charCodeAt(i);
+      hash = ((hash << 5) - hash) + chr;
+      hash |= 0; // Convert to 32bit integer
+    }
+    return hash;
   }
 
   private _addToLocalStorage(log: Log) {


### PR DESCRIPTION
# Description

replaces `ethers.utils.hashMessage` with a non secure 32 bit hash function which has a low collision chance but quick throughput. This does mean the hashing function is non secure, meaning it is possible to reverse hashes in reasonable time. However we do need a secure hashing implementation for the purposes of the logger. 

Test times are observed to be the same and in some cases **100 - 200ms faster**  measurement was done with `logger.spec.ts` tests with both hashing implementations. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
`logger.spec.ts` was run against the new hashing function

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
