### PR TITLE
Fix/lit network must be provided of lit auth client

### DIFF
--- a/lit.config.json
+++ b/lit.config.json
@@ -46,9 +46,9 @@
     "debug": true,
     "sevAttestation": false,
     "CONTROLLER_AUTHSIG": {
-      "sig": "0x6c6447a53fe789fd0ae681c7698cb414985d006a00637906f412d292bbfd2e352e10af744428e3208df35d2d4065c767941eb4d7d502dfe569267705f0d4d5e61c",
+      "sig": "0xfb92424c176ef64e4e3303a736a756aba88d98962e54fb3f0c995c36788511511fa154a3c03a33b614266dd27a7cf3babd770d35c2aa1ae3f10b1edf0cc086d61c",
       "derivedVia": "web3.eth.personal.sign",
-      "signedMessage": "localhost wants you to sign in with your Ethereum account:\n0xeF71c2604f17Ec6Fc13409DF24EfdC440D240d37\n\nThis is a test statement.  You can put anything you want here.\n\nURI: https://localhost/login\nVersion: 1\nChain ID: 1\nNonce: 0x6cbca5687b3e317ecd4c2c5ef54aa6f8743c63f80dab435a981fa1fe29a2000f\nIssued At: 2024-03-12T13:34:47.589Z\nExpiration Time: 2024-03-12T14:34:47.584Z",
+      "signedMessage": "localhost wants you to sign in with your Ethereum account:\n0xeF71c2604f17Ec6Fc13409DF24EfdC440D240d37\n\nThis is a test statement.  You can put anything you want here.\n\nURI: https://localhost/login\nVersion: 1\nChain ID: 1\nNonce: 0x7d63756ab17120b5ba0beb8f250cd2803c21d7685f332247ef68cb55b3f5e0c1\nIssued At: 2024-04-12T14:26:45.227Z\nExpiration Time: 2024-04-12T15:26:45.224Z",
       "address": "0xeF71c2604f17Ec6Fc13409DF24EfdC440D240d37"
     },
     "CONTROLLER_WALLET": {

--- a/packages/lit-auth-client/src/lib/lit-auth-client.ts
+++ b/packages/lit-auth-client/src/lib/lit-auth-client.ts
@@ -87,8 +87,7 @@ export class LitAuthClient {
     if (options?.litNodeClient) {
       this.litNodeClient = options?.litNodeClient;
     } else {
-
-      if(!options.litNetwork){
+      if (!options.litNetwork) {
         throw new Error(`litNetwork is required to create a LitNodeClient`);
       }
 

--- a/packages/lit-auth-client/src/lib/lit-auth-client.ts
+++ b/packages/lit-auth-client/src/lib/lit-auth-client.ts
@@ -87,8 +87,13 @@ export class LitAuthClient {
     if (options?.litNodeClient) {
       this.litNodeClient = options?.litNodeClient;
     } else {
+
+      if(!options.litNetwork){
+        throw new Error(`litNetwork is required to create a LitNodeClient`);
+      }
+
       this.litNodeClient = new LitNodeClient({
-        litNetwork: 'cayenne',
+        litNetwork: options.litNetwork,
         debug: options.debug ?? false,
       });
     }

--- a/packages/lit-auth-client/src/lib/lit-auth-client.ts
+++ b/packages/lit-auth-client/src/lib/lit-auth-client.ts
@@ -109,7 +109,8 @@ export class LitAuthClient {
 
       if (!supportedNetworks.includes(this.litNodeClient.config.litNetwork)) {
         throw new Error(
-          `Unsupported litNetwork: ${this.litNodeClient.config.litNetwork
+          `Unsupported litNetwork: ${
+            this.litNodeClient.config.litNetwork
           }. Supported networks are: ${supportedNetworks.join(', ')}`
         );
       }

--- a/packages/lit-auth-client/src/lib/lit-auth-client.ts
+++ b/packages/lit-auth-client/src/lib/lit-auth-client.ts
@@ -88,9 +88,8 @@ export class LitAuthClient {
       this.litNodeClient = options?.litNodeClient;
     } else {
       if (!options.litNetwork) {
-        throw new Error(`litNetwork is required to create a LitNodeClient`);
+        console.warn(`litNetwork is required to create a LitNodeClient`);
       }
-
       this.litNodeClient = new LitNodeClient({
         litNetwork: options.litNetwork,
         debug: options.debug ?? false,
@@ -110,8 +109,7 @@ export class LitAuthClient {
 
       if (!supportedNetworks.includes(this.litNodeClient.config.litNetwork)) {
         throw new Error(
-          `Unsupported litNetwork: ${
-            this.litNodeClient.config.litNetwork
+          `Unsupported litNetwork: ${this.litNodeClient.config.litNetwork
           }. Supported networks are: ${supportedNetworks.join(', ')}`
         );
       }

--- a/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
@@ -54,9 +54,10 @@ export default class EthWalletProvider extends BaseProvider {
   public async authenticate(
     options?: EthWalletAuthenticateOptions
   ): Promise<AuthMethod> {
-
     if (!options) {
-      throw new Error("Options are required to authenticate with EthWalletProvider.");
+      throw new Error(
+        'Options are required to authenticate with EthWalletProvider.'
+      );
     }
 
     return EthWalletProvider.authenticate({
@@ -72,7 +73,7 @@ export default class EthWalletProvider extends BaseProvider {
 
   /**
    * Generate a wallet signature to use as an auth method
-   * 
+   *
    * @param {EthWalletAuthenticateOptions} options
    * @param {string} [options.address] - Address to sign with
    * @param {function} [options.signMessage] - Function to sign message with
@@ -81,7 +82,7 @@ export default class EthWalletProvider extends BaseProvider {
    * @returns {Promise<AuthMethod>} - Auth method object containing the auth signature
    * @static
    * @memberof EthWalletProvider
-   * 
+   *
    * @example
    * ```typescript
    *   const authMethod = await EthWalletProvider.authenticate({
@@ -107,7 +108,6 @@ export default class EthWalletProvider extends BaseProvider {
     domain?: string;
     origin?: string;
   }): Promise<AuthMethod> {
-
     if (!litNodeClient.latestBlockhash) {
       throwError({
         message:
@@ -122,10 +122,15 @@ export default class EthWalletProvider extends BaseProvider {
     let authSig: AuthSig;
 
     // convert to EIP-55 format or else SIWE complains
-    address = address || await signer?.getAddress!() || (signer as ethers.Wallet)?.address;
+    address =
+      address ||
+      (await signer?.getAddress!()) ||
+      (signer as ethers.Wallet)?.address;
 
     if (!address) {
-      throw new Error(`Address is required to authenticate with EthWalletProvider. Cannot find it in signer or options.`);
+      throw new Error(
+        `Address is required to authenticate with EthWalletProvider. Cannot find it in signer or options.`
+      );
     }
 
     address = ethers.utils.getAddress(address);

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -1179,7 +1179,7 @@ export interface LitAuthClientOptions {
 
   litOtpConfig?: OtpProviderOptions;
 
-  litNetwork?: LIT_NETWORKS_KEYS
+  litNetwork?: LIT_NETWORKS_KEYS;
 }
 
 export interface OtpSessionResult {

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -1178,6 +1178,8 @@ export interface LitAuthClientOptions {
   debug?: boolean;
 
   litOtpConfig?: OtpProviderOptions;
+
+  litNetwork?: LIT_NETWORKS_KEYS
 }
 
 export interface OtpSessionResult {


### PR DESCRIPTION
# Description

We should ~~force~~ **warn** users to provide `lit network` when initialising lit auth client, and we shouldn't default to `cayenne` 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update