### PR TITLE
hex prefix the sig so we don't need to re-sign every time

### DIFF
--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -684,7 +684,7 @@ export class LitNodeClientNodeJs
     const authSigSiweMessage = new siwe.SiweMessage(authSig.signedMessage);
 
     try {
-      await authSigSiweMessage.validate(authSig.sig);
+      await authSigSiweMessage.verify({signature: hexPrefixed(authSig.sig)});
     } catch (e) {
       console.debug('Need retry because verify failed', e);
       return true;

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -684,7 +684,7 @@ export class LitNodeClientNodeJs
     const authSigSiweMessage = new siwe.SiweMessage(authSig.signedMessage);
 
     try {
-      await authSigSiweMessage.verify({signature: hexPrefixed(authSig.sig)});
+      await authSigSiweMessage.verify({ signature: hexPrefixed(authSig.sig) });
     } catch (e) {
       console.debug('Need retry because verify failed', e);
       return true;


### PR DESCRIPTION
When working with session sigs, i noticed we seem to re-sign stuff everytime, with this error below.  I think it's just because the signature isn't hex prefixed.  This PR should fix this by upgrading us to use the verify() function and hex prefixing the signature.

```
validate() has been deprecated, please update your code to use verify(). validate() may be removed in future versions.
Error: signature missing v and recoveryParam (argument="signature", value="3782d0a8c088bfd8e071593d9b0002df8cb2aa4258e639d708ad70041652e478282f60a019bbd3e69bf09831f8b2df2dcfdf220fe050e2280de2a6ef8588a8961c", code=INVALID_ARGUMENT, version=bytes/5.7.0)
    at Logger.makeError (/Users/chris/Documents/WorkStuff/Lit/pkp-capacity-credit-delegator/node_modules/@ethersproject/logger/lib/index.js:238:21)
    at Logger.throwError (/Users/chris/Documents/WorkStuff/Lit/pkp-capacity-credit-delegator/node_modules/@ethersproject/logger/lib/index.js:247:20)
    at Logger.throwArgumentError (/Users/chris/Documents/WorkStuff/Lit/pkp-capacity-credit-delegator/node_modules/@ethersproject/logger/lib/index.js:250:21)
    at splitSignature (/Users/chris/Documents/WorkStuff/Lit/pkp-capacity-credit-delegator/node_modules/@ethersproject/bytes/lib/index.js:359:24)
    at recoverPublicKey (/Users/chris/Documents/WorkStuff/Lit/pkp-capacity-credit-delegator/node_modules/@ethersproject/signing-key/lib/index.js:59:42)
    at recoverAddress (/Users/chris/Documents/WorkStuff/Lit/pkp-capacity-credit-delegator/node_modules/@ethersproject/transactions/lib/index.js:72:62)
    at verifyMessage (/Users/chris/Documents/WorkStuff/Lit/pkp-capacity-credit-delegator/node_modules/@ethersproject/wallet/lib/index.js:241:46)
    at /Users/chris/Documents/WorkStuff/Lit/pkp-capacity-credit-delegator/node_modules/siwe/dist/client.js:241:61
    at new Promise (<anonymous>)
    at SiweMessage.<anonymous> (/Users/chris/Documents/WorkStuff/Lit/pkp-capacity-credit-delegator/node_modules/siwe/dist/client.js:160:20) {
  reason: 'signature missing v and recoveryParam',
  code: 'INVALID_ARGUMENT',
  argument: 'signature',
  value: '3782d0a8c088bfd8e071593d9b0002df8cb2aa4258e639d708ad70041652e478282f60a019bbd3e69bf09831f8b2df2dcfdf220fe050e2280de2a6ef8588a8961c'
}
Need retry because verify failed SiweError {
  type: 'Signature does not match address of the message.',
  expected: undefined,
  received: 'Resolved address to be 0x6250BdbeF65c05Cb14F5AEE3A261Ba3E29dD69Da'
}
```