### PR TITLE
BREAKING CHANGE: make getLatestBlockhash async

### DIFF
--- a/e2e-nodejs/0_manual-tests/test-block-has-update-after-exp.mjs
+++ b/e2e-nodejs/0_manual-tests/test-block-has-update-after-exp.mjs
@@ -18,7 +18,7 @@ export async function main() {
   console.log(client.hdRootPubkeys);
   let subnetKey = '' + client.subnetPubKey;
   let rootKeys = client.hdRootPubkeys;
-  let blockhash = client.getLatestBlockhash();
+  let blockhash = await client.getLatestBlockhash();
   await new Promise((resolve, _reject) => {
     setTimeout(resolve, 35_000);
   });

--- a/e2e-nodejs/group-connection/test-latest-blockhash.mjs
+++ b/e2e-nodejs/group-connection/test-latest-blockhash.mjs
@@ -1,0 +1,32 @@
+import path from 'path';
+import { success, fail, testThis } from '../../tools/scripts/utils.mjs';
+import LITCONFIG from '../../lit.config.json' assert { type: 'json' };
+import { LitNodeClient } from '@lit-protocol/lit-node-client';
+
+const LIT_NETWORK = 'cayenne';
+
+export async function main() {
+  // ==================== Test Logic ====================
+  const client = new LitNodeClient({
+    litNetwork: globalThis.LitCI.network,
+    debug: globalThis.LitCI.debug,
+    checkNodeAttestation: globalThis.LitCI.sevAttestation,
+  });
+  await client.connect();
+
+  const latestBlockhash = await litNodeClient.getLatestBlockhash();
+
+  // ==================== Post-Validation ====================
+  if (!latestBlockhash) {
+    return fail('latest blockhash not found');
+  }
+
+  if (!latestBlockhash.startsWith('0x')) {
+    return fail('latest blockhash not in hex format');
+  }
+
+  // ==================== Success ====================
+  return success(`Latest blockhash found: ${latestBlockhash}`);
+}
+
+await testThis({ name: path.basename(import.meta.url), fn: main });

--- a/e2e-nodejs/group-hotwallet-with-blockhash/test-hotwallet-with-blockhash.mjs
+++ b/e2e-nodejs/group-hotwallet-with-blockhash/test-hotwallet-with-blockhash.mjs
@@ -62,7 +62,7 @@ export async function main() {
   });
   await litNodeClient.connect();
 
-  let nonce = litNodeClient.getLatestBlockhash();
+  let nonce = await litNodeClient.getLatestBlockhash();
   console.log('Eth blockhash nonce- ', nonce);
 
   if (!nonce) {

--- a/e2e-nodejs/group-latest-blockhash-update/test-block-has-update-after-exp.mjs
+++ b/e2e-nodejs/group-latest-blockhash-update/test-block-has-update-after-exp.mjs
@@ -18,7 +18,7 @@ export async function main() {
   console.log(client.hdRootPubkeys);
   let subnetKey = '' + client.subnetPubKey;
   let rootKeys = client.hdRootPubkeys;
-  let blockhash = client.getLatestBlockhash();
+  let blockhash = await client.getLatestBlockhash();
   await new Promise((resolve, _reject) => {
     setTimeout(resolve, 35_000);
   });

--- a/e2e-nodejs/group-pkp-encryption-decryption/test-pkp-encryption-decryption-nodes.mjs
+++ b/e2e-nodejs/group-pkp-encryption-decryption/test-pkp-encryption-decryption-nodes.mjs
@@ -58,7 +58,7 @@ export async function main() {
     uri: 'https://localhost/login',
     version: '1',
     chainId: 1,
-    nonce: litNodeClient.getLatestBlockhash(),
+    nonce: await litNodeClient.getLatestBlockhash(),
     expirationTime: new Date(Date.now() + 60_000 * 60).toISOString(),
   });
   const messageToSign = siweMessage.prepareMessage();

--- a/e2e-nodejs/loader.mjs
+++ b/e2e-nodejs/loader.mjs
@@ -36,7 +36,7 @@ if (loadEnv) {
 
   await litNodeClient.connect();
 
-  let nonce = litNodeClient.getLatestBlockhash();
+  let nonce = await litNodeClient.getLatestBlockhash();
   console.log('GENERATED NONCE: ', nonce);
 
   const domain = 'localhost';


### PR DESCRIPTION
# Description

"so i was thinking about how we get the poller out of the JS SDK.  the main issue is that `litNodeClient.getLatestBlockhash();` is not async.  if we make it async, then we can remove the poller, and just get the latest block hash when they call that function.  this is a breaking change, but def worth it IMO"

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] yarn test:e2e:nodejs --filter=test-latest-blockhash.mjs            

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
