### PR TITLE
feature/lit-2493-js-sdk-remove-vanilla-packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "tools": "yarn node ./tools/scripts/tools.mjs",
     "graph": "nx graph",
     "npm:login": "npm login",
-    "cy:open:html": "yarn tools --test --e2e html",
     "cy:open:react": "yarn tools --test --e2e react",
     "dev": "nodemon --watch packages --ext js,ts --exec \"yarn build:packages && yarn tools --yalc --publish\"",
     "dev:target": "yarn tools --watch --target",

--- a/packages/access-control-conditions/project.json
+++ b/packages/access-control-conditions/project.json
@@ -26,23 +26,6 @@
         "assets": ["packages/access-control-conditions/*.md"]
       }
     },
-    "_buildWeb": {
-      "executor": "@websaam/nx-esbuild:package",
-      "options": {
-        "globalName": "LitJsSdk_accessControlConditions",
-        "outfile": "dist/packages/access-control-conditions-vanilla/access-control-conditions.js",
-        "entryPoints": ["./packages/access-control-conditions/src/index.ts"],
-        "define": {
-          "process.env.NODE_DEBUG": "false"
-        },
-        "plugins": [
-          {
-            "package": "esbuild-node-builtins",
-            "function": "nodeBuiltIns"
-          }
-        ]
-      }
-    },
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "outputs": ["{options.outputFile}"],

--- a/packages/auth-browser/project.json
+++ b/packages/auth-browser/project.json
@@ -26,24 +26,6 @@
         "assets": ["packages/auth-browser/*.md"]
       }
     },
-    "_buildWeb": {
-      "executor": "@websaam/nx-esbuild:package",
-      "options": {
-        "globalName": "LitJsSdk_authBrowser",
-        "outfile": "dist/packages/auth-browser-vanilla/auth-browser.js",
-        "entryPoints": ["./packages/auth-browser/src/index.ts"],
-        "define": {
-          "process.env.NODE_DEBUG": "false",
-          "global": "window"
-        },
-        "plugins": [
-          {
-            "package": "esbuild-node-builtins",
-            "function": "nodeBuiltIns"
-          }
-        ]
-      }
-    },
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "outputs": ["{options.outputFile}"],

--- a/packages/auth-helpers/project.json
+++ b/packages/auth-helpers/project.json
@@ -20,24 +20,6 @@
         "assets": ["packages/auth-helpers/*.md"]
       }
     },
-    "_buildWeb": {
-      "executor": "@websaam/nx-esbuild:package",
-      "options": {
-        "globalName": "LitJsSdk_authHelpers",
-        "outfile": "dist/packages/auth-helpers-vanilla/auth-helpers.js",
-        "entryPoints": ["./packages/auth-helpers/src/index.ts"],
-        "define": {
-          "process.env.NODE_DEBUG": "false",
-          "global": "window"
-        },
-        "plugins": [
-          {
-            "package": "esbuild-node-builtins",
-            "function": "nodeBuiltIns"
-          }
-        ]
-      }
-    },
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "outputs": ["{options.outputFile}"],

--- a/packages/bls-sdk/project.json
+++ b/packages/bls-sdk/project.json
@@ -20,23 +20,6 @@
         "assets": ["packages/bls-sdk/*.md"]
       }
     },
-    "_buildWeb": {
-      "executor": "@websaam/nx-esbuild:package",
-      "options": {
-        "globalName": "LitJsSdk_blsSdk",
-        "outfile": "dist/packages/bls-sdk-vanilla/bls-sdk.js",
-        "entryPoints": ["./packages/bls-sdk/src/index.ts"],
-        "define": {
-          "process.env.NODE_DEBUG": "false"
-        },
-        "plugins": [
-          {
-            "package": "esbuild-node-builtins",
-            "function": "nodeBuiltIns"
-          }
-        ]
-      }
-    },
     "test": {
       "executor": "@nrwl/jest:jest",
       "outputs": ["coverage/packages/bls-sdk"],

--- a/packages/constants/project.json
+++ b/packages/constants/project.json
@@ -21,24 +21,6 @@
         "assets": ["packages/constants/*.md"]
       }
     },
