### PR TITLE
feat(lit-node-client-nodejs): prefix 0x to pkp pubkey if not present

### DIFF
--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -2474,10 +2474,12 @@ export class LitNodeClientNodeJs
 
     // Compute the address from the public key if it's provided. Otherwise, the node will compute it.
     const pkpEthAddress = (function () {
-      // prefix '0x' if it's not already prefixed
-      const hexedPkpPublicKey = hexPrefixed(params.pkpPublicKey!);
+      if (params.pkpPublicKey) {
+        // prefix '0x' if it's not already prefixed
+        const hexedPkpPublicKey = hexPrefixed(params.pkpPublicKey);
 
-      if (hexedPkpPublicKey) return computeAddress(hexedPkpPublicKey);
+        if (hexedPkpPublicKey) return computeAddress(hexedPkpPublicKey);
+      }
 
       // This will be populated by the node, using dummy value for now.
       return '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -2474,6 +2474,10 @@ export class LitNodeClientNodeJs
 
     // Compute the address from the public key if it's provided. Otherwise, the node will compute it.
     const pkpEthAddress = (function () {
+
+      // prefix '0x' if it's not already prefixed
+      params.pkpPublicKey = hexPrefixed(params.pkpPublicKey!);
+      
       if (params.pkpPublicKey) return computeAddress(params.pkpPublicKey);
 
       // This will be populated by the node, using dummy value for now.

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -2474,11 +2474,10 @@ export class LitNodeClientNodeJs
 
     // Compute the address from the public key if it's provided. Otherwise, the node will compute it.
     const pkpEthAddress = (function () {
-
       // prefix '0x' if it's not already prefixed
-      params.pkpPublicKey = hexPrefixed(params.pkpPublicKey!);
-      
-      if (params.pkpPublicKey) return computeAddress(params.pkpPublicKey);
+      const hexedPkpPublicKey = hexPrefixed(params.pkpPublicKey!);
+
+      if (hexedPkpPublicKey) return computeAddress(hexedPkpPublicKey);
 
       // This will be populated by the node, using dummy value for now.
       return '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';


### PR DESCRIPTION
# Description

When creating session sigs, user will need to prefix their pkp public key with hex `0x`, and if they don't, they will run into
```
error: invalid arrayify value (argument="value", value="048161e8dd7b3efc0c1dab3c6e89d3c3f0181947d4a35994113b32f30a86f3f4bc0cdc4d3ea12c6afa42252dfc3a8316b298d78aa6470da59d260432d644bba84a", code=INVALID_ARGUMENT, version=bytes/5.7.0)
```
when trying to sign. We should really just prefix it for them if it's not already.

Before
```ts
  const sessionSigs = await litNodeClient.getSessionSigs({
    pkpPublicKey: `0x${pkpPublicKey}`;
    expiration: expiration,
    chain: 'ethereum',
    resourceAbilityRequests: [
      {
        resource: new LitPKPResource('*'),
        ability: LitAbility.PKPSigning,
      },
    ],
```

After
```ts
  const sessionSigs = await litNodeClient.getSessionSigs({
    pkpPublicKey: pkpPublicKey,
    expiration: expiration,
    chain: 'ethereum',
    resourceAbilityRequests: [
      {
        resource: new LitPKPResource('*'),
        ability: LitAbility.PKPSigning,
      },
    ],
```


## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update