### PR TITLE
Feature/lit 3017 auth unification migrate actual tests

### DIFF
--- a/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptFile.ts
+++ b/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptFile.ts
@@ -6,6 +6,7 @@ import { LitAccessControlConditionResource } from '@lit-protocol/auth-helpers';
 import { getPkpSessionSigs } from 'local-tests/setup/session-sigs/get-pkp-session-sigs';
 import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 import { log } from '@lit-protocol/misc';
+import { getLitActionSessionSigs } from 'local-tests/setup/session-sigs/get-lit-action-session-sigs';
 
 /**
  * Test Commands:
@@ -28,13 +29,13 @@ export const testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptFile =
       userAddress: alice.authMethodOwnedPkp.ethAddress,
     });
 
-    const pkpSessionSigs = await getPkpSessionSigs(devEnv, alice);
+    const litActionSessionSigs = await getLitActionSessionSigs(devEnv, alice);
 
     const encryptRes = await LitJsSdk.encryptString(
       {
         accessControlConditions: accs,
         chain: 'ethereum',
-        sessionSigs: pkpSessionSigs,
+        sessionSigs: litActionSessionSigs,
         dataToEncrypt: 'Hello world',
       },
       devEnv.litNodeClient as unknown as ILitNodeClient

--- a/packages/encryption/src/lib/encryption.ts
+++ b/packages/encryption/src/lib/encryption.ts
@@ -126,7 +126,7 @@ export async function decryptFromJson<T extends DecryptFromJsonProps>(
     ? ReturnType<typeof decryptToString>
     : never
 > {
-  const { authSig, sessionSigs, parsedJsonData, litNodeClient } = params;
+  const { sessionSigs, parsedJsonData, litNodeClient } = params;
 
   // -- validate
   const paramsIsSafe = safeParams({
@@ -153,7 +153,6 @@ export async function decryptFromJson<T extends DecryptFromJsonProps>(
         ciphertext: parsedJsonData.ciphertext,
         dataToEncryptHash: parsedJsonData.dataToEncryptHash,
         chain: parsedJsonData.chain,
-        authSig,
         sessionSigs,
       },
       litNodeClient
@@ -169,7 +168,6 @@ export async function decryptFromJson<T extends DecryptFromJsonProps>(
         ciphertext: parsedJsonData.ciphertext,
         dataToEncryptHash: parsedJsonData.dataToEncryptHash,
         chain: parsedJsonData.chain,
-        authSig,
         sessionSigs,
       },
       litNodeClient
@@ -444,7 +442,6 @@ export const encryptFileAndZipWithMetadata = async (
   params: EncryptFileAndZipWithMetadataProps
 ): Promise<any> => {
   const {
-    authSig,
     sessionSigs,
     accessControlConditions,
     evmContractConditions,
@@ -460,7 +457,6 @@ export const encryptFileAndZipWithMetadata = async (
   const paramsIsSafe = safeParams({
     functionName: 'encryptFileAndZipWithMetadata',
     params: {
-      authSig,
       sessionSigs,
       accessControlConditions,
       evmContractConditions,
@@ -545,13 +541,12 @@ export const encryptFileAndZipWithMetadata = async (
 export const decryptZipFileWithMetadata = async (
   params: DecryptZipFileWithMetadataProps
 ): Promise<DecryptZipFileWithMetadata | undefined> => {
-  const { authSig, sessionSigs, file, litNodeClient } = params;
+  const { sessionSigs, file, litNodeClient } = params;
 
   // -- validate
   const paramsIsSafe = safeParams({
     functionName: 'decryptZipFileWithMetadata',
     params: {
-      authSig,
       sessionSigs,
       file,
       litNodeClient,

--- a/packages/lit-auth-client/src/lib/providers/BaseProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/BaseProvider.ts
@@ -167,7 +167,7 @@ export abstract class BaseProvider {
 
         // common data for the signSessionKey function call
         const commonData = {
-          sessionKey: params.sessionSigsParams.sessionKey,
+          sessionKey: sessionKey,
           statement: authCallbackParams.statement,
           pkpPublicKey: params.pkpPublicKey,
           expiration: authCallbackParams.expiration,

--- a/packages/lit-auth-client/src/lib/providers/BaseProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/BaseProvider.ts
@@ -178,29 +178,20 @@ export abstract class BaseProvider {
           }),
         };
 
-        // prepare auth-specific data based on the authentication method
-        let authSpecificData = {};
-
         if (params.authMethod.authMethodType === AuthMethodType.EthWallet) {
-          authSpecificData = {
-            authSig: JSON.parse(params.authMethod.accessToken),
+          const authSig = JSON.parse(params.authMethod.accessToken);
+
+          response = await nodeClient.signSessionKey({
+            ...commonData,
+            authSig: authSig,
             authMethods: [],
-          };
+          });
         } else {
-          authSpecificData = {
+          response = await nodeClient.signSessionKey({
+            ...commonData,
             authMethods: [params.authMethod],
-          };
+          });
         }
-
-        // Merge the common and auth-specific data
-        response = await nodeClient.signSessionKey({
-          // default
-          authMethods: [],
-
-          // override
-          ...commonData,
-          ...authSpecificData,
-        });
 
         return response.authSig;
       };

--- a/packages/lit-auth-client/src/lib/providers/BaseProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/BaseProvider.ts
@@ -200,6 +200,7 @@ export abstract class BaseProvider {
     // Generate session sigs with the given session params
     const sessionSigs = await this.litNodeClient.getSessionSigs({
       ...params.sessionSigsParams,
+      sessionKey,
       authNeededCallback,
     });
 

--- a/packages/lit-auth-client/src/lib/providers/BaseProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/BaseProvider.ts
@@ -142,6 +142,10 @@ export abstract class BaseProvider {
 
     let authNeededCallback = params.sessionSigsParams.authNeededCallback;
 
+    // If no session key is provided, generate a new session key from the LitNodeClient
+    const sessionKey =
+      params.sessionSigsParams.sessionKey || this.litNodeClient.getSessionKey();
+
     // If no authNeededCallback is provided, create one that uses the provided PKP and auth method
     // to sign a session key and return an auth sig
     if (!authNeededCallback) {
@@ -163,7 +167,7 @@ export abstract class BaseProvider {
 
         // common data for the signSessionKey function call
         const commonData = {
-          sessionKey: params.sessionSigsParams.sessionKey,
+          sessionKey: sessionKey,
           statement: authCallbackParams.statement,
           pkpPublicKey: params.pkpPublicKey,
           expiration: authCallbackParams.expiration,

--- a/packages/lit-auth-client/src/lib/providers/BaseProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/BaseProvider.ts
@@ -167,7 +167,7 @@ export abstract class BaseProvider {
 
         // common data for the signSessionKey function call
         const commonData = {
-          sessionKey: sessionKey,
+          sessionKey: params.sessionSigsParams.sessionKey,
           statement: authCallbackParams.statement,
           pkpPublicKey: params.pkpPublicKey,
           expiration: authCallbackParams.expiration,

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -2427,23 +2427,15 @@ export class LitNodeClientNodeJs
       params.expiration ||
       new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
 
-    let sessionKeyUri: string;
+    // Try to get it from local storage, if not generates one~
+    const sessionKey: SessionKeyPair =
+      params.sessionKey ?? this.getSessionKey();
+    const sessionKeyUri = LIT_SESSION_KEY_URI + sessionKey.publicKey;
 
-    // This allow the user to provide a sessionKeyUri directly without using the session key pair
-    if (params?.sessionKeyUri) {
-      sessionKeyUri = params.sessionKeyUri;
-      log(`[signSessionKey] sessionKeyUri found in params:`, sessionKeyUri);
-    } else {
-      // Try to get it from local storage, if not generates one~
-      let sessionKey: SessionKeyPair =
-        params.sessionKey ?? this.getSessionKey();
-      sessionKeyUri = LIT_SESSION_KEY_URI + sessionKey.publicKey;
-
-      log(
-        `[signSessionKey] sessionKeyUri is not found in params, generating a new one`,
-        sessionKeyUri
-      );
-    }
+    log(
+      `[signSessionKey] sessionKeyUri is not found in params, generating a new one`,
+      sessionKeyUri
+    );
 
     if (!sessionKeyUri) {
       throw new Error(

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -2520,7 +2520,6 @@ export class LitNodeClientNodeJs
       sessionKey: sessionKeyUri,
       authMethods: params.authMethods,
       ...(params?.pkpPublicKey && { pkpPublicKey: params.pkpPublicKey }),
-      ...(params?.authSig && { authSig: params.authSig }),
       siweMessage: siweMessage,
       curveType: LIT_CURVE.BLS,
 

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -702,7 +702,7 @@ export class LitNodeClientNodeJs
       throw new Error('authSig or sessionSig is required');
     }
     const data: JsExecutionRequestBody = {
-      ...(authSig ? { authSig } : {}),
+      authSig,
       ...(code ? { code } : {}),
       ...(ipfsId ? { ipfsId } : {}),
       ...(authMethods ? { authMethods } : {}),

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -2622,26 +2622,15 @@ export class LitNodeClientNodeJs
         }
 
         // each of this field cannot be empty
-        let requiredFields =
-          curveType === LIT_CURVE.BLS
-            ? [
-                'signatureShare',
-                'curveType',
-                'shareIndex',
-                'siweMessage',
-                'dataSigned',
-                'blsRootPubkey',
-                'result',
-              ]
-            : [
-                'sigType',
-                'dataSigned',
-                'signatureShare',
-                'bigr',
-                'publicKey',
-                'sigName',
-                'siweMessage',
-              ];
+        let requiredFields = [
+          'signatureShare',
+          'curveType',
+          'shareIndex',
+          'siweMessage',
+          'dataSigned',
+          'blsRootPubkey',
+          'result',
+        ];
 
         // check if all required fields are present
         for (const field of requiredFields) {
@@ -2688,59 +2677,43 @@ export class LitNodeClientNodeJs
 
     let signatures: any;
 
-    if (curveType === LIT_CURVE.BLS) {
-      const blsSignedData: BlsResponseData[] =
-        validatedSignedDataList as BlsResponseData[];
+    const blsSignedData: BlsResponseData[] =
+      validatedSignedDataList as BlsResponseData[];
 
-      const sigType = mostCommonString(
-        blsSignedData.map((s: any) => s.sigType)
-      );
-      log(`[signSessionKey] sigType:`, sigType);
+    const sigType = mostCommonString(blsSignedData.map((s: any) => s.sigType));
+    log(`[signSessionKey] sigType:`, sigType);
 
-      const signatureShares = blsSignedData.map((s) => ({
-        ProofOfPossession: s.signatureShare.ProofOfPossession,
-      }));
+    const signatureShares = blsSignedData.map((s) => ({
+      ProofOfPossession: s.signatureShare.ProofOfPossession,
+    }));
 
-      log(`[signSessionKey] signatureShares:`, signatureShares);
+    log(`[signSessionKey] signatureShares:`, signatureShares);
 
-      const blsCombinedSignature = blsSdk.combine_signature_shares(
-        signatureShares.map((s) => JSON.stringify(s))
-      );
+    const blsCombinedSignature = blsSdk.combine_signature_shares(
+      signatureShares.map((s) => JSON.stringify(s))
+    );
 
-      log(`[signSessionKey] blsCombinedSignature:`, blsCombinedSignature);
+    log(`[signSessionKey] blsCombinedSignature:`, blsCombinedSignature);
 
-      const publicKey = params.pkpPublicKey.startsWith('0x')
-        ? params.pkpPublicKey.slice(2)
-        : params.pkpPublicKey;
+    const publicKey = params.pkpPublicKey.startsWith('0x')
+      ? params.pkpPublicKey.slice(2)
+      : params.pkpPublicKey;
 
-      const dataSigned = mostCommonString(
-        blsSignedData.map((s: any) => s.dataSigned)
-      );
-      const siweMessage = mostCommonString(
-        blsSignedData.map((s: any) => s.siweMessage)
-      );
-      signatures = {
-        sessionSig: {
-          signature: blsCombinedSignature,
-          publicKey,
-          dataSigned,
-          siweMessage,
-        },
-      };
-    } else {
-      // Shape: [signSessionKey] signatures: {
-      //   sessionSig: {
-      //     r: "xx",
-      //     s: "yy",
-      //     recid: 1,
-      //     signature: "0x...",
-      //     publicKey: "04e...",
-      //     dataSigned: "7c1...",
-      //     siweMessage: "litprotocol.com wants you to sign in with your Ethereum account:\n0xd69969c6a2E56C928d63F12325fe1d9D47115C91\n\nLit Protocol PKP session signature Some custom statement. I further authorize the stated URI to perform the following actions on my behalf: (1) 'Threshold': 'Signing' for 'lit-pkp://*'.\n\nURI: lit:session:95ff87b5d2210c382ccfcba6bdb16ceb217da9726c91d0fdda5eb888f087488f\nVersion: 1\nChain ID: 1\nNonce: 0x337906a8c2a6da52d438495fc1b0145ed5632ec32ffa1dda1064f43775b3a802\nIssued At: 2024-04-09T17:58:47Z\nExpiration Time: 2024-04-10T17:59:13.420Z\nResources:\n- urn:recap:eyJhdHQiOnt9LCJwcmYiOltdfQ\n- urn:recap:eyJhdHQiOnsibGl0LXBrcDovLyoiOnsiVGhyZXNob2xkL1NpZ25pbmciOlt7fV19fSwicHJmIjpbXX0",
-      //   },
-      // }
-      signatures = this.getSessionSignatures(validatedSignedDataList);
-    }
+    const dataSigned = mostCommonString(
+      blsSignedData.map((s: any) => s.dataSigned)
+    );
+    const mostCommonSiweMessage = mostCommonString(
+      blsSignedData.map((s: any) => s.siweMessage)
+    );
+
+    signatures = {
+      sessionSig: {
+        signature: blsCombinedSignature,
+        publicKey,
+        dataSigned,
+        siweMessage: mostCommonSiweMessage,
+      },
+    };
 
     log('[signSessionKey] signatures:', signatures);
 

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -173,6 +173,11 @@ export class LitNodeClientNodeJs
   createCapacityDelegationAuthSig = async (
     params: CapacityCreditsReq
   ): Promise<CapacityCreditsRes> => {
+    // -- validate
+    if (!params.dAppOwnerWallet) {
+      throw new Error('dAppOwnerWallet must exist');
+    }
+
     // Useful log for debugging
     if (!params.delegateeAddresses || params.delegateeAddresses.length === 0) {
       log(
@@ -189,11 +194,6 @@ export class LitNodeClientNodeJs
     // -- if it's not ready yet, then connect
     if (!this.ready) {
       await this.connect();
-    }
-
-    // -- validate
-    if (!params.dAppOwnerWallet) {
-      throw new Error('dAppOwnerWallet must exist');
     }
 
     const nonce = await this.getLatestBlockhash();

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -117,14 +117,8 @@ import type {
   JsExecutionRequestBody,
   JsonSignSessionKeyRequestV1,
   BlsResponseData,
-  SessionKeyCache,
 } from '@lit-protocol/types';
 import * as blsSdk from '@lit-protocol/bls-sdk';
-
-const TEMP_CACHE_PERIOD = 30000; // 30 seconds
-
-// Global cache variable
-let sessionKeyCache: SessionKeyCache | null = null;
 
 export class LitNodeClientNodeJs
   extends LitCore
@@ -327,15 +321,6 @@ export class LitNodeClientNodeJs
         `Storage key "${storageKey}" is missing. Not a problem. Contiune...`
       );
 
-      // Check if a valid session key exists in cache
-      if (
-        sessionKeyCache &&
-        Date.now() - sessionKeyCache.timestamp < TEMP_CACHE_PERIOD
-      ) {
-        log(`[getSessionKey] Returning session key from cache.`);
-        return sessionKeyCache.value;
-      }
-
       // Generate new one
       const newSessionKey = generateSessionKeyPair();
 
@@ -346,14 +331,6 @@ export class LitNodeClientNodeJs
         log(
           `[getSessionKey] Localstorage not available.Not a problem.Contiune...`
         );
-
-        // Store in cache
-        sessionKeyCache = {
-          value: newSessionKey,
-          timestamp: Date.now(),
-        };
-
-        log(`[getSessionKey] newSessionKey set to cache: `, sessionKeyCache);
       }
 
       return newSessionKey;

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -315,7 +315,7 @@ export interface JsonSignSessionKeyRequestV1 {
   pkpPublicKey?: string;
   authSig?: AuthSig;
   siweMessage: string;
-  curveType: 'BLS' | 'ECDSA';
+  curveType: 'BLS';
   code?: string;
   litActionIpfsId?: string;
   jsParams?: any;

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -247,7 +247,7 @@ export interface BaseJsonExecutionRequest {
 /**
  * FIXME: We should create a separate interface for JsExecutionRequestBody
  * a body that the SDK accepts, and another one the node actually accepts.
- * 
+ *
  */
 export interface WithAuthSig extends BaseJsonExecutionRequest {
   authSig: AuthSig;

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -244,6 +244,11 @@ export interface BaseJsonExecutionRequest {
   authMethods?: AuthMethod[];
 }
 
+/**
+ * FIXME: We should create a separate interface for JsExecutionRequestBody
+ * a body that the SDK accepts, and another one the node actually accepts.
+ * 
+ */
 export interface WithAuthSig extends BaseJsonExecutionRequest {
   authSig: AuthSig;
   sessionSigs?: any;
@@ -257,7 +262,7 @@ export interface WithSessionSigs extends BaseJsonExecutionRequest {
 export type JsonExecutionRequest = WithAuthSig | WithSessionSigs;
 
 export interface JsExecutionRequestBody {
-  authSig?: AuthSig;
+  authSig: AuthSig;
   code?: string;
   ipfsId?: string;
   authMethods?: AuthMethod[];
@@ -313,7 +318,6 @@ export interface JsonSignSessionKeyRequestV1 {
   sessionKey: string;
   authMethods: AuthMethod[];
   pkpPublicKey?: string;
-  authSig?: AuthSig;
   siweMessage: string;
   curveType: 'BLS';
   code?: string;

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -1471,7 +1471,7 @@ export interface BaseProviderSessionSigsParams {
   /**
    * Lit Node Client to use. If not provided, will use an existing Lit Node Client or create a new one
    */
-  litNodeClient?: any;
+  litNodeClient?: ILitNodeClient;
 
   resourceAbilityRequests?: LitResourceAbilityRequest[];
 }

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -929,9 +929,6 @@ export interface SignSessionKeyProp {
 
   resourceAbilityRequests?: LitResourceAbilityRequest[];
 
-  // -- as part of auth unification
-  sessionKeyUri?: string;
-
   litActionCode?: string;
 
   jsParams?: {

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -987,8 +987,11 @@ export interface GetSessionSigsProps extends LitCustomAuth {
    */
   authNeededCallback?: AuthCallback;
 
-  // The serialized session key pair to sign. If not provided, a session key pair will be fetched from localStorge or generated.
-  sessionKey?: any;
+  /**
+   * The serialized session key pair to sign.
+   * If not provided, a session key pair will be fetched from localStorge or generated.
+   */
+  sessionKey?: SessionKeyPair;
 
   /**
    * @deprecated - use capabilityAuthSigs instead


### PR DESCRIPTION
# Description

This PR merges several other PRs https://github.com/LIT-Protocol/js-sdk/pull/439 https://github.com/LIT-Protocol/js-sdk/pull/438 https://github.com/LIT-Protocol/js-sdk/pull/436, so we can run the tests as they rely on the new features introduced in those branches.

Please check this [directory](https://github.com/LIT-Protocol/js-sdk/tree/757d588dedc66864d0fcec692e9a22677ce38f0f/local-tests/tests) for all the tests

## Changes
- Introduced a helper function for composing an access control resource string. Previously, we only required `dataToHash`, but it turns out that the string of the hashed access control string must be prepended before it. See 72bcd8d6485bf7a9dfe12c1a4e9e1a177841d9e4.
- Better types on Node response https://github.com/LIT-Protocol/js-sdk/pull/440/commits/fe71ddfba4c9701c513bb649a4e53af45ea66bd8
- Unfortunately `node-fetch` is needed when running against local tests for some reasons. The package is added a dev dependency so won't affect production. It's only being used in this test. 757d588dedc66864d0fcec692e9a22677ce38f0f

Also want to note that we should write scenario in the test/JsDocs for more complex operations, see example https://github.com/LIT-Protocol/js-sdk/blob/757d588dedc66864d0fcec692e9a22677ce38f0f/local-tests/tests/testDelegatingCapacityCreditsNFTToAnotherWalletToExecuteJs.ts#L6-L19


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

```
 NETWORK=localchain DEBUG=true yarn test:local         
```

<img width="621" alt="image" src="https://github.com/LIT-Protocol/js-sdk/assets/4049673/f9bf2997-d82f-4d0a-8695-86f452d1344e">


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
