### PR TITLE
Feature/lit 3267 move to a lazy loading model for wasm instantiation instead

### DIFF
--- a/local-tests/setup/tinny-environment.ts
+++ b/local-tests/setup/tinny-environment.ts
@@ -215,6 +215,24 @@ export class TinnyEnvironment {
       });
     }
 
+    if (globalThis.wasmExports) {
+      console.warn(
+        'WASM modules already loaded. wil overide. when connect is called'
+      );
+    }
+
+    if (globalThis.wasmECDSA) {
+      console.warn(
+        'WASM modules already loaded. wil overide. when connect is called'
+      );
+    }
+
+    if (globalThis.wasmSevSnpUtils) {
+      console.warn(
+        'WASM modules already loaded. wil overide. when connect is called'
+      );
+    }
+
     await this.litNodeClient.connect();
 
     if (!this.litNodeClient.ready) {

--- a/local-tests/setup/tinny-environment.ts
+++ b/local-tests/setup/tinny-environment.ts
@@ -217,7 +217,7 @@ export class TinnyEnvironment {
 
     if (globalThis.wasmExports) {
       console.warn(
-        'WASM modules already loaded. wil overide. when connect is called'
+        'WASM modules already loaded. Will overide when connect is called'
       );
     }
 

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -470,8 +470,7 @@ export class LitCore {
 
     this._stopListeningForNewEpoch();
     this._stopNetworkPolling();
-    if (globalThis.litConfig)
-      delete globalThis.litConfig;
+    if (globalThis.litConfig) delete globalThis.litConfig;
   }
 
   _stopNetworkPolling() {

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -26,7 +26,12 @@ import {
   CAYENNE_URL,
 } from '@lit-protocol/constants';
 import { LitContracts } from '@lit-protocol/contracts-sdk';
-import { checkSevSnpAttestation, computeHDPubKey } from '@lit-protocol/crypto';
+import {
+  checkSevSnpAttestation,
+  computeHDPubKey,
+  loadModules,
+  unloadModules,
+} from '@lit-protocol/crypto';
 import {
   bootstrapLogManager,
   executeWithRetry,
@@ -457,11 +462,16 @@ export class LitCore {
   }
 
   /**
-   *  Stops internal listeners/polling that refresh network state and watch for epoch changes
+   *  Stops internal listeners/polling that refresh network state and watch for epoch changes.
+   *  Removes global objects created internally
    */
   async disconnect() {
+    unloadModules();
+
     this._stopListeningForNewEpoch();
     this._stopNetworkPolling();
+    if (globalThis.litConfig)
+      delete globalThis.litConfig;
   }
 
   _stopNetworkPolling() {
@@ -529,6 +539,11 @@ export class LitCore {
    *
    */
   async connect(): Promise<void> {
+    // If we have never connected on this client instance first load WASM modules.
+    if (!this.ready) {
+      await loadModules();
+    }
+
     // Ensure that multiple closely timed calls to `connect()` don't result in concurrent connect() operations being run
     if (this._connectingPromise) {
       return this._connectingPromise;

--- a/packages/crypto/src/lib/crypto.spec.ts
+++ b/packages/crypto/src/lib/crypto.spec.ts
@@ -6,6 +6,7 @@ import {
   combineSignatureShares,
   verifySignature,
   combineEcdsaShares,
+  loadModules,
 } from './crypto';
 import * as ethers from 'ethers';
 import { joinSignature } from 'ethers/lib/utils';
@@ -25,6 +26,7 @@ const identityParam = new Uint8Array([
 
 describe('crypto', () => {
   beforeAll(async () => {
+    await loadModules();
     await blsSdk.initWasmBlsSdk();
   });
 

--- a/packages/crypto/src/lib/crypto.ts
+++ b/packages/crypto/src/lib/crypto.ts
@@ -22,62 +22,87 @@ import { CombinedECDSASignature } from '@lit-protocol/types';
 
 const LIT_CORS_PROXY = `https://cors.litgateway.com`;
 
-// if 'wasmExports' is not available, we need to initialize the BLS SDK
-if (!globalThis.wasmExports) {
-  blsSdk.initWasmBlsSdk().then((exports) => {
-    globalThis.wasmExports = exports;
-
-    if (!globalThis.jestTesting) {
-      log(
-        `✅ [BLS SDK] wasmExports loaded. ${
-          Object.keys(exports).length
-        } functions available. Run 'wasmExports' in the console to see them.`
-      );
-    }
-  });
-}
-
-if (!globalThis.wasmECDSA) {
-  let init = ecdsaSdk.initWasmEcdsaSdk;
-  let env;
-
-  if (isBrowser()) {
-    env = 'Browser';
-  } else {
-    env = 'NodeJS';
-  }
-
-  init().then((sdk: any) => {
-    globalThis.wasmECDSA = sdk;
-
-    if (!globalThis.jestTesting) {
-      log(
-        `✅ [ECDSA SDK ${env}] wasmECDSA loaded. ${
-          Object.keys(wasmECDSA).length
-        } functions available. Run 'wasmECDSA' in the console to see them.`
-      );
-    }
-  });
-}
-
-if (!globalThis.wasmSevSnpUtils) {
-  sevSnpUtilsSdk.initWasmSevSnpUtilsSdk().then((exports) => {
-    globalThis.wasmSevSnpUtils = exports;
-
-    if (!globalThis.jestTesting) {
-      log(
-        `✅ [SEV SNP Utils SDK] wasmSevSnpUtils loaded. ${
-          Object.keys(exports).length
-        } functions available. Run 'wasmSevSnpUtils' in the console to see them.`
-      );
-    }
-  });
-}
-
-/** ---------- Exports ---------- */
-
 export interface BlsSignatureShare {
   ProofOfPossession: string;
+}
+
+/**
+  Loads all wasm modules into the glboal scope
+
+  - ECDSA utilities - wasmECDSA
+  - BLS utilities - wasmExports
+  - SEV-SNP utilities - wasmSevSnpUtilities
+
+  @returns {Promise<void>}
+*/
+export const loadModules = (): Promise<void> => {
+  // if 'wasmExports' is not available, we need to initialize the BLS SDK
+  if (!globalThis.wasmExports) {
+    blsSdk.initWasmBlsSdk().then((exports) => {
+      globalThis.wasmExports = exports;
+
+      if (!globalThis.jestTesting) {
+        log(
+          `✅ [BLS SDK] wasmExports loaded. ${
+            Object.keys(exports).length
+          } functions available. Run 'wasmExports' in the console to see them.`
+        );
+      }
+    });
+  }
+
+  if (!globalThis.wasmECDSA) {
+    let init = ecdsaSdk.initWasmEcdsaSdk;
+    let env;
+
+    if (isBrowser()) {
+      env = 'Browser';
+    } else {
+      env = 'NodeJS';
+    }
+
+    init().then((sdk: any) => {
+      globalThis.wasmECDSA = sdk;
+
+      if (!globalThis.jestTesting) {
+        log(
+          `✅ [ECDSA SDK ${env}] wasmECDSA loaded. ${
+            Object.keys(wasmECDSA).length
+          } functions available. Run 'wasmECDSA' in the console to see them.`
+        );
+      }
+    });
+  }
+
+  if (!globalThis.wasmSevSnpUtils) {
+    sevSnpUtilsSdk.initWasmSevSnpUtilsSdk().then((exports) => {
+      globalThis.wasmSevSnpUtils = exports;
+
+      if (!globalThis.jestTesting) {
+        log(
+          `✅ [SEV SNP Utils SDK] wasmSevSnpUtils loaded. ${
+            Object.keys(exports).length
+          } functions available. Run 'wasmSevSnpUtils' in the console to see them.`
+        );
+      }
+    });
+  }
+};
+
+/*
+  Removes wasm modules from global scope
+  if found to be defined. Can be called multiple times safely.
+*/
+export const unloadModules = () => {
+  log('running cleanup for global modules');
+  if (globalThis.wasmExports)
+      delete globalThis.wasmExports;
+  
+  if (globalThis.wasmECDSA)
+      delete globalThis.wasmECDSA;
+  
+  if(globalThis.wasmSevSnpUtilsSdk) 
+    delete globalThis.initWasmSevSnpUtilsSdk;
 }
 
 /**

--- a/packages/crypto/src/lib/crypto.ts
+++ b/packages/crypto/src/lib/crypto.ts
@@ -27,7 +27,7 @@ export interface BlsSignatureShare {
 }
 
 /**
-  Loads all wasm modules into the glboal scope
+  Loads all wasm modules into the global scope
 
   - ECDSA utilities - wasmECDSA
   - BLS utilities - wasmExports

--- a/packages/crypto/src/lib/crypto.ts
+++ b/packages/crypto/src/lib/crypto.ts
@@ -95,15 +95,12 @@ export const loadModules = (): Promise<void> => {
 */
 export const unloadModules = () => {
   log('running cleanup for global modules');
-  if (globalThis.wasmExports)
-      delete globalThis.wasmExports;
-  
-  if (globalThis.wasmECDSA)
-      delete globalThis.wasmECDSA;
-  
-  if(globalThis.wasmSevSnpUtilsSdk) 
-    delete globalThis.initWasmSevSnpUtilsSdk;
-}
+  if (globalThis.wasmExports) delete globalThis.wasmExports;
+
+  if (globalThis.wasmECDSA) delete globalThis.wasmECDSA;
+
+  if (globalThis.wasmSevSnpUtilsSdk) delete globalThis.initWasmSevSnpUtilsSdk;
+};
 
 /**
  * Encrypt data with a BLS public key.


### PR DESCRIPTION
# Description
Removes implicit WASM module loading in favor of loading at time of `connect`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

aded loading of to the crypto.spec `beforeAll` hook

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
