### PR TITLE
Enable signin using popup modals instead of redirections

### DIFF
--- a/packages/lit-auth-client/src/lib/providers/GoogleProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/GoogleProvider.ts
@@ -10,6 +10,7 @@ import {
   parseLoginParams,
   getStateParam,
   decode,
+  LIT_LOGIN_GATEWAY,
 } from '../utils';
 import { BaseProvider } from './BaseProvider';
 import { ethers } from 'ethers';
@@ -107,6 +108,61 @@ export default class GoogleProvider extends BaseProvider {
       accessToken: idToken,
     };
     return authMethod;
+  }
+
+  /**
+   * Sign in using popup window
+   *
+   * @param baseURL
+   */
+  public async signInUsingPopup(baseURL: string): Promise<AuthMethod> {
+    const width = 500;
+    const height = 600;
+    const left = window.screen.width / 2 - width / 2;
+    const top = window.screen.height / 2 - height / 2;
+
+    const url = await prepareLoginUrl('google', this.redirectUri, baseURL);
+    const popup = window.open(
+      `${url}&caller=${window.location.origin}`,
+      'popup',
+      `toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=no, copyhistory=no, width=${width}, height=${height}, top=${top}, left=${left}`
+    );
+
+    if (!popup) {
+      throw new Error('Failed to open popup window');
+    }
+
+    return new Promise((resolve, reject) => {
+      // window does not have a closed event, so we need to poll using a timer
+      const interval = setInterval(() => {
+        if (popup.closed) {
+          clearInterval(interval);
+          reject(new Error('User closed popup window'));
+        }
+      }, 1000);
+
+      window.addEventListener('message', (event) => {
+        if (event.origin !== (baseURL || LIT_LOGIN_GATEWAY)) {
+          return;
+        }
+
+        const { provider, token, error } = event.data;
+
+        if (error) {
+          clearInterval(interval);
+          reject(new Error(error));
+        }
+
+        if (provider === 'google' && token) {
+          clearInterval(interval);
+          popup.close();
+          resolve({
+            authMethodType: AuthMethodType.Google,
+            accessToken: token,
+          });
+        }
+      });
+    });
   }
 
   /**

--- a/packages/lit-auth-client/src/lib/utils.ts
+++ b/packages/lit-auth-client/src/lib/utils.ts
@@ -3,6 +3,7 @@ import { LoginUrlParams } from '@lit-protocol/types';
 import * as cbor from 'cbor-web';
 
 export const STATE_PARAM_KEY = 'lit-state-param';
+export const LIT_LOGIN_GATEWAY = 'https://login.litgateway.com';
 
 /**
  * Check if OAuth provider is supported
@@ -25,9 +26,9 @@ export function isSocialLoginSupported(provider: string): boolean {
  */
 export async function prepareLoginUrl(
   provider: string,
-  redirectUri: string
+  redirectUri: string,
+  baseUrl = LIT_LOGIN_GATEWAY,
 ): Promise<string> {
-  const baseUrl = 'https://login.litgateway.com';
   const loginUrl = `${baseUrl}${getLoginRoute(provider)}`;
   const state = encode(await setStateParam());
   const authParams = {


### PR DESCRIPTION
# Description

This PR adds a signin method that handles authenticating with an oauth provider using a popup modal instead of a redirect and two steps
This feature requires [lit-login-server PR#4](https://github.com/LIT-Protocol/lit-login-server/pull/4)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually built the SDK, dropped built files in the wagmi connector demo and used Google and Discord auth modal flows there. Also running a local version of lit login server

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