-    "_buildWeb": {
-      "executor": "@websaam/nx-esbuild:package",
-      "options": {
-        "bundle": true,
-        "sourcemap": true,
-        "metafile": true,
-        "globalName": "LitJsSdk_constants",
-        "outfile": "dist/packages/constants-vanilla/constants.js",
-        "entryPoints": ["./packages/constants/src/index.ts"],
-        "define": { "global": "window" },
-        "plugins": [
-          {
-            "package": "esbuild-node-builtins",
-            "function": "nodeBuiltIns"
-          }
-        ]
-      }
-    },
 
     "copyJSONFilesToDist": {
       "executor": "nx:run-commands",

--- a/packages/contracts-sdk/project.json
+++ b/packages/contracts-sdk/project.json
@@ -24,24 +24,7 @@
         "assets": ["packages/contracts-sdk/*.md"]
       }
     },
-    "_buildWeb": {
-      "executor": "@websaam/nx-esbuild:package",
-      "options": {
-        "globalName": "LitJsSdk_contractsSdk",
-        "outfile": "dist/packages/contracts-sdk-vanilla/contracts-sdk.js",
-        "entryPoints": ["./packages/contracts-sdk/src/index.ts"],
-        "define": {
-          "process.env.NODE_DEBUG": "false",
-          "global": "window"
-        },
-        "plugins": [
-          {
-            "package": "esbuild-node-builtins",
-            "function": "nodeBuiltIns"
-          }
-        ]
-      }
-    },
+
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "outputs": ["{options.outputFile}"],

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -20,24 +20,6 @@
         "assets": ["packages/core/*.md"]
       }
     },
-    "_buildWeb": {
-      "executor": "@websaam/nx-esbuild:package",
-      "options": {
-        "globalName": "LitJsSdk_core",
-        "outfile": "dist/packages/core-vanilla/core.js",
-        "entryPoints": ["./packages/core/src/index.ts"],
-        "define": {
-          "process.env.NODE_DEBUG": "false",
-          "global": "window"
-        },
-        "plugins": [
-          {
-            "package": "esbuild-node-builtins",
-            "function": "nodeBuiltIns"
-          }
-        ]
-      }
-    },
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "outputs": ["{options.outputFile}"],

--- a/packages/crypto/project.json
+++ b/packages/crypto/project.json
@@ -20,23 +20,6 @@
         "assets": ["packages/crypto/*.md"]
       }
     },
-    "_buildWeb": {
-      "executor": "@websaam/nx-esbuild:package",
-      "options": {
-        "globalName": "LitJsSdk_crypto",
-        "outfile": "dist/packages/crypto-vanilla/crypto.js",
-        "entryPoints": ["./packages/crypto/src/index.ts"],
-        "define": {
-          "process.env.NODE_DEBUG": "false"
-        },
-        "plugins": [
-          {
-            "package": "esbuild-node-builtins",
-            "function": "nodeBuiltIns"
-          }
-        ]
-      }
-    },
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "outputs": ["{options.outputFile}"],

--- a/packages/ecdsa-sdk/project.json
+++ b/packages/ecdsa-sdk/project.json
@@ -20,23 +20,6 @@
         "assets": ["packages/ecdsa-sdk/*.md"]
       }
     },
-    "_buildWeb": {
-      "executor": "@websaam/nx-esbuild:package",
-      "options": {
-        "globalName": "LitJsSdk_ecdsaSdk",
-        "outfile": "dist/packages/ecdsa-sdk-vanilla/ecdsa-sdk.js",
-        "entryPoints": ["./packages/ecdsa-sdk/src/index.ts"],
-        "define": {
-          "process.env.NODE_DEBUG": "false"
-        },
-        "plugins": [
-          {
-            "package": "esbuild-node-builtins",
-            "function": "nodeBuiltIns"
-          }
-        ]
-      }
-    },
     "test": {
       "executor": "@nrwl/jest:jest",
       "outputs": ["coverage/packages/ecdsa-sdk"],

--- a/packages/encryption/project.json
+++ b/packages/encryption/project.json
@@ -26,23 +26,6 @@
         "assets": ["packages/encryption/*.md"]
       }
     },
-    "_buildWeb": {
-      "executor": "@websaam/nx-esbuild:package",
-      "options": {
-        "globalName": "LitJsSdk_encryption",
-        "outfile": "dist/packages/encryption-vanilla/encryption.js",
-        "entryPoints": ["./packages/encryption/src/index.ts"],
-        "define": {
-          "process.env.NODE_DEBUG": "false"
-        },
-        "plugins": [
-          {
-            "package": "esbuild-node-builtins",
-            "function": "nodeBuiltIns"
-          }
-        ]
-      }
-    },
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "outputs": ["{options.outputFile}"],

