### PR TITLE
Fix/execute with retry wrapper exec

### DIFF
--- a/local-tests/setup/tinny-operations.ts
+++ b/local-tests/setup/tinny-operations.ts
@@ -188,8 +188,8 @@ export const runTestsParallel = async ({
                 testIndex + 1
               }. ${testName} - Failed after ${maxAttempts} attempts (${timeTaken} ms)\x1b[0m`
             );
-            console.error(`\x1b[31m❌Error:\x1b[90m ${error}\x1b[0m`);
-            return `${testName} (Failed in ${timeTaken} ms) - Error: ${error}`;
+            console.error(`\x1b[31m❌Error:\x1b[90m ${error.message}\x1b[0m`);
+            return `${testName} (Failed in ${timeTaken} ms) - Error: ${error.message}\n Stack Tace: ${error.stack}`;
           }
         }
       }

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -111,7 +111,7 @@ export class LitCore {
     bootstrapUrls: [], // Default value, should be replaced
     retryTolerance: {
       timeout: 31_000,
-      maxRetryCount: 3,
+      maxRetryCount: 1,
       interval: 100,
     },
     rpcUrl: null,

--- a/packages/misc/src/lib/misc.ts
+++ b/packages/misc/src/lib/misc.ts
@@ -860,7 +860,7 @@ export async function executeWithRetry<T>(
         promiseReject({
           errorKind: 'Timeout',
           status: 500,
-          details: [`timeout limit reached timeout limit: ${opts.timeout}ms`],
+          details: [`timeout limit reached timeout limit: ${opts?.timeout}ms`],
           message: 'Request timeout',
         });
       }, opts.timeout);
@@ -905,7 +905,7 @@ export async function executeWithRetry<T>(
       errorKind: 'Timeout',
       status: 500,
       message: 'Request timeout',
-      details: [`timeout limit reached timeout limit: ${opts.timeout}ms`],
+      details: [`timeout limit reached timeout limit: ${opts?.timeout}ms`],
     },
     requestId,
   };

--- a/packages/pkp-base/src/lib/pkp-base.ts
+++ b/packages/pkp-base/src/lib/pkp-base.ts
@@ -315,21 +315,8 @@ export class PKPBase<T = PKPBaseDefaultParams> {
     this.log('executeJsArgs:', executeJsArgs);
 
     try {
-      const res = await executeWithRetry<ExecuteJsResponse>(
-        async (_id: string) =>
-          await this.litNodeClient.executeJs(executeJsArgs),
-        (error: any, requestId: string, isFinal: boolean) => {
-          if (!isFinal) {
-            this.log('an error has occurred, attempting to retry');
-          }
-        }
-      );
+      const res = await this.litNodeClient.executeJs(executeJsArgs);
 
-      if ('error' in res) {
-        return this.throwError(
-          `error while attempting signature operation, request identifier: lit_${res.requestId}`
-        );
-      }
       const sig = (res as ExecuteJsResponse).signatures[sigName];
 
       this.log('res:', res);


### PR DESCRIPTION
# Description

- Refactors `executeWithRetry` to no longer block  but rather poll the `executeCallback` for its completion which allows the Timeout to successfully invoke and short circuit operations.
- Reduces the default retry attempts from `3` to `1`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Added new unit tests to `misc.spec.ts` for exercising different retry situations that where not covered.
- Used local testing 

command to test: `DEBUG=false NETWORK=manzano yarn test:local --filter=testDelegatingCapacityCreditsNFTToAnotherWalletToExecuteJs`
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
