### PR TITLE
fix: session key signature default expiration always used

### DIFF
--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -474,7 +474,7 @@ export class LitNodeClientNodeJs
 
   /**
    *
-   * Get expiration for session default time is 1 hour
+   * Get expiration for session default time is 1 day / 24 hours
    *
    */
   static getExpiration = () => {

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -474,7 +474,7 @@ export class LitNodeClientNodeJs
 
   /**
    *
-   * Get expiration for session
+   * Get expiration for session default time is 1 hour
    *
    */
   static getExpiration = () => {
@@ -2812,7 +2812,8 @@ export class LitNodeClientNodeJs
     // - Let's sign the resources with the session key
     // - 5 minutes is the default expiration for a session signature
     // - Because we can generate a new session sig every time the user wants to access a resource without prompting them to sign with their wallet
-    const sessionExpiration = new Date(Date.now() + 1000 * 60 * 5);
+    const sessionExpiration =
+      params.expiration ?? new Date(Date.now() + 1000 * 60 * 5);
 
     const capabilities = params.capacityDelegationAuthSig
       ? [params.capacityDelegationAuthSig, authSig]


### PR DESCRIPTION
# Description
Fixes an issue with session key signatures having an expiration of 5 minutes regardless of what was set by the user as an `expiration`


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
