### PR TITLE
fix: change call to 'checkAndSignAuthMessage' in eth provider authenticate

### DIFF
--- a/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
@@ -13,7 +13,7 @@ import {
   LitNodeClient,
   checkAndSignAuthMessage,
 } from '@lit-protocol/lit-node-client';
-import { log, throwError } from '@lit-protocol/misc';
+import { log, throwError, isBrowser } from '@lit-protocol/misc';
 
 export default class EthWalletProvider extends BaseProvider {
   /**
@@ -168,9 +168,17 @@ export default class EthWalletProvider extends BaseProvider {
         address: address,
       };
     } else {
-      throw new Error(
-        "Could not find a 'signMessage' implementation on the provided signer instance"
-      );
+      // only allow calls if we are in a browser as it assumes browser extension wallets are used.
+      if (isBrowser()) {
+        authSig = await checkAndSignAuthMessage({
+          chain,
+          nonce: nonce,
+        });
+      } else {
+        throw new Error(
+          "Could not find a 'signMessage' implementation on the provided signer instance"
+        );
+      }
     }
 
     const authMethod = {

--- a/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
@@ -134,7 +134,7 @@ export default class EthWalletProvider extends BaseProvider {
     }
 
     address = ethers.utils.getAddress(address);
-
+    const nonce = await litNodeClient.getLatestBlockhash();
     if (signer?.signMessage) {
       // Get chain ID or default to Ethereum mainnet
       const selectedChain = LIT_CHAINS[chain];
@@ -152,7 +152,7 @@ export default class EthWalletProvider extends BaseProvider {
         version: '1',
         chainId,
         expirationTime: expiration,
-        nonce: litNodeClient.latestBlockhash!,
+        nonce: nonce,
       };
 
       const message: SiweMessage = new SiweMessage(preparedMessage);
@@ -168,10 +168,9 @@ export default class EthWalletProvider extends BaseProvider {
         address: address,
       };
     } else {
-      authSig = await checkAndSignAuthMessage({
-        chain,
-        nonce: litNodeClient.latestBlockhash!,
-      });
+      throw new Error(
+        "Could not find a 'signMessage' implementation on the provided signer instance"
+      );
     }
 
     const authMethod = {


### PR DESCRIPTION
# Description

- Refactors access to the `latestBlockHash` to use `getLatestBlockhash` which will force re-syncing if needed.
- wraps a call to `checkAndSignAuthMessage` for use only within a browser context as currently the implementation will assume access to a global object for wallet interactions typically only found within browser plugin models. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran current e2e testing and confirmed signatures from a `signer` with a `signMessage` implementation

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
