### PR TITLE
Feat: Add retry to attestation cert fetch

### DIFF
--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -616,7 +616,12 @@ export class LitCore {
 
       try {
         // ensure we won't try to use a node with an invalid attestation response
-        await checkSevSnpAttestation(attestation, challenge, url);
+        await checkSevSnpAttestation(
+          attestation,
+          challenge,
+          url,
+          this.config.retryTolerance
+        );
         log(`Lit Node Attestation verified for ${url}`);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } catch (e: any) {


### PR DESCRIPTION
# Description
There have been cases where there is failure when attempting to remote fetch AMD SEV SNP certificates for attestation checks. `executeWithRetry` is no wrapping the request to allow for retry if the operation fails
Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

