### PR TITLE
add(chain): add 'lit' to supported chains in constant.ts file

### DIFF
--- a/packages/constants/src/lib/constants/constants.ts
+++ b/packages/constants/src/lib/constants/constants.ts
@@ -477,6 +477,17 @@ export const LIT_CHAINS: LITChain<LITEVMChain> = {
     type: null,
     vmType: 'EVM',
   },
+  lit: {
+    contractAddress: null,
+    chainId: 175177,
+    name: 'Chronicle - Lit Protocol Testnet',
+    symbol: 'testLPX',
+    decimals: 18,
+    rpcUrls: ['https://chain-rpc.litprotocol.com/http'],
+    blockExplorerUrls: ['https://chain.litprotocol.com/'],
+    type: null,
+    vmType: 'EVM',
+  },
   chiado: {
     contractAddress: null,
     chainId: 10200,


### PR DESCRIPTION
# Description

Add `lit`(Chronicle) to the [supported chains](https://developer.litprotocol.com/v3/resources/supported-chains) page.

Adding to docs is done automatically using script. But it appears `lit` as an supported chain is missing from [constants.ts](https://github.com/LIT-Protocol/js-sdk/blob/068a0f4dd9a6705105c1bab81c20931cfd597ed1/packages/constants/src/lib/constants/constants.ts#L35)

As @glitch003 suggested, let's add a new chain in constants.ts with the name `lit`, with the same exact data as the `chronicleTestnet` entry. Then, once the new SDK is published, any commit to the docs repo will automatically pull down the latest version of the SDK and regenerate the list of supported chains in the doc (it's a pre-commit hook in the docs repo).

### Fixes: [LIT-2927](https://linear.app/litprotocol/issue/LIT-2927/add-chronicle-to-supported-chains)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
