### PR TITLE
fix(types): LIT-2706 - Modify LitNodeClientConfig properties incorrectly marked as required to be optional

### DIFF
--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -76,13 +76,28 @@ interface EpochCache {
   lastUpdateTime: null | number;
 }
 
+export type LitNodeClientConfigWithDefaults = Required<
+  Pick<
+    LitNodeClientConfig,
+    | 'bootstrapUrls'
+    | 'alertWhenUnauthorized'
+    | 'debug'
+    | 'connectTimeout'
+    | 'checkNodeAttestation'
+    | 'litNetwork'
+    | 'minNodeCount'
+    | 'retryTolerance'
+  >
+> &
+  Partial<Pick<LitNodeClientConfig, 'storageProvider' | 'contractContext'>>;
+
 // On epoch change, we wait this many seconds for the nodes to update to the new epoch before using the new epoch #
 const EPOCH_PROPAGATION_DELAY = 30_000;
 // This interval is responsible for keeping latest block hash up to date
 const NETWORK_SYNC_INTERVAL = 30_000;
 
 export class LitCore {
-  config: LitNodeClientConfig = {
+  config: LitNodeClientConfigWithDefaults = {
     alertWhenUnauthorized: false,
     debug: true,
     connectTimeout: 20000,

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -170,12 +170,12 @@ export type KV = Record<string, any>;
 
 /** ---------- Lit Node Client ---------- */
 export interface LitNodeClientConfig {
-  alertWhenUnauthorized: boolean;
-  minNodeCount: number;
-  debug: boolean;
-  bootstrapUrls: string[];
   litNetwork: LIT_NETWORKS_KEYS;
-  connectTimeout: number;
+  alertWhenUnauthorized?: boolean;
+  minNodeCount?: number;
+  debug?: boolean;
+  bootstrapUrls?: string[];
+  connectTimeout?: number;
   checkNodeAttestation?: boolean;
   contractContext?: LitContractContext | LitContractResolverContext;
   storageProvider?: StorageProvider;


### PR DESCRIPTION
# Description
After we removed the any union type on the node client constructor in v4.1, users began reporting that they were being forced to add properties to the configuration that they did not expect to be required.

Upon inspection, there is a complete set of default values for the node client provided in lit-core , some properties are set in the code itself based on the value of litNetwork, and others are loaded from the on-chain staking contract.

Thus, every property in the config is theoretically optional except for litNetwork — but this was being hidden by the any union type that was allowing consumers to pass objects with any shape into the constructor.

This PR makes those properties optional.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
