### PR TITLE
feat: decouple eth wallet from provider

### DIFF
--- a/e2e-nodejs/group-pkp-auth-method/test-pkp-eth-wallet-provider.mjs
+++ b/e2e-nodejs/group-pkp-auth-method/test-pkp-eth-wallet-provider.mjs
@@ -18,9 +18,10 @@ export async function main() {
 
   const wallet = new ethers.Wallet(PRIVATE_KEY, provider);
 
-  const ethWalletProvider = new EthWalletProvider({ litNodeClient: client });
-
-  const authMethod = await ethWalletProvider.authenticate(wallet);
+  const authMethod = await EthWalletProvider.authenticate({
+    signer: wallet,
+    litNodeClient: client,
+  });
 
   if (!authMethod) {
     fail('Unable to authenticate with eth wallet provider');

--- a/e2e-nodejs/group-pkp-auth-method/test-pkp-eth-wallet-provider.mjs
+++ b/e2e-nodejs/group-pkp-auth-method/test-pkp-eth-wallet-provider.mjs
@@ -1,0 +1,32 @@
+// Test command:
+// DEBUG=true NETWORK=cayenne yarn test:e2e:nodejs --filter=test-pkp-eth-wallet-provider.mjs
+
+import { client } from '../00-setup.mjs';
+import { LitAuthClient } from '@lit-protocol/lit-auth-client';
+import LITCONFIG from '../../lit.config.json' assert { type: 'json' };
+import { success, fail, testThis } from '../../tools/scripts/utils.mjs';
+import path from 'path';
+import { EthWalletProvider } from '@lit-protocol/lit-auth-client';
+import { ethers } from 'ethers';
+
+export async function main() {
+  const PRIVATE_KEY = LITCONFIG.CONTROLLER_PRIVATE_KEY;
+
+  const provider = new ethers.providers.JsonRpcProvider(
+    LITCONFIG.CHRONICLE_RPC
+  );
+
+  const wallet = new ethers.Wallet(PRIVATE_KEY, provider);
+
+  const ethWalletProvider = new EthWalletProvider({ litNodeClient: client });
+
+  const authMethod = await ethWalletProvider.authenticate(wallet);
+
+  if (!authMethod) {
+    fail('Unable to authenticate with eth wallet provider');
+  }
+
+  return success(`authMethod created: ${JSON.stringify(authMethod)}`);
+}
+
+await testThis({ name: path.basename(import.meta.url), fn: main });

--- a/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
@@ -107,6 +107,16 @@ export default class EthWalletProvider extends BaseProvider {
     domain?: string;
     origin?: string;
   }): Promise<AuthMethod> {
+
+    if (!litNodeClient.latestBlockhash) {
+      throwError({
+        message:
+          'Eth Blockhash is undefined. Try connecting to the Lit network again.',
+        errorKind: LIT_ERROR.INVALID_ETH_BLOCKHASH.kind,
+        errorCode: LIT_ERROR.INVALID_ETH_BLOCKHASH.name,
+      });
+    }
+
     chain = chain || 'ethereum';
 
     let authSig: AuthSig;
@@ -153,15 +163,6 @@ export default class EthWalletProvider extends BaseProvider {
         address: address,
       };
     } else {
-      if (!litNodeClient.latestBlockhash) {
-        throwError({
-          message:
-            'Eth Blockhash is undefined. Try connecting to the Lit network again.',
-          errorKind: LIT_ERROR.INVALID_ETH_BLOCKHASH.kind,
-          errorCode: LIT_ERROR.INVALID_ETH_BLOCKHASH.name,
-        });
-      }
-
       authSig = await checkAndSignAuthMessage({
         chain,
         nonce: litNodeClient.latestBlockhash!,

--- a/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
@@ -25,13 +25,8 @@ export default class EthWalletProvider extends BaseProvider {
    */
   public origin: string;
 
-  constructor(options: EthWalletProviderOptions) {
-    super({
-      rpcUrl: '',
-      relay: null as any,
-      litNodeClient: null,
-      ...options,
-    });
+  constructor(options: EthWalletProviderOptions & BaseProviderOptions) {
+    super(options);
 
     try {
       this.domain = options.domain || window.location.hostname;

--- a/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
@@ -22,8 +22,14 @@ export default class EthWalletProvider extends BaseProvider {
    */
   public origin: string;
 
-  constructor(options: BaseProviderOptions & EthWalletProviderOptions) {
-    super(options);
+  constructor(options: EthWalletProviderOptions) {
+    super({
+      rpcUrl: '',
+      relay: null as any,
+      litNodeClient: null,
+      ...options,
+    });
+
     try {
       this.domain = options.domain || window.location.hostname;
       this.origin = options.origin || window.location.origin;
@@ -51,12 +57,11 @@ export default class EthWalletProvider extends BaseProvider {
     options?: EthWalletAuthenticateOptions
   ): Promise<AuthMethod> {
     const address = options?.address;
-    const signMessage = options?.signMessage;
     const chain = options?.chain || 'ethereum';
 
     let authSig: AuthSig;
 
-    if (address && signMessage) {
+    if (address && options?.signMessage) {
       // Get chain ID or default to Ethereum mainnet
       const selectedChain = LIT_CHAINS[chain];
       const chainId = selectedChain?.chainId ? selectedChain.chainId : 1;
@@ -81,7 +86,7 @@ export default class EthWalletProvider extends BaseProvider {
       const toSign: string = message.prepareMessage();
 
       // Use provided function to sign message
-      const signature = await signMessage(toSign);
+      const signature = await options.signMessage(toSign);
 
       authSig = {
         sig: signature,

--- a/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
@@ -54,9 +54,10 @@ export default class EthWalletProvider extends BaseProvider {
   public async authenticate(
     options?: EthWalletAuthenticateOptions
   ): Promise<AuthMethod> {
-
     if (!options) {
-      throw new Error("Options are required to authenticate with EthWalletProvider.");
+      throw new Error(
+        'Options are required to authenticate with EthWalletProvider.'
+      );
     }
 
     return EthWalletProvider.authenticate({
@@ -72,7 +73,7 @@ export default class EthWalletProvider extends BaseProvider {
 
   /**
    * Generate a wallet signature to use as an auth method
-   * 
+   *
    * @param {EthWalletAuthenticateOptions} options
    * @param {string} [options.address] - Address to sign with
    * @param {function} [options.signMessage] - Function to sign message with
@@ -81,7 +82,7 @@ export default class EthWalletProvider extends BaseProvider {
    * @returns {Promise<AuthMethod>} - Auth method object containing the auth signature
    * @static
    * @memberof EthWalletProvider
-   * 
+   *
    * @example
    * ```typescript
    *   const authMethod = await EthWalletProvider.authenticate({
@@ -107,7 +108,6 @@ export default class EthWalletProvider extends BaseProvider {
     domain?: string;
     origin?: string;
   }): Promise<AuthMethod> {
-
     if (!litNodeClient.latestBlockhash) {
       throwError({
         message:
@@ -122,10 +122,15 @@ export default class EthWalletProvider extends BaseProvider {
     let authSig: AuthSig;
 
     // convert to EIP-55 format or else SIWE complains
-    address = address || await signer?.getAddress!() || (signer as ethers.Wallet)?.address;
+    address =
+      address ||
+      (await signer?.getAddress!()) ||
+      (signer as ethers.Wallet)?.address;
 
     if (!address) {
-      throw new Error(`Address is required to authenticate with EthWalletProvider. Cannot find it in signer or options.`);
+      throw new Error(
+        `Address is required to authenticate with EthWalletProvider. Cannot find it in signer or options.`
+      );
     }
 
     address = ethers.utils.getAddress(address);

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -1527,6 +1527,12 @@ export interface EthWalletAuthenticateOptions extends BaseAuthenticateOptions {
    * When the auth signature expires
    */
   expiration?: string;
+
+  /**
+   * Get the address of the wallet
+   * @returns {string} - Ethereum wallet address
+   */
+  getAddress?: () => string;
 }
 
 export interface OtpAuthenticateOptions extends BaseAuthenticateOptions {


### PR DESCRIPTION
# Description

At the moment, if you want to create an eth wallet auth method from Lit Auth Client, you will need to provide an API key. This shouldn't be the case because it's all client side signing the siwe message, and all we do is wrap around their authSig as an access token as an auth method. 

# Proposed solution

Create a static `authenticate` method, and then the original method can consume the static method, so that it can still use the base methods that relies on the relayer 

```ts
  const authMethod = await EthWalletProvider.authenticate({
    signer: wallet,
    litNodeClient: client,
  });
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

## Test command
```
DEBUG=true NETWORK=cayenne yarn test:e2e:nodejs --filter=test-pkp-eth-wallet-provider.mjs
```

## Test result

```
✓    authMethod created: {"authMethodType":1,"accessToken":"{\"sig\":\"0x433c7c22d488dc604b610312c2ad074d1c3e339d42fb14a80430fee69637f6011cae28ed0fe7110fc6f9ffce276475daf243bdb6bab4d5253aa7da0440e45fc81b\",\"derivedVia\":\"web3.eth.personal.sign\",\"signedMessage\":\"localhost wants you to sign in with your Ethereum account:\\n0xeF71c2604f17Ec6Fc13409DF24EfdC440D240d30\\n\\n\\nURI: http://localhost\\nVersion: 1\\nChain ID: 1\\nNonce: 0x81347476f3c006acb4a7863d31de774d6b90c1600bcfb6af110b3ff7dbe28cd0\\nIssued At: 2024-04-11T22:32:46.376Z\\nExpiration Time: 2024-04-12T22:32:46.375Z\",\"address\":\"0xeF71c2604f17Ec6Fc13409DF24EfdC440D240d30\"}"} (12ms) 
```

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
