### PR TITLE
feat(package.json): add local dev build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "reset:dev": "yarn tools --remove-local-dev",
     "reset": "rm -rf ./dist/packages && yarn reset:dev",
     "build": "yarn build:packages",
+    "build:dev": "yarn tools --remove-local-dev && rm -rf ./dist && yarn tools check --no-empty-directories=true && yarn tools fixTsConfig && yarn tools --build --packages && yarn tools --setup-local-dev && yarn build:verify",
     "build:packages": "yarn tools --remove-local-dev && rm -rf ./dist && yarn gen:internal-dev && yarn tools check --no-empty-directories=true && yarn tools fixTsConfig && yarn tools --build --packages && yarn tools --setup-local-dev && yarn gen:readme && yarn build:verify && yarn nx format:write --all",
     "build:target": "yarn node tools/scripts/build.mjs",
     "build:setupLocalDev": "yarn tools --setup-local-dev",


### PR DESCRIPTION
# Description

Average build time now running yarn build on a M1 Max pro machine takes around 17s (which is not that bad), but we can optimise it further by stripping away operations that don't matter in local development.

Introducing `yarn build:dev` command

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
