### PR TITLE
Feature/lit 3146 discord cannot read properties of undefined reading topics

### DIFF
--- a/packages/contracts-sdk/src/lib/contracts-sdk.ts
+++ b/packages/contracts-sdk/src/lib/contracts-sdk.ts
@@ -1065,6 +1065,12 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
 
     let tokenId;
 
+    if (!events[0].topics || events[0].topics.length < 1) {
+      throw new Error(
+        `No topics found in events, can not derive pkp information. Transaction hash: ${receipt.transactionHash} If you are using your own contracts please use ethers directly`
+      );
+    }
+
     tokenId = events[0].topics[1];
     console.warn('tokenId:', tokenId);
 


### PR DESCRIPTION
# Description
Connects https://github.com/LIT-Protocol/Issues-and-Reports/issues/32
Where in the event of no topic data in our transaction receipt our `mintWithAuth` implementation would throw the exception
`Cannot read properties of undefined (reading topics).`
This pr adds checks to the event topic we require for the `tokenId` and will throw an exception with the `transactionHash` included to let users better understand why an exception is occurring. If `topics` are not present in the event data we cannot return the `pkpInfo` as we do not have a `tokenId` to perform look ups with.