### PR TITLE
feat(AMD Cert): Always fetch from CORS

### DIFF
--- a/lit.config.json
+++ b/lit.config.json
@@ -43,12 +43,12 @@
   },
   "CACHE": {
     "network": "cayenne",
-    "debug": false,
+    "debug": true,
     "sevAttestation": false,
     "CONTROLLER_AUTHSIG": {
-      "sig": "0x3ebf0dc7e847b9108ae5d66f69e3ef94b1e8022085d19cca2431a2f3857722b1272edd1181e713707f90a5a89c27fdda51eb659ab962e79f790acab36a5b37ec1c",
+      "sig": "0x01d7f16d2e1c79846d235c45e506bd866b0c9b0af05736ed6d2cd9de4a08d5dc1156a8884550df267b1cafc9a81bb029ed3348d15d53a6ae421ec848472c2c341b",
       "derivedVia": "web3.eth.personal.sign",
-      "signedMessage": "localhost wants you to sign in with your Ethereum account:\n0xeF71c2604f17Ec6Fc13409DF24EfdC440D240d37\n\nThis is a test statement.  You can put anything you want here.\n\nURI: https://localhost/login\nVersion: 1\nChain ID: 1\nNonce: 0x69d030761ca65a79b040360e92f50a3f4462fa412acf0740aaa52da75cb53aaa\nIssued At: 2024-04-15T17:12:43.836Z\nExpiration Time: 2024-04-15T18:12:43.829Z",
+      "signedMessage": "localhost wants you to sign in with your Ethereum account:\n0xeF71c2604f17Ec6Fc13409DF24EfdC440D240d37\n\nThis is a test statement.  You can put anything you want here.\n\nURI: https://localhost/login\nVersion: 1\nChain ID: 1\nNonce: 0x6a1c254dc3cad8dcdd02e02ba9d5c0c706ce4b1e040bdfc06e87fb360644d81c\nIssued At: 2024-04-15T17:19:38.839Z\nExpiration Time: 2024-04-15T18:19:38.837Z",
       "address": "0xeF71c2604f17Ec6Fc13409DF24EfdC440D240d37"
     },
     "CONTROLLER_WALLET": {

--- a/lit.config.json
+++ b/lit.config.json
@@ -43,12 +43,12 @@
   },
   "CACHE": {
     "network": "cayenne",
-    "debug": true,
+    "debug": false,
     "sevAttestation": false,
     "CONTROLLER_AUTHSIG": {
-      "sig": "0x6c6447a53fe789fd0ae681c7698cb414985d006a00637906f412d292bbfd2e352e10af744428e3208df35d2d4065c767941eb4d7d502dfe569267705f0d4d5e61c",
+      "sig": "0x3ebf0dc7e847b9108ae5d66f69e3ef94b1e8022085d19cca2431a2f3857722b1272edd1181e713707f90a5a89c27fdda51eb659ab962e79f790acab36a5b37ec1c",
       "derivedVia": "web3.eth.personal.sign",
-      "signedMessage": "localhost wants you to sign in with your Ethereum account:\n0xeF71c2604f17Ec6Fc13409DF24EfdC440D240d37\n\nThis is a test statement.  You can put anything you want here.\n\nURI: https://localhost/login\nVersion: 1\nChain ID: 1\nNonce: 0x6cbca5687b3e317ecd4c2c5ef54aa6f8743c63f80dab435a981fa1fe29a2000f\nIssued At: 2024-03-12T13:34:47.589Z\nExpiration Time: 2024-03-12T14:34:47.584Z",
+      "signedMessage": "localhost wants you to sign in with your Ethereum account:\n0xeF71c2604f17Ec6Fc13409DF24EfdC440D240d37\n\nThis is a test statement.  You can put anything you want here.\n\nURI: https://localhost/login\nVersion: 1\nChain ID: 1\nNonce: 0x69d030761ca65a79b040360e92f50a3f4462fa412acf0740aaa52da75cb53aaa\nIssued At: 2024-04-15T17:12:43.836Z\nExpiration Time: 2024-04-15T18:12:43.829Z",
       "address": "0xeF71c2604f17Ec6Fc13409DF24EfdC440D240d37"
     },
     "CONTROLLER_WALLET": {

--- a/packages/crypto/src/lib/crypto.ts
+++ b/packages/crypto/src/lib/crypto.ts
@@ -373,7 +373,9 @@ function base64ToBufferAsync(base64) {
 async function getAmdCert(url: string): Promise<Uint8Array> {
   const proxyUrl = `${LIT_CORS_PROXY}/${url}`;
 
-  log(`[getAmdCert] Fetching AMD cert using proxy URL ${proxyUrl} due to CORS restrictions.`);
+  log(
+    `[getAmdCert] Fetching AMD cert using proxy URL ${proxyUrl} due to CORS restrictions.`
+  );
 
   let response;
 

--- a/packages/crypto/src/lib/crypto.ts
+++ b/packages/crypto/src/lib/crypto.ts
@@ -29,8 +29,7 @@ if (!globalThis.wasmExports) {
 
     if (!globalThis.jestTesting) {
       log(
-        `✅ [BLS SDK] wasmExports loaded. ${
-          Object.keys(exports).length
+        `✅ [BLS SDK] wasmExports loaded. ${Object.keys(exports).length
         } functions available. Run 'wasmExports' in the console to see them.`
       );
     }
@@ -52,8 +51,7 @@ if (!globalThis.wasmECDSA) {
 
     if (!globalThis.jestTesting) {
       log(
-        `✅ [ECDSA SDK ${env}] wasmECDSA loaded. ${
-          Object.keys(wasmECDSA).length
+        `✅ [ECDSA SDK ${env}] wasmECDSA loaded. ${Object.keys(wasmECDSA).length
         } functions available. Run 'wasmECDSA' in the console to see them.`
       );
     }
@@ -66,8 +64,7 @@ if (!globalThis.wasmSevSnpUtils) {
 
     if (!globalThis.jestTesting) {
       log(
-        `✅ [SEV SNP Utils SDK] wasmSevSnpUtils loaded. ${
-          Object.keys(exports).length
+        `✅ [SEV SNP Utils SDK] wasmSevSnpUtils loaded. ${Object.keys(exports).length
         } functions available. Run 'wasmSevSnpUtils' in the console to see them.`
       );
     }
@@ -363,8 +360,11 @@ function base64ToBufferAsync(base64) {
 
 /**
  * Asynchronously fetches an AMD certification from a specified URL using a CORS proxy.
- * This approach is used to bypass CORS restrictions when accessing external APIs that do not support CORS.
- * It attempts to fetch the AMD cert through a proxy and if the proxy fetch fails, it throws an error.
+ * The primary purpose of using a CORS proxy is to avoid being rate-limited by AMD.
+ * The function attempts to fetch the AMD cert through a proxy, and if the proxy fetch fails,
+ * it retries directly from the original URL.
+ * 
+ * Note: This project is hosted on heroku and uses this codebase: https://github.com/LIT-Protocol/cors-proxy-amd
  *
  * @param url The URL from which to fetch the AMD cert.
  * @returns A Promise that resolves to a Uint8Array containing the AMD certification data.
@@ -386,12 +386,12 @@ async function getAmdCert(url: string): Promise<Uint8Array> {
     return new Uint8Array(arrayBuffer);
   }
 
-   try {
+  try {
     return await fetchAsUint8Array(proxyUrl);
   } catch (e) {
-      log(`[getAmdCert] Failed to fetch AMD cert from proxy:`, e);
+    log(`[getAmdCert] Failed to fetch AMD cert from proxy:`, e);
   }
-  
+
   // Try direct fetch only if proxy fails
   log('[getAmdCert] Attempting to fetch directly without proxy.');
   try {

--- a/packages/crypto/src/lib/crypto.ts
+++ b/packages/crypto/src/lib/crypto.ts
@@ -373,27 +373,27 @@ function base64ToBufferAsync(base64) {
 async function getAmdCert(url: string): Promise<Uint8Array> {
   const proxyUrl = `${LIT_CORS_PROXY}/${url}`;
 
-  console.log(`Fetching AMD cert using proxy URL due to CORS restrictions.`);
+  log(`[getAmdCert] Fetching AMD cert using proxy URL ${proxyUrl} due to CORS restrictions.`);
 
   let response;
 
   try {
     response = await fetch(proxyUrl);
     if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
+      throw new Error(`[getAmdCert] HTTP error! status: ${response.status}`);
     }
   } catch (e) {
-    console.error(`Failed to fetch AMD cert from proxy:`, e);
+    log(`[getAmdCert] Failed to fetch AMD cert from proxy:`, e);
 
     // Try direct fetch only if proxy fails
-    console.log('Attempting to fetch directly without proxy.');
+    log('[getAmdCert] Attempting to fetch directly without proxy.');
     try {
       response = await fetch(url);
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
     } catch (e) {
-      console.error('Direct fetch also failed:', e);
+      log('[getAmdCert] Direct fetch also failed:', e);
       throw e; // Re-throw to signal that both methods failed
     }
   }

--- a/packages/crypto/src/lib/crypto.ts
+++ b/packages/crypto/src/lib/crypto.ts
@@ -20,6 +20,8 @@ import { nacl } from '@lit-protocol/nacl';
 import { SIGTYPE } from '@lit-protocol/constants';
 import { CombinedECDSASignature } from '@lit-protocol/types';
 
+const LIT_CORS_PROXY = `https://cors.litgateway.com`
+
 // if 'wasmExports' is not available, we need to initialize the BLS SDK
 if (!globalThis.wasmExports) {
   blsSdk.initWasmBlsSdk().then((exports) => {
@@ -27,8 +29,7 @@ if (!globalThis.wasmExports) {
 
     if (!globalThis.jestTesting) {
       log(
-        `✅ [BLS SDK] wasmExports loaded. ${
-          Object.keys(exports).length
+        `✅ [BLS SDK] wasmExports loaded. ${Object.keys(exports).length
         } functions available. Run 'wasmExports' in the console to see them.`
       );
     }
@@ -50,8 +51,7 @@ if (!globalThis.wasmECDSA) {
 
     if (!globalThis.jestTesting) {
       log(
-        `✅ [ECDSA SDK ${env}] wasmECDSA loaded. ${
-          Object.keys(wasmECDSA).length
+        `✅ [ECDSA SDK ${env}] wasmECDSA loaded. ${Object.keys(wasmECDSA).length
         } functions available. Run 'wasmECDSA' in the console to see them.`
       );
     }
@@ -64,8 +64,7 @@ if (!globalThis.wasmSevSnpUtils) {
 
     if (!globalThis.jestTesting) {
       log(
-        `✅ [SEV SNP Utils SDK] wasmSevSnpUtils loaded. ${
-          Object.keys(exports).length
+        `✅ [SEV SNP Utils SDK] wasmSevSnpUtils loaded. ${Object.keys(exports).length
         } functions available. Run 'wasmSevSnpUtils' in the console to see them.`
       );
     }
@@ -359,14 +358,44 @@ function base64ToBufferAsync(base64) {
     });
 }
 
-async function getAmdCert(url: string) {
-  // unfortunately, until AMD enables CORS, we have to use a proxy when in the browser
-  // This project is hosted on heroku and uses this codebase: https://github.com/LIT-Protocol/cors-proxy-amd
-  if (isBrowser()) {
-    // CORS proxy url
-    url = `https://cors.litgateway.com/${url}`;
+/**
+ * Asynchronously fetches an AMD certification from a specified URL using a CORS proxy.
+ * This approach is used to bypass CORS restrictions when accessing external APIs that do not support CORS.
+ * It attempts to fetch the AMD cert through a proxy and if the proxy fetch fails, it throws an error.
+ * 
+ * @param url The URL from which to fetch the AMD cert.
+ * @returns A Promise that resolves to a Uint8Array containing the AMD certification data.
+ * @throws An error detailing HTTP or network issues encountered during the fetch process.
+ */
+async function getAmdCert(url: string): Promise<Uint8Array> {
+
+  const proxyUrl = `${LIT_CORS_PROXY}/${url}`;
+
+  console.log(`Fetching AMD cert using proxy URL due to CORS restrictions.`);
+
+  let response;
+
+  try {
+    response = await fetch(proxyUrl);
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+  } catch (e) {
+    console.error(`Failed to fetch AMD cert from proxy:`, e);
+  
+    // Try direct fetch only if proxy fails
+    console.log("Attempting to fetch directly without proxy.");
+    try {
+      response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+    } catch (e) {
+      console.error('Direct fetch also failed:', e);
+      throw e; // Re-throw to signal that both methods failed
+    }
   }
-  const response = await fetch(url);
+
   const arrayBuffer = await response.arrayBuffer();
   return new Uint8Array(arrayBuffer);
 }

--- a/packages/crypto/src/lib/crypto.ts
+++ b/packages/crypto/src/lib/crypto.ts
@@ -20,7 +20,7 @@ import { nacl } from '@lit-protocol/nacl';
 import { SIGTYPE } from '@lit-protocol/constants';
 import { CombinedECDSASignature } from '@lit-protocol/types';
 
-const LIT_CORS_PROXY = `https://cors.litgateway.com`
+const LIT_CORS_PROXY = `https://cors.litgateway.com`;
 
 // if 'wasmExports' is not available, we need to initialize the BLS SDK
 if (!globalThis.wasmExports) {
@@ -29,7 +29,8 @@ if (!globalThis.wasmExports) {
 
     if (!globalThis.jestTesting) {
       log(
-        `✅ [BLS SDK] wasmExports loaded. ${Object.keys(exports).length
+        `✅ [BLS SDK] wasmExports loaded. ${
+          Object.keys(exports).length
         } functions available. Run 'wasmExports' in the console to see them.`
       );
     }
@@ -51,7 +52,8 @@ if (!globalThis.wasmECDSA) {
 
     if (!globalThis.jestTesting) {
       log(
-        `✅ [ECDSA SDK ${env}] wasmECDSA loaded. ${Object.keys(wasmECDSA).length
+        `✅ [ECDSA SDK ${env}] wasmECDSA loaded. ${
+          Object.keys(wasmECDSA).length
         } functions available. Run 'wasmECDSA' in the console to see them.`
       );
     }
@@ -64,7 +66,8 @@ if (!globalThis.wasmSevSnpUtils) {
 
     if (!globalThis.jestTesting) {
       log(
-        `✅ [SEV SNP Utils SDK] wasmSevSnpUtils loaded. ${Object.keys(exports).length
+        `✅ [SEV SNP Utils SDK] wasmSevSnpUtils loaded. ${
+          Object.keys(exports).length
         } functions available. Run 'wasmSevSnpUtils' in the console to see them.`
       );
     }
@@ -362,13 +365,12 @@ function base64ToBufferAsync(base64) {
  * Asynchronously fetches an AMD certification from a specified URL using a CORS proxy.
  * This approach is used to bypass CORS restrictions when accessing external APIs that do not support CORS.
  * It attempts to fetch the AMD cert through a proxy and if the proxy fetch fails, it throws an error.
- * 
+ *
  * @param url The URL from which to fetch the AMD cert.
  * @returns A Promise that resolves to a Uint8Array containing the AMD certification data.
  * @throws An error detailing HTTP or network issues encountered during the fetch process.
  */
 async function getAmdCert(url: string): Promise<Uint8Array> {
-
   const proxyUrl = `${LIT_CORS_PROXY}/${url}`;
 
   console.log(`Fetching AMD cert using proxy URL due to CORS restrictions.`);
@@ -382,9 +384,9 @@ async function getAmdCert(url: string): Promise<Uint8Array> {
     }
   } catch (e) {
     console.error(`Failed to fetch AMD cert from proxy:`, e);
-  
+
     // Try direct fetch only if proxy fails
-    console.log("Attempting to fetch directly without proxy.");
+    console.log('Attempting to fetch directly without proxy.');
     try {
       response = await fetch(url);
       if (!response.ok) {

--- a/packages/crypto/src/lib/crypto.ts
+++ b/packages/crypto/src/lib/crypto.ts
@@ -377,7 +377,7 @@ async function getAmdCert(url: string): Promise<Uint8Array> {
   const proxyUrl = `${LIT_CORS_PROXY}/${url}`;
 
   log(
-    `[getAmdCert] Fetching AMD cert using proxy URL ${proxyUrl} due to CORS restrictions.`
+    `[getAmdCert] Fetching AMD cert using proxy URL ${proxyUrl} to manage CORS restrictions and to avoid being rate limited by AMD.`
   );
 
   async function fetchAsUint8Array(targetUrl) {
@@ -397,15 +397,13 @@ async function getAmdCert(url: string): Promise<Uint8Array> {
 
   // Try direct fetch only if proxy fails
   log('[getAmdCert] Attempting to fetch directly without proxy.');
+
   try {
     return await fetchAsUint8Array(url);
   } catch (e) {
     log('[getAmdCert] Direct fetch also failed:', e);
     throw e; // Re-throw to signal that both methods failed
   }
-
-  const arrayBuffer = await response.arrayBuffer();
-  return new Uint8Array(arrayBuffer);
 }
 
 /**

--- a/packages/crypto/src/lib/crypto.ts
+++ b/packages/crypto/src/lib/crypto.ts
@@ -29,7 +29,8 @@ if (!globalThis.wasmExports) {
 
     if (!globalThis.jestTesting) {
       log(
-        `✅ [BLS SDK] wasmExports loaded. ${Object.keys(exports).length
+        `✅ [BLS SDK] wasmExports loaded. ${
+          Object.keys(exports).length
         } functions available. Run 'wasmExports' in the console to see them.`
       );
     }
@@ -51,7 +52,8 @@ if (!globalThis.wasmECDSA) {
 
     if (!globalThis.jestTesting) {
       log(
-        `✅ [ECDSA SDK ${env}] wasmECDSA loaded. ${Object.keys(wasmECDSA).length
+        `✅ [ECDSA SDK ${env}] wasmECDSA loaded. ${
+          Object.keys(wasmECDSA).length
         } functions available. Run 'wasmECDSA' in the console to see them.`
       );
     }
@@ -64,7 +66,8 @@ if (!globalThis.wasmSevSnpUtils) {
 
     if (!globalThis.jestTesting) {
       log(
-        `✅ [SEV SNP Utils SDK] wasmSevSnpUtils loaded. ${Object.keys(exports).length
+        `✅ [SEV SNP Utils SDK] wasmSevSnpUtils loaded. ${
+          Object.keys(exports).length
         } functions available. Run 'wasmSevSnpUtils' in the console to see them.`
       );
     }
@@ -363,7 +366,7 @@ function base64ToBufferAsync(base64) {
  * The primary purpose of using a CORS proxy is to avoid being rate-limited by AMD.
  * The function attempts to fetch the AMD cert through a proxy, and if the proxy fetch fails,
  * it retries directly from the original URL.
- * 
+ *
  * Note: This project is hosted on heroku and uses this codebase: https://github.com/LIT-Protocol/cors-proxy-amd
  *
  * @param url The URL from which to fetch the AMD cert.
@@ -400,7 +403,6 @@ async function getAmdCert(url: string): Promise<Uint8Array> {
     log('[getAmdCert] Direct fetch also failed:', e);
     throw e; // Re-throw to signal that both methods failed
   }
-
 
   const arrayBuffer = await response.arrayBuffer();
   return new Uint8Array(arrayBuffer);


### PR DESCRIPTION
# Description

AMD certificate endpoints are rate limited, so we are going to always use our Lit CORS server caches certificates locally to avoid hitting the rate limit.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

## Test Command

```
DEBUG=true yarn test:e2e:node --filter=multi-network          
```
## Result
<img width="1386" alt="image" src="https://github.com/LIT-Protocol/js-sdk/assets/4049673/7fc36c08-9199-4d6e-853d-e8b5f36187af">

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