--- a/packages/lit-auth-client/project.json
+++ b/packages/lit-auth-client/project.json
@@ -20,24 +20,6 @@
         "assets": ["packages/lit-auth-client/*.md"]
       }
     },
-    "_buildWeb": {
-      "executor": "@websaam/nx-esbuild:package",
-      "options": {
-        "globalName": "LitJsSdk_litAuthClient",
-        "outfile": "dist/packages/lit-auth-client-vanilla/lit-auth-client.js",
-        "entryPoints": ["./packages/lit-auth-client/src/index.ts"],
-        "define": {
-          "process.env.NODE_DEBUG": "false",
-          "global": "window"
-        },
-        "plugins": [
-          {
-            "package": "esbuild-node-builtins",
-            "function": "nodeBuiltIns"
-          }
-        ]
-      }
-    },
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "outputs": ["{options.outputFile}"],

--- a/packages/lit-node-client-nodejs/project.json
+++ b/packages/lit-node-client-nodejs/project.json
@@ -20,24 +20,6 @@
         "assets": ["packages/lit-node-client-nodejs/*.md"]
       }
     },
-    "_buildWeb": {
-      "executor": "@websaam/nx-esbuild:package",
-      "options": {
-        "globalName": "LitJsSdk_litNodeClientNodejs",
-        "outfile": "dist/packages/lit-node-client-nodejs-vanilla/lit-node-client-nodejs.js",
-        "entryPoints": ["./packages/lit-node-client-nodejs/src/index.ts"],
-        "define": {
-          "process.env.NODE_DEBUG": "false",
-          "global": "window"
-        },
-        "plugins": [
-          {
-            "package": "esbuild-node-builtins",
-            "function": "nodeBuiltIns"
-          }
-        ]
-      }
-    },
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "outputs": ["{options.outputFile}"],

--- a/packages/lit-node-client/project.json
+++ b/packages/lit-node-client/project.json
@@ -24,25 +24,6 @@
         "assets": ["packages/lit-node-client/*.md"]
       }
     },
-    "_buildWeb": {
-      "executor": "@websaam/nx-esbuild:package",
-      "options": {
-        "globalName": "LitJsSdk_litNodeClient",
-        "outfile": "dist/packages/lit-node-client-vanilla/lit-node-client.js",
-        "entryPoints": ["./packages/lit-node-client/src/index.ts"],
-        "define": {
-          "process.env.NODE_DEBUG": "false",
-          "global": "window",
-          "Buffer": "Buffer"
-        },
-        "plugins": [
-          {
-            "package": "esbuild-node-builtins",
-            "function": "nodeBuiltIns"
-          }
-        ]
-      }
-    },
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "outputs": ["{options.outputFile}"],

--- a/packages/lit-third-party-libs/project.json
+++ b/packages/lit-third-party-libs/project.json
@@ -24,26 +24,6 @@
         ]
       }
     },
-    "_buildWeb": {
-      "executor": "@websaam/nx-esbuild:package",
-      "options": {
-        "globalName": "LitJsSdk_litThirdPartyLibs",
-        "outfile": "dist/packages/lit-third-party-libs-vanilla/lit-third-party-libs.js",
-        "entryPoints": [
-          "./packages/lit-third-party-libs/src/index.ts"
-        ],
-        "define": {
-          "process.env.NODE_DEBUG": "false",
-          "global": "window"
-        },
-        "plugins": [
-          {
-            "package": "esbuild-node-builtins",
-            "function": "nodeBuiltIns"
-          }
-        ]
-      }
-    },
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "outputs": [

--- a/packages/misc-browser/project.json
+++ b/packages/misc-browser/project.json
@@ -20,23 +20,6 @@
         "assets": ["packages/misc-browser/*.md"]
       }
     },
-    "_buildWeb": {
-      "executor": "@websaam/nx-esbuild:package",
-      "options": {
-        "globalName": "LitJsSdk_miscBrowser",
-        "outfile": "dist/packages/misc-browser-vanilla/misc-browser.js",
-        "entryPoints": ["./packages/misc-browser/src/index.ts"],
-        "define": {
-          "process.env.NODE_DEBUG": "false"
-        },
-        "plugins": [
-          {
-            "package": "esbuild-node-builtins",
-            "function": "nodeBuiltIns"
-          }
-        ]
-      }
-    },
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "outputs": ["{options.outputFile}"],

