### PR TITLE
fix: use AuthMethodType.GoogleJwt when loging in using popup

### DIFF
--- a/packages/lit-auth-client/src/lib/providers/GoogleProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/GoogleProvider.ts
@@ -157,7 +157,7 @@ export default class GoogleProvider extends BaseProvider {
           clearInterval(interval);
           popup.close();
           resolve({
-            authMethodType: AuthMethodType.Google,
+            authMethodType: AuthMethodType.GoogleJwt,
             accessToken: token,
           });
         }


### PR DESCRIPTION

# Description

This PR changes the AuthMethodType returned when signing in with google using a popup to GoogleJwt, which is the one used when creating domain wallets pkps and therefore the one used in the wagmi connector

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Tested locally using the domain wallets sdk inside the wagmi connector
- [ ] Inspected a [domain wallet pkp claimed in chain explorer](https://lit-protocol.calderaexplorer.xyz/tx/0xabb4073836cec954034b48bfa1d6652cd222ea3fde2228284fb5af17182305fb)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
