### PR TITLE
fix: Remove invalid test case and adds an exception if no `arguments` are supplied to `LitNodeClient`

### DIFF
--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.spec.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.spec.ts
@@ -26,11 +26,6 @@ describe('LitNodeClientNodeJs', () => {
     expect(isClass(LitNodeClientNodeJs)).toBe(true);
   });
 
-  it('should be able to instantiate a new LitNodeClientNodeJs', async () => {
-    const litNodeClient = new LitNodeClientNodeJs();
-    expect(litNodeClient).toBeDefined();
-  });
-
   it('should be able to instantiate a new LitNodeClientNodeJs to localhost', async () => {
     const litNodeClient = new LitNodeClientNodeJs({
       litNetwork: 'localhost',

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -134,9 +134,9 @@ export class LitNodeClientNodeJs
 
   // ========== Constructor ==========
   constructor(args: LitNodeClientConfig | CustomNetwork) {
-    if(!args) {
+    if (!args) {
       throwError({
-        message: "must probvide LitNodeClient parameters",
+        message: 'must probvide LitNodeClient parameters',
         errorKind: LIT_ERROR.PARAMS_MISSING_ERROR.kind,
         errorCode: LIT_ERROR.PARAMS_MISSING_ERROR.name,
       });

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -135,7 +135,7 @@ export class LitNodeClientNodeJs
   constructor(args: LitNodeClientConfig | CustomNetwork) {
     super(args);
 
-    if ('defaultAuthCallback' in args) {
+    if (args && 'defaultAuthCallback' in args) {
       this.defaultAuthCallback = args.defaultAuthCallback;
     }
   }

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -136,7 +136,7 @@ export class LitNodeClientNodeJs
   constructor(args: LitNodeClientConfig | CustomNetwork) {
     if (!args) {
       throwError({
-        message: 'must probvide LitNodeClient parameters',
+        message: 'must provide LitNodeClient parameters',
         errorKind: LIT_ERROR.PARAMS_MISSING_ERROR.kind,
         errorCode: LIT_ERROR.PARAMS_MISSING_ERROR.name,
       });

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -47,6 +47,7 @@ import {
   logWithRequestId,
   mostCommonString,
   throwError,
+  throwErrorV1,
 } from '@lit-protocol/misc';
 import {
   getStorageItem,
@@ -133,9 +134,17 @@ export class LitNodeClientNodeJs
 
   // ========== Constructor ==========
   constructor(args: LitNodeClientConfig | CustomNetwork) {
+    if(!args) {
+      throwError({
+        message: "must probvide LitNodeClient parameters",
+        errorKind: LIT_ERROR.PARAMS_MISSING_ERROR.kind,
+        errorCode: LIT_ERROR.PARAMS_MISSING_ERROR.name,
+      });
+    }
+
     super(args);
 
-    if (args && 'defaultAuthCallback' in args) {
+    if ('defaultAuthCallback' in args) {
       this.defaultAuthCallback = args.defaultAuthCallback;
     }
   }


### PR DESCRIPTION
Adds an undefined check for using the `in` syntax for property check against `args` instance.