### PR TITLE
Feat/prehex pkp pubkey

### DIFF
--- a/packages/lit-auth-client/src/lib/lit-auth-client.ts
+++ b/packages/lit-auth-client/src/lib/lit-auth-client.ts
@@ -8,9 +8,11 @@ import {
   WebAuthnProviderOptions,
   AuthMethod,
   MintRequestBody,
+  BaseProviderOptions,
 } from '@lit-protocol/types';
 import {
   AuthMethodType,
+  LitNetwork,
   ProviderType,
   RELAY_URL_CAYENNE,
   RELAY_URL_HABANERO,
@@ -84,11 +86,17 @@ export class LitAuthClient {
     }
 
     // Check if Lit node client is provided
+    // FIXME: In the near future, a breaking change will introduce to always require a LitNodeClient
     if (options?.litNodeClient) {
       this.litNodeClient = options?.litNodeClient;
     } else {
+
+      if (!options?.litNetwork) {
+        throw new Error(`"litNetwork" is required to create a LitNodeClient. Received: "${options?.litNetwork}". Here are the supported networks: ${Object.values(LitNetwork)}`);
+      }
+
       this.litNodeClient = new LitNodeClient({
-        litNetwork: 'cayenne',
+        litNetwork: options.litNetwork,
         debug: options.debug ?? false,
       });
     }
@@ -106,8 +114,7 @@ export class LitAuthClient {
 
       if (!supportedNetworks.includes(this.litNodeClient.config.litNetwork)) {
         throw new Error(
-          `Unsupported litNetwork: ${
-            this.litNodeClient.config.litNetwork
+          `Unsupported litNetwork: ${this.litNodeClient.config.litNetwork
           }. Supported networks are: ${supportedNetworks.join(', ')}`
         );
       }
@@ -246,6 +253,10 @@ export class LitAuthClient {
    */
   getProvider(type: ProviderType): BaseProvider | undefined {
     return this.providers.get(type);
+  }
+
+  public static getEthWalletProvider(params: EthWalletProviderOptions): EthWalletProvider {
+    return new EthWalletProvider(params);
   }
 
   /**

--- a/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
@@ -22,8 +22,13 @@ export default class EthWalletProvider extends BaseProvider {
    */
   public origin: string;
 
-  constructor(options: BaseProviderOptions & EthWalletProviderOptions) {
-    super(options);
+  constructor(options: EthWalletProviderOptions) {
+    super({
+      rpcUrl: '',
+      relay: null as any,
+      litNodeClient: null,
+      ...options
+    });
     try {
       this.domain = options.domain || window.location.hostname;
       this.origin = options.origin || window.location.origin;
@@ -51,12 +56,13 @@ export default class EthWalletProvider extends BaseProvider {
     options?: EthWalletAuthenticateOptions
   ): Promise<AuthMethod> {
     const address = options?.address;
-    const signMessage = options?.signMessage;
+
     const chain = options?.chain || 'ethereum';
 
     let authSig: AuthSig;
 
-    if (address && signMessage) {
+    if (address && options?.signMessage) {
+
       // Get chain ID or default to Ethereum mainnet
       const selectedChain = LIT_CHAINS[chain];
       const chainId = selectedChain?.chainId ? selectedChain.chainId : 1;
@@ -80,8 +86,10 @@ export default class EthWalletProvider extends BaseProvider {
       const message: SiweMessage = new SiweMessage(preparedMessage);
       const toSign: string = message.prepareMessage();
 
+      console.log('toSign:', toSign);
+
       // Use provided function to sign message
-      const signature = await signMessage(toSign);
+      const signature = await options?.signMessage(toSign);
 
       authSig = {
         sig: signature,

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -704,7 +704,7 @@ export class LitNodeClientNodeJs
           resourceAbilityRequest.ability
         )
       ) {
-        console.debug('Need retry because capabilities do not match', {
+        log('Need retry because capabilities do not match', {
           authSigSessionCapabilityObject,
           resourceAbilityRequest,
         });
@@ -2474,6 +2474,8 @@ export class LitNodeClientNodeJs
 
     // Compute the address from the public key if it's provided. Otherwise, the node will compute it.
     const pkpEthAddress = (function () {
+      params.pkpPublicKey = hexPrefixed(params.pkpPublicKey!);
+
       if (params.pkpPublicKey) return computeAddress(params.pkpPublicKey);
 
       // This will be populated by the node, using dummy value for now.

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -1178,6 +1178,8 @@ export interface LitAuthClientOptions {
   debug?: boolean;
 
   litOtpConfig?: OtpProviderOptions;
+
+  litNetwork?: LIT_NETWORKS_KEYS;
 }
 
 export interface OtpSessionResult {
@@ -1397,6 +1399,8 @@ export interface EthWalletProviderOptions {
    * The origin from which the signing request is made
    */
   origin?: string;
+
+  litNodeClient?: any;
 }
 
 export interface WebAuthnProviderOptions {


### PR DESCRIPTION
# Description

When creating session sigs, user will need to prefix their pkp public key with hex `0x`, and if they don't, they will run into `invalid arrayify value while using bytes32 array` when trying to sign. We should really just prefix it for them if it's not already.

Before
```ts
  const sessionSigs = await litNodeClient.getSessionSigs({
    pkpPublicKey: `0x${pkpPublicKey}`;
    expiration: expiration,
    chain: 'ethereum',
    resourceAbilityRequests: [
      {
        resource: new LitPKPResource('*'),
        ability: LitAbility.PKPSigning,
      },
    ],
```

After
```ts
  const sessionSigs = await litNodeClient.getSessionSigs({
    pkpPublicKey: pkpPublicKey,
    expiration: expiration,
    chain: 'ethereum',
    resourceAbilityRequests: [
      {
        resource: new LitPKPResource('*'),
        ability: LitAbility.PKPSigning,
      },
    ],
```


## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update