### PR TITLE
fix: calculation should be UTC now instead of executor's now

### DIFF
--- a/packages/contracts-sdk/src/lib/utils.ts
+++ b/packages/contracts-sdk/src/lib/utils.ts
@@ -9,13 +9,19 @@ export function convertRequestsPerDayToPerSecond(
 // Calculates the expiration timestamp in UTC for a given number of days from now.
 // The expiration time is set to midnight (00:00:00) UTC of the target day.
 export function calculateUTCMidnightExpiration(daysFromNow: number): number {
+  // Create a Date object for the current time in UTC
   const now = new Date();
-  const futureDate = new Date(
+  const utcNow = Date.UTC(
     now.getUTCFullYear(),
     now.getUTCMonth(),
-    now.getUTCDate() + daysFromNow
+    now.getUTCDate()
   );
+
+  // Create a future Date object in UTC, adding the specified number of days
+  const futureDate = new Date(utcNow);
+  futureDate.setUTCDate(futureDate.getUTCDate() + daysFromNow);
   futureDate.setUTCHours(0, 0, 0, 0); // Set to midnight UTC
+
   return Math.floor(futureDate.getTime() / 1000);
 }
 


### PR DESCRIPTION
# Description

This PR addresses an issue in the `calculateUTCMidnightExpiration` function, where calculations for expiration timestamps were inaccurately computed for users in timezones ahead of UTC. Specifically, when attempting to calculate the expiration timestamp with a parameter like `daysUntilUTCMidnightExpiration: 1`, the result would inaccurately represent less than 24 hours until expiration due to the discrepancy between local and UTC times.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

minting rli with 1 day expiration

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x]  My changes generate no new warnings
- [x]  I have added tests that prove my fix is effective or that my feature works
- [x]  New and existing unit tests pass locally with my changes
- [x]  Any dependent changes have been merged and published in downstream modules
