### PR TITLE
feat: allow cert caching if local storage is defined

### DIFF
--- a/e2e-nodejs/group-connection/test-connection-cert-caching.mjs
+++ b/e2e-nodejs/group-connection/test-connection-cert-caching.mjs
@@ -1,0 +1,53 @@
+import path from 'path';
+import { success, fail, testThis, log } from '../../tools/scripts/utils.mjs';
+import { LitNodeClient } from '@lit-protocol/lit-node-client';
+import { LocalStorage } from 'node-localstorage';
+export async function main() {
+  const networks = ['habanero', 'manzano'];
+  const storageProvider = new LocalStorage('./storage.test.db');
+  for (const network of networks) {
+    // ==================== Test Logic ====================
+    const client = new LitNodeClient({
+      litNetwork: network,
+      debug: globalThis.LitCI.debug,
+      storageProvider: {
+        provider: storageProvider,
+      },
+    });
+    log(`connecting to ${network.toUpperCase()}...`);
+    await client.connect();
+
+    // ==================== Post-Validation ====================
+    if (!client.ready) {
+      return fail('client not ready');
+    }
+    if (client.config.litNetwork !== network) {
+      return fail(`client not connected to ${network}`);
+    }
+
+    if (storageProvider.length < 1) {
+      fail(`cache is not hydrated with certificates`);
+    }
+
+    if (storageProvider.length < client.config.bootstrapUrls) {
+      fail(
+        `cache is not hydrated with enough certificates found: ${storageProvider.length} need ${client.config.bootstrapUrls.length}`
+      );
+    }
+    for (let i = 0; i < storageProvider.length; i++) {
+      const key = storageProvider.key(i);
+      if (!key.includes('https://kdsintf.amd.com/vcek/v1/Milan/')) {
+        fail(
+          'found cache item which does not match indexing schema should contain: https://kdsintf.amd.com/vcek/v1/Milan/'
+        );
+      }
+    }
+  }
+
+  // ==================== Success ====================
+  return success(
+    `Connected to ${networks.join(', ')} and found certs in cache`
+  );
+}
+
+await testThis({ name: path.basename(import.meta.url), fn: main });

--- a/e2e-nodejs/group-connection/test-connection-cert-caching.mjs
+++ b/e2e-nodejs/group-connection/test-connection-cert-caching.mjs
@@ -36,7 +36,7 @@ export async function main() {
     }
     for (let i = 0; i < storageProvider.length; i++) {
       const key = storageProvider.key(i);
-      if (!key.includes('https://kdsintf.amd.com/vcek/')) {
+      if (!key.includes('https://kdsintf.amd.com/')) {
         fail(
           'found cache item which does not match indexing schema should contain: https://kdsintf.amd.com/vcek/v1/Milan/'
         );

--- a/e2e-nodejs/group-connection/test-connection-cert-caching.mjs
+++ b/e2e-nodejs/group-connection/test-connection-cert-caching.mjs
@@ -36,7 +36,7 @@ export async function main() {
     }
     for (let i = 0; i < storageProvider.length; i++) {
       const key = storageProvider.key(i);
-      if (!key.includes('https://kdsintf.amd.com/vcek/v1/Milan/')) {
+      if (!key.includes('https://kdsintf.amd.com/vcek/')) {
         fail(
           'found cache item which does not match indexing schema should contain: https://kdsintf.amd.com/vcek/v1/Milan/'
         );

--- a/packages/crypto/src/lib/crypto.ts
+++ b/packages/crypto/src/lib/crypto.ts
@@ -481,8 +481,9 @@ export const checkSevSnpAttestation = async (
   // get the VCEK certificate
   let vcekCert;
   const vcekUrl = sevSnpUtilsSdk.get_vcek_url(report);
-  // if browser, use local storage
-  if (isBrowser()) {
+  // use local storage if we have one available
+  if (globalThis.localStorage) {
+    log('Using local storage for certificate caching');
     vcekCert = localStorage.getItem(vcekUrl);
     if (vcekCert) {
       vcekCert = uint8arrayFromString(vcekCert, 'base64');


### PR DESCRIPTION
# Description

Changes a conditional check for storing AMD SEV SNP certificates in `localstorage` to now check if the api is available rather than doing a check for a browser environment. this will allow for caching in local storage in non browser environments if the api is available. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

A new `connection` e2e test has been added which defines a `localstorage` provider and checks that certs have been cached after `connect` finishes.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
