### PR TITLE
LIT-2658 - Empty delegateeAddresses passed to createCapacityDelegationAuthSig() now means "everyone can use this"

### DIFF
--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -122,8 +122,6 @@ interface CapacityCreditsRes {
   capacityDelegationAuthSig: AuthSig;
 }
 
-/** ---------- Main Export Class ---------- */
-
 export class LitNodeClientNodeJs
   extends LitCore
   implements LitClientSessionManager
@@ -180,18 +178,12 @@ export class LitNodeClientNodeJs
     const {
       dAppOwnerWallet,
       capacityTokenId,
+      delegateeAddresses,
       uses,
       domain,
       expiration,
       statement,
     } = params;
-
-    let { delegateeAddresses } = params;
-
-    // -- if delegateeAddresses is not provided, set it to an empty array
-    if (!delegateeAddresses) {
-      delegateeAddresses = [];
-    }
 
     // -- This is the owner address who holds the Capacity Credits NFT token and wants to delegate its
     // usage to a list of delegatee addresses
@@ -223,13 +215,6 @@ export class LitNodeClientNodeJs
     //   throw new Error('dAppOwnerWallet must be an ethers wallet');
     // }
 
-    // -- Strip the 0x prefix from each element in the addresses array if it exists
-    if (delegateeAddresses && delegateeAddresses.length > 0) {
-      delegateeAddresses = delegateeAddresses.map((address) =>
-        address.startsWith('0x') ? address.slice(2) : address
-      );
-    }
-
     // -- create LitRLIResource
     // Note: we have other resources such as LitAccessControlConditionResource, LitPKPResource and LitActionResource)
     // lit-ratelimitincrease://{tokenId}
@@ -241,7 +226,13 @@ export class LitNodeClientNodeJs
 
     const capabilities = {
       ...(capacityTokenId ? { nft_id: [capacityTokenId] } : {}), // Conditionally include nft_id
-      delegate_to: delegateeAddresses,
+      ...(delegateeAddresses
+        ? {
+            delegate_to: delegateeAddresses.map((address) =>
+              address.startsWith('0x') ? address.slice(2) : address
+            ),
+          }
+        : {}),
       uses: _uses.toString(),
     };
 


### PR DESCRIPTION
# Description

Modifies logic in `createCapacityDelegationAuthSig()` so that callers can omit the `delegateeAddresses` and the behaviour will be that _anyone_ can use it rather than the current logic which adds an empty array,  making it so _nobody_ can use it :)

**Without** this fix, we actually created and set an empty array into the `delegate_to` property on the capability, which meant "Nobody can use this".
**With** this fix, we don't set `delegate_to` on the capability at all if no `delegateeAddresses` was provided as an argument.  This means "Anyone can use this".  It matches the behaviour [described in our docs](https://github.com/LIT-Protocol/docs/blob/9f6bccaad533bafa34b9e4020feca6b74186c57b/docs/sdk/capacity-credits.md?plain=1#L88).

- I ran `eslint -- fix` on the file, so there are incidental changes. Best reviewed commit-by-commit. Actual changes are here: https://github.com/LIT-Protocol/js-sdk/pull/400/commits/4940e490becbc2b8eb9821b69db32769a3f70eb2
- I "drive-by" fixed the usage of `any` type on the arguments passed to the node client, so that TS can do basic inference there now 🎉  :)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] E2E tests

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
