### PR TITLE
auth method id for eth wallet is just the wallet address

### DIFF
--- a/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
@@ -204,6 +204,6 @@ export default class EthWalletProvider extends BaseProvider {
       );
     }
 
-    return ethers.utils.keccak256(ethers.utils.toUtf8Bytes(`${address}:lit`));
+    return address;
   }
 }


### PR DESCRIPTION
The encoding for the EthWallet auth method type was wrong.  It should just be the raw address.  You can see this in the PKPPermissions facet here: https://github.com/LIT-Protocol/lit-assets/blob/8d26f49faf8d1648fb50deb9ff8d45a68ed49f80/blockchain/contracts/contracts/lit-node/PKPPermissions/PKPPermissionsFacet.sol#L506

Note that there is not ":lit" appended, no keccak256, etc.  it's just the address bytes.

For context, this is the function where the changed line is: 

```
public static async authMethodId(authMethod: AuthMethod): Promise<string> {
    let address: string;

    try {
      address = JSON.parse(authMethod.accessToken).address;
    } catch (err) {
      throw new Error(
        `Error when parsing auth method to generate auth method ID for Eth wallet: ${err}`
      );
    }

    return address;
  }
```