--- a/packages/misc/project.json
+++ b/packages/misc/project.json
@@ -20,23 +20,6 @@
         "assets": ["packages/misc/*.md"]
       }
     },
-    "_buildWeb": {
-      "executor": "@websaam/nx-esbuild:package",
-      "options": {
-        "globalName": "LitJsSdk_misc",
-        "outfile": "dist/packages/misc-vanilla/misc.js",
-        "entryPoints": ["./packages/misc/src/index.ts"],
-        "define": {
-          "process.env.NODE_DEBUG": "false"
-        },
-        "plugins": [
-          {
-            "package": "esbuild-node-builtins",
-            "function": "nodeBuiltIns"
-          }
-        ]
-      }
-    },
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "outputs": ["{options.outputFile}"],

--- a/packages/nacl/project.json
+++ b/packages/nacl/project.json
@@ -20,24 +20,6 @@
         "assets": ["packages/nacl/*.md"]
       }
     },
-    "_buildWeb": {
-      "executor": "@websaam/nx-esbuild:package",
-      "options": {
-        "globalName": "LitJsSdk_nacl",
-        "outfile": "dist/packages/nacl-vanilla/nacl.js",
-        "entryPoints": ["./packages/nacl/src/index.ts"],
-        "define": {
-          "process.env.NODE_DEBUG": "false",
-          "global": "window"
-        },
-        "plugins": [
-          {
-            "package": "esbuild-node-builtins",
-            "function": "nodeBuiltIns"
-          }
-        ]
-      }
-    },
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "outputs": ["{options.outputFile}"],

--- a/packages/pkp-base/project.json
+++ b/packages/pkp-base/project.json
@@ -20,24 +20,6 @@
         "assets": ["packages/pkp-base/*.md"]
       }
     },
-    "_buildWeb": {
-      "executor": "@websaam/nx-esbuild:package",
-      "options": {
-        "globalName": "LitJsSdk_pkpBase",
-        "outfile": "dist/packages/pkp-base-vanilla/pkp-base.js",
-        "entryPoints": ["./packages/pkp-base/src/index.ts"],
-        "define": {
-          "process.env.NODE_DEBUG": "false",
-          "global": "window"
-        },
-        "plugins": [
-          {
-            "package": "esbuild-node-builtins",
-            "function": "nodeBuiltIns"
-          }
-        ]
-      }
-    },
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "outputs": ["{options.outputFile}"],

--- a/packages/pkp-client/project.json
+++ b/packages/pkp-client/project.json
@@ -20,24 +20,6 @@
         "assets": ["packages/pkp-client/*.md"]
       }
     },
-    "_buildWeb": {
-      "executor": "@websaam/nx-esbuild:package",
-      "options": {
-        "globalName": "LitJsSdk_pkpClient",
-        "outfile": "dist/packages/pkp-client-vanilla/pkp-client.js",
-        "entryPoints": ["./packages/pkp-client/src/index.ts"],
-        "define": {
-          "process.env.NODE_DEBUG": "false",
-          "global": "window"
-        },
-        "plugins": [
-          {
-            "package": "esbuild-node-builtins",
-            "function": "nodeBuiltIns"
-          }
-        ]
-      }
-    },
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "outputs": ["{options.outputFile}"],

--- a/packages/pkp-cosmos/project.json
+++ b/packages/pkp-cosmos/project.json
@@ -20,24 +20,6 @@
         "assets": ["packages/pkp-cosmos/*.md"]
       }
     },
-    "_buildWeb": {
-      "executor": "@websaam/nx-esbuild:package",
-      "options": {
-        "globalName": "LitJsSdk_pkpCosmos",
-        "outfile": "dist/packages/pkp-cosmos-vanilla/pkp-cosmos.js",
-        "entryPoints": ["./packages/pkp-cosmos/src/index.ts"],
-        "define": {
-          "process.env.NODE_DEBUG": "false",
-          "global": "window"
-        },
-        "plugins": [
-          {
-            "package": "esbuild-node-builtins",
-            "function": "nodeBuiltIns"
-          }
-        ]
-      }
-    },
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "outputs": ["{options.outputFile}"],

--- a/packages/pkp-ethers/project.json
+++ b/packages/pkp-ethers/project.json
@@ -20,24 +20,6 @@
         "assets": ["packages/pkp-ethers/*.md"]
       }
     },
-    "_buildWeb": {
-      "executor": "@websaam/nx-esbuild:package",
-      "options": {
-        "globalName": "LitJsSdk_pkpEthers",
-        "outfile": "dist/packages/pkp-ethers-vanilla/pkp-ethers.js",
-        "entryPoints": ["./packages/pkp-ethers/src/index.ts"],
-        "define": {
-          "process.env.NODE_DEBUG": "false",
-          "global": "window"
-        },
-        "plugins": [
-          {
-            "package": "esbuild-node-builtins",
-            "function": "nodeBuiltIns"
-          }
-        ]
-      }
-    },
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "outputs": ["{options.outputFile}"],

--- a/packages/pkp-sui/project.json
+++ b/packages/pkp-sui/project.json
@@ -20,24 +20,6 @@
         "assets": ["packages/pkp-sui/*.md"]
       }
     },
-    "_buildWeb": {
-      "executor": "@websaam/nx-esbuild:package",
-      "options": {
-        "globalName": "LitJsSdk_pkpSui",
-        "outfile": "dist/packages/pkp-sui-vanilla/pkp-sui.js",
-        "entryPoints": ["./packages/pkp-sui/src/index.ts"],
-        "define": {
-          "process.env.NODE_DEBUG": "false",
-          "global": "window"
-        },
-        "plugins": [
-          {
-            "package": "esbuild-node-builtins",
-            "function": "nodeBuiltIns"
-          }
-        ]
-      }
-    },
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "outputs": ["{options.outputFile}"],

--- a/packages/pkp-walletconnect/project.json
+++ b/packages/pkp-walletconnect/project.json
@@ -20,24 +20,6 @@
         "assets": ["packages/pkp-walletconnect/*.md"]
       }
     },
-    "_buildWeb": {
-      "executor": "@websaam/nx-esbuild:package",
-      "options": {
-        "globalName": "LitJsSdk_pkpWalletconnect",
-        "outfile": "dist/packages/pkp-walletconnect-vanilla/pkp-walletconnect.js",
-        "entryPoints": ["./packages/pkp-walletconnect/src/index.ts"],
-        "define": {
-          "process.env.NODE_DEBUG": "false",
-          "global": "window"
-        },
-        "plugins": [
-          {
-            "package": "esbuild-node-builtins",
-            "function": "nodeBuiltIns"
-          }
-        ]
-      }
-    },
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "outputs": ["{options.outputFile}"],

--- a/packages/sev-snp-utils-sdk/project.json
+++ b/packages/sev-snp-utils-sdk/project.json
@@ -20,23 +20,6 @@
         "assets": ["packages/sev-snp-utils-sdk/*.md"]
       }
     },
-    "_buildWeb": {
-      "executor": "@websaam/nx-esbuild:package",
-      "options": {
-        "globalName": "LitJsSdk_blsSdk",
-        "outfile": "dist/packages/sev-snp-utils-sdk-vanilla/sev-snp-utils-sdk.js",
-        "entryPoints": ["./packages/sev-snp-utils-sdk/src/index.ts"],
-        "define": {
-          "process.env.NODE_DEBUG": "false"
-        },
-        "plugins": [
-          {
-            "package": "esbuild-node-builtins",
-            "function": "nodeBuiltIns"
-          }
-        ]
-      }
-    },
     "test": {
       "executor": "@nrwl/jest:jest",
       "outputs": ["coverage/packages/sev-snp-utils-sdk"],

--- a/packages/types/project.json
+++ b/packages/types/project.json
@@ -20,24 +20,6 @@
         "assets": ["packages/types/*.md"]
       }
     },
-    "_buildWeb": {
-      "executor": "@websaam/nx-esbuild:package",
-      "options": {
-        "globalName": "LitJsSdk_types",
-        "outfile": "dist/packages/types-vanilla/types.js",
-        "entryPoints": ["./packages/types/src/index.ts"],
-        "define": {
-          "process.env.NODE_DEBUG": "false",
-          "global": "window"
-        },
-        "plugins": [
-          {
-            "package": "esbuild-node-builtins",
-            "function": "nodeBuiltIns"
-          }
-        ]
-      }
-    },
     "lint": {
       "executor": "@nrwl/linter:eslint",
       "outputs": ["{options.outputFile}"],

--- a/packages/uint8arrays/project.json
+++ b/packages/uint8arrays/project.json
@@ -21,23 +21,6 @@
         "assets": ["packages/uint8arrays/*.md"]
       }
     },
