### PR TITLE
Feat/add authenticate method pkp base

### DIFF
--- a/e2e-nodejs/group-pkp-session-sigs/test-pkp-sign-with-session-sigs-session-cache.mjs
+++ b/e2e-nodejs/group-pkp-session-sigs/test-pkp-sign-with-session-sigs-session-cache.mjs
@@ -75,11 +75,17 @@ export async function main() {
     },
   });
   await pkpWallet.init();
-
+  await pkpWallet.authenticate();
+  const sessionSigs = pkpWallet.controllerSessionSigs;
   const signature = await pkpWallet.signMessage(message);
 
   // ==================== Post-Validation ====================
 
+  if (!sessionSigs) {
+    return fail(
+      'session is not defined after calling authenticate on the instance'
+    );
+  }
   if (!signature) {
     return fail('Failed to sign data with sessionSigs generated previously');
   }

--- a/packages/pkp-base/src/lib/pkp-base.ts
+++ b/packages/pkp-base/src/lib/pkp-base.ts
@@ -211,7 +211,6 @@ export class PKPBase<T = PKPBaseDefaultParams> {
   private validateAuthContext() {
     const providedAuthentications = [
       this.controllerAuthSig,
-      this.controllerSessionSigs,
       this.authContext,
     ].filter(Boolean).length;
 


### PR DESCRIPTION
# Description
Adds an `authenticate` method which will use the `authContext` if provided to reassign the `controllerSessionSigs` property on `PKPBase` which allows for `authentication` operations to be explicitly invoked. This is helpful when we require to first check the authentication status before allowing other operations to occur. Without this addition it would not be possible to get the `controllerSessionSigs` before calling a higher level function on `PKPEthers` for example.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

An Additional check has been added to [test-pkp-sign-with-session-sigs-session-cache.mjs](https://github.com/LIT-Protocol/js-sdk/compare/feat/add-authenticate-method-pkp-base?expand=1#diff-bce9a9e7d7f9d561dc46d4831e321663be35d1c1ea15be2249d7544a731c9bde)
to assert that `session` has been defined before calling `signMessage`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
