### PR TITLE
Fix doc strings for GetSessionSigsProps

### DIFF
--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -889,10 +889,23 @@ export interface GetSignSessionKeySharesProp {
 }
 
 export interface GetSessionSigsProps {
-  // When this session signature will expire.  The user will have to reauthenticate after this time using whatever auth method you set up.  This means you will have to call this signSessionKey function again to get a new session signature.  This is a RFC3339 timestamp.  The default is 24 hours from now.
+  /**
+   * When this session signature will expire.
+   * The user will have to reauthenticate after this time using whatever auth method you set up.
+   * This means you will have to call this signSessionKey function again to get a new session signature.
+   * This is a RFC3339 timestamp.
+   * The default is 24 hours from now.
+   *
+   * Example value:
+   *     new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString(), // 24 hours
+   */
   expiration?: any;
 
-  //   The chain to use for the session signature.  This is the chain that will be used to sign the session key.  If you're using EVM then this probably doesn't matter at all.
+  /**
+   * The chain to use for the session signature.
+   * This is the chain that will be used to sign the session key.
+   * If you're using EVM then this probably doesn't matter at all.
+   **/
   chain: Chain;
 
   /**
@@ -913,20 +926,35 @@ export interface GetSessionSigsProps {
    */
   sessionCapabilityObject?: ISessionCapabilityObject;
 
-  //   If you want to ask Metamask to try and switch the user's chain, you may pass true here.  This will only work if the user is using Metamask.  If the user is not using Metamask, then this will be ignored.
+  /**
+   * If you want to ask Metamask to try and switch the user's chain, you may pass `true` here.
+   * This will only work if the user is using Metamask.
+   * If the user is not using Metamask, then this will be ignored.
+   **/
   switchChain?: boolean;
 
-  //   This is a callback that will be called if the user needs to authenticate using a PKP.  For example, if the user has no wallet, but owns a Lit PKP though something like Google Oauth, then you can use this callback to prompt the user to authenticate with their PKP.  This callback should use the LitNodeClient.signSessionKey function to get a session signature for the user from their PKP.  If you don't pass this callback, then the user will be prompted to authenticate with their wallet, like metamask.
+  /**
+   * This is a callback that will be called if the user needs to authenticate using a PKP.
+   * For example, if the user has no wallet, but owns a Lit PKP though something like Google Oauth, then you can use this callback to prompt the user to authenticate with their PKP.
+   * This callback should use the `LitNodeClient.signSessionKey` function to get a session signature for the user from their PKP.
+   * If you don't pass this callback, then the user will be prompted to authenticate with their wallet, like metamask.
+   */
   authNeededCallback?: AuthCallback;
 
-  // The serialized session key pair to sign. If not provided, a session key pair will be fetched from localStorge or generated.
+  /**
+   * The serialized session key pair to sign.
+   * If not provided, a session key pair will be fetched from localStorge or generated.
+   */
   sessionKey?: any;
 
   // rateLimitAuthSig: AuthSig;
 
-  // Used for delegation of Capacity Credit. This signature will be checked for proof of capacity credit.
-  // on both manzano and habanero networks capacity credit proof is required.
-  // see more here: https://developer.litprotocol.com/v3/sdk/capacity-credits
+  /**
+   * Used for delegation of Capacity Credit. This signature will be checked for proof of capacity credit.
+   * On both manzano and habanero networks capacity credit proof is required.
+   *
+   * See more here: https://developer.litprotocol.com/v3/sdk/capacity-credits
+   */
   capacityDelegationAuthSig?: AuthSig;
 }
 


### PR DESCRIPTION
# Description

TypeScript displays `/** ... */` comments on properties but ignores `// ...` comments. This PR fixes comment docs for a single interface (the one I'm currently dealing with).

Also added an example for the `expiration` field.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