-    "_buildWeb": {
-      "executor": "@websaam/nx-esbuild:package",
-      "options": {
-        "globalName": "LitJsSdk_uint8arrays",
-        "outfile": "dist/packages/uint8arrays-vanilla/uint8arrays.js",
-        "entryPoints": ["./packages/uint8arrays/src/index.ts"],
-        "define": {
-          "process.env.NODE_DEBUG": "false"
-        },
-        "plugins": [
-          {
-            "package": "esbuild-node-builtins",
-            "function": "nodeBuiltIns"
-          }
-        ]
-      }
-    },
     "test": {
       "executor": "@nrwl/jest:jest",
       "outputs": ["coverage/packages/uint8arrays"],

--- a/tools/scripts/build.mjs
+++ b/tools/scripts/build.mjs
@@ -37,13 +37,6 @@ const build = async (name) => {
   greenLog('Building Tsc...');
   await runCommand(`yarn nx run ${name}:_buildTsc`);
 
-  greenLog('Building Vanilla...');
-  try {
-    await runCommand(`yarn nx run ${name}:_buildWeb`);
-  } catch (e) {
-    redLog('❌ Vanilla build failed, skipping...');
-  }
-
   greenLog('Polyfilling...');
   await childRunCommand(`yarn tools --polyfills ${name}`);
 

--- a/tools/scripts/gen-lib.mjs
+++ b/tools/scripts/gen-lib.mjs
@@ -80,40 +80,6 @@ const createBuild = (name) => {
   };
 };
 
-/**
- *
- * This function creates a new build config for esbuild,
- * and add it under the "targets" property in the project.json
- * @param { string } name the name of the project
- * @param { object }
- *  @property { string } globalPrefix the prefix of the global variable
- *
- */
-const createBuildWeb = (name, { globalPrefix = 'LitJsSdk' }) => {
-  const camelCase = name.replace(/-([a-z])/g, (g) => g[1].toUpperCase());
-
-  return {
-    _buildWeb: {
-      executor: '@websaam/nx-esbuild:package',
-      options: {
-        globalName: `${globalPrefix}_${camelCase}`,
-        outfile: `dist/packages/${name}-vanilla/${name}.js`,
-        entryPoints: [`./packages/${name}/src/index.ts`],
-        define: {
-          'process.env.NODE_DEBUG': 'false',
-          global: 'window',
-        },
-        plugins: [
-          {
-            package: 'esbuild-node-builtins',
-            function: 'nodeBuiltIns',
-          },
-        ],
-      },
-    },
-  };
-};
-
 const getProject = () => {
   const graph = readCachedProjectGraph();
   const nodes = graph.nodes;
@@ -161,9 +127,6 @@ const editProjectJson = async () => {
   delete project.targets.build.dependsOn;
 
   project.targets['_buildTsc'] = project.targets.build;
-  project.targets['_buildWeb'] = createBuildWeb(PROJECT_NAME, {
-    globalPrefix: 'LitJsSdk',
-  })._buildWeb;
   project.targets['build'] = createBuild(PROJECT_NAME).build;
 
   // move 'lint' and 'test' objects to the end

--- a/tools/scripts/tools.mjs
+++ b/tools/scripts/tools.mjs
@@ -496,7 +496,6 @@ async function buildFunc() {
     }
 
     await childRunCommand(`yarn nx run ${TARGET}:_buildTsc`);
-    spawnListener(`yarn nx run ${TARGET}:_buildWeb`);
     await childRunCommand(
       `yarn tools --postBuildIndividual --target ${TARGET}`
     );
@@ -534,9 +533,6 @@ async function buildFunc() {
     spawnListener(command, {
       onDone: () => {
         console.log('Done!');
-
-        // // then run vanilla build
-        // const command = `yarn nx run-many --target=_buildWeb --exclude=${ignoreList}`;
 
         // spawnListener(command, {
         //   onDone: async () => {


### PR DESCRIPTION
# Description

Removing vanilla js builds due to low usage, this should reduce around 30 seconds (125s -> 95s)  in build time.

## Type of change

- [ ] Build

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
