### PR TITLE
Add/jit wallet tinny person

### DIFF
--- a/local-tests/setup/tinny-environment.ts
+++ b/local-tests/setup/tinny-environment.ts
@@ -334,7 +334,7 @@ export class TinnyEnvironment {
     // There is a correlation between the number of Capacity Credit NFTs in a wallet and the speed at which nodes can verify a given rate limit authorization. Creating a single wallet to hold all Capacity Credit NFTs improves network performance during tests.
     const capacityCreditWallet = ethers.Wallet.createRandom().connect(provider);
 
-    let transferTx = await wallet.sendTransaction({
+    const transferTx = await wallet.sendTransaction({
       to: capacityCreditWallet.address,
       value: ethers.utils.parseEther('0.001'),
     });
@@ -381,6 +381,7 @@ export class TinnyEnvironment {
       await this.litNodeClient.createCapacityDelegationAuthSig({
         dAppOwnerWallet: wallet,
         capacityTokenId: capacityTokenId,
+        // Sets a maximum limit of 200 times that the delegation can be used and prevents usage beyond it
         uses: '200',
       })
     ).capacityDelegationAuthSig;

--- a/local-tests/setup/tinny-environment.ts
+++ b/local-tests/setup/tinny-environment.ts
@@ -330,11 +330,9 @@ export class TinnyEnvironment {
     const wallet = new ethers.Wallet(privateKey.privateKey, provider);
 
     // TODO: This wallet should be cached somehwere and reused to create delegation signatures.
-    let capacityCreditWallet = ethers.Wallet.createRandom();
-    capacityCreditWallet = new ethers.Wallet(
-      capacityCreditWallet.privateKey,
-      provider
-    );
+```suggestion
+    // There is a correlation between the number of Capacity Credit NFTs in a wallet and the speed at which nodes can verify a given rate limit authorization. Creating a single wallet to hold all Capacity Credit NFTs improves network performance during tests.
+    const capacityCreditWallet = ethers.Wallet.createRandom().connect(provider);
 
     let transferTx = await wallet.sendTransaction({
       to: capacityCreditWallet.address,

--- a/local-tests/setup/tinny-environment.ts
+++ b/local-tests/setup/tinny-environment.ts
@@ -330,7 +330,6 @@ export class TinnyEnvironment {
     const wallet = new ethers.Wallet(privateKey.privateKey, provider);
 
     // TODO: This wallet should be cached somehwere and reused to create delegation signatures.
-```suggestion
     // There is a correlation between the number of Capacity Credit NFTs in a wallet and the speed at which nodes can verify a given rate limit authorization. Creating a single wallet to hold all Capacity Credit NFTs improves network performance during tests.
     const capacityCreditWallet = ethers.Wallet.createRandom().connect(provider);
 

--- a/local-tests/setup/tinny-environment.ts
+++ b/local-tests/setup/tinny-environment.ts
@@ -331,11 +331,14 @@ export class TinnyEnvironment {
 
     // TODO: This wallet should be cached somehwere and reused to create delegation signatures.
     let capacityCreditWallet = ethers.Wallet.createRandom();
-    capacityCreditWallet = new ethers.Wallet(capacityCreditWallet.privateKey, provider);
+    capacityCreditWallet = new ethers.Wallet(
+      capacityCreditWallet.privateKey,
+      provider
+    );
 
     let transferTx = await wallet.sendTransaction({
       to: capacityCreditWallet.address,
-      value: ethers.utils.parseEther("0.001")
+      value: ethers.utils.parseEther('0.001'),
     });
     await transferTx.wait();
 
@@ -380,7 +383,7 @@ export class TinnyEnvironment {
       await this.litNodeClient.createCapacityDelegationAuthSig({
         dAppOwnerWallet: wallet,
         capacityTokenId: capacityTokenId,
-        uses: "200"
+        uses: '200',
       })
     ).capacityDelegationAuthSig;
   };

--- a/local-tests/setup/tinny-person.ts
+++ b/local-tests/setup/tinny-person.ts
@@ -56,7 +56,7 @@ export class TinnyPerson {
  
     const transferTx = await this.wallet.sendTransaction({
       to: fundingWallet.address,
-      value: ethers.utils.parseEther("0.001")
+      value: ethers.utils.parseEther("0.00001")
     });
 
     const transferReciept = await transferTx.wait();

--- a/local-tests/setup/tinny-person.ts
+++ b/local-tests/setup/tinny-person.ts
@@ -51,8 +51,8 @@ export class TinnyPerson {
   }
 
   async spawn() {
-    let fundingWallet = ethers.Wallet.createRandom();
-    fundingWallet = new ethers.Wallet(fundingWallet.privateKey, this.provider);
+    // Create a new funding wallet, funds it with small amount of ethers, and updates the current wallet to the new one.
+    const fundingWallet = ethers.Wallet.createRandom().connect(this.provider);
 
     const transferTx = await this.wallet.sendTransaction({
       to: fundingWallet.address,

--- a/local-tests/setup/tinny-person.ts
+++ b/local-tests/setup/tinny-person.ts
@@ -53,16 +53,18 @@ export class TinnyPerson {
   async spawn() {
     let fundingWallet = ethers.Wallet.createRandom();
     fundingWallet = new ethers.Wallet(fundingWallet.privateKey, this.provider);
- 
+
     const transferTx = await this.wallet.sendTransaction({
       to: fundingWallet.address,
-      value: ethers.utils.parseEther("0.00001")
+      value: ethers.utils.parseEther('0.00001'),
     });
 
     const transferReciept = await transferTx.wait();
-    console.log('[𐬺🧪 Tinny Person𐬺] Transfered Assets for person tx: ', transferReciept.transactionHash);
+    console.log(
+      '[𐬺🧪 Tinny Person𐬺] Transfered Assets for person tx: ',
+      transferReciept.transactionHash
+    );
     this.wallet = fundingWallet;
-
 
     console.log('[𐬺🧪 Tinny Person𐬺] Spawning person:', this.wallet.address);
     /**
@@ -176,7 +178,7 @@ export class TinnyPerson {
     console.log(
       '[𐬺🧪 Tinny Person𐬺] Mint a Capacity Credits NFT and get a capacity delegation authSig with it'
     );
-    
+
     const capacityTokenId = (
       await this.contractsClient.mintCapacityCreditsNFT({
         requestsPerKilosecond:

--- a/local-tests/setup/tinny-person.ts
+++ b/local-tests/setup/tinny-person.ts
@@ -51,6 +51,19 @@ export class TinnyPerson {
   }
 
   async spawn() {
+    let fundingWallet = ethers.Wallet.createRandom();
+    fundingWallet = new ethers.Wallet(fundingWallet.privateKey, this.provider);
+ 
+    const transferTx = await this.wallet.sendTransaction({
+      to: fundingWallet.address,
+      value: ethers.utils.parseEther("0.001")
+    });
+
+    const transferReciept = await transferTx.wait();
+    console.log('[𐬺🧪 Tinny Person𐬺] Transfered Assets for person tx: ', transferReciept.transactionHash);
+    this.wallet = fundingWallet;
+
+
     console.log('[𐬺🧪 Tinny Person𐬺] Spawning person:', this.wallet.address);
     /**
      * ====================================
@@ -163,6 +176,7 @@ export class TinnyPerson {
     console.log(
       '[𐬺🧪 Tinny Person𐬺] Mint a Capacity Credits NFT and get a capacity delegation authSig with it'
     );
+    
     const capacityTokenId = (
       await this.contractsClient.mintCapacityCreditsNFT({
         requestsPerKilosecond:
@@ -171,6 +185,8 @@ export class TinnyPerson {
       })
     ).capacityTokenIdStr;
 
+    this.contractsClient.signer = this.wallet;
+    await this.contractsClient.connect();
     return (
       await this.envConfig.litNodeClient.createCapacityDelegationAuthSig({
         dAppOwnerWallet: this.wallet,


### PR DESCRIPTION
# Description

Adds new wallet generation to `person` generation in `tinny` for more performant capacity delegation. There is a correlation to how many `Capacity Credit NFT` there are in a wallet and how quickly the nodes can look up a given rate limit authorization. This change helps with network performance when running tests on networks which require payment. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
tinny was used to run tests on `manzano` and the new wallet will work to mint a pkp. 

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
