### PR TITLE
LIT-3394 - Improve connect() performance

### DIFF
--- a/local-tests/setup/tinny-environment.ts
+++ b/local-tests/setup/tinny-environment.ts
@@ -199,7 +199,6 @@ export class TinnyEnvironment {
       const networkContext = this._testnet.ContractContext;
       this.litNodeClient = new LitNodeClient({
         litNetwork: 'custom',
-        bootstrapUrls: this.processEnvs.BOOTSTRAP_URLS,
         rpcUrl: this.processEnvs.LIT_RPC_URL,
         debug: this.processEnvs.DEBUG,
         checkNodeAttestation: false, // disable node attestation check for local testing

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -491,6 +491,10 @@ export class LitCore {
           this.config.rpcUrl || LIT_CHAINS['lit'].rpcUrls[0]
         )
       );
+    } else if (!this.config.contractContext.Staking) {
+      throw new Error(
+        'The provided contractContext was missing the "Staking" contract`'
+      );
     }
 
     if (this.config.contractContext) {

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -93,10 +93,11 @@ export type LitNodeClientConfigWithDefaults = Required<
     | 'checkNodeAttestation'
     | 'litNetwork'
     | 'minNodeCount'
-    | 'rpcUrl'
   >
 > &
-  Partial<Pick<LitNodeClientConfig, 'storageProvider' | 'contractContext'>>;
+  Partial<
+    Pick<LitNodeClientConfig, 'storageProvider' | 'contractContext' | 'rpcUrl'>
+  >;
 
 // On epoch change, we wait this many seconds for the nodes to update to the new epoch before using the new epoch #
 const EPOCH_PROPAGATION_DELAY = 30_000;
@@ -112,7 +113,6 @@ export class LitCore {
     litNetwork: 'cayenne', // Default to cayenne network. will be replaced by custom config.
     minNodeCount: 2, // Default value, should be replaced
     bootstrapUrls: [], // Default value, should be replaced
-    rpcUrl: null,
   };
   connectedNodes = new Set<string>();
   serverKeys: Record<string, JsonHandshakeResponse> = {};
@@ -134,6 +134,7 @@ export class LitCore {
   };
   private _blockHashUrl =
     'http://block-indexer.litgateway.com/get_most_recent_valid_block';
+
   // ========== Constructor ==========
   constructor(config: LitNodeClientConfig | CustomNetwork) {
     // Initialize default config based on litNetwork

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -482,10 +482,6 @@ export class LitCore {
     // Ensure we don't fire an existing network sync poll handler while we're in the midst of connecting anyway
     this._stopNetworkPolling();
 
-    if (this.config.litNetwork === LitNetwork.Custom) {
-      log('using custom contracts: ', this.config.contractContext);
-    }
-
     // Initialize a contractContext if we were not given one; this allows interaction against the staking contract
     // to be handled locally from then on
     if (!this.config.contractContext) {
@@ -495,6 +491,20 @@ export class LitCore {
           this.config.rpcUrl || LIT_CHAINS['lit'].rpcUrls[0]
         )
       );
+    }
+
+    if (this.config.contractContext) {
+      const logAddresses = Object.entries(this.config.contractContext).reduce(
+        (output, [key, val]) => {
+          // @ts-expect-error since the object hash returned by `getContractAddresses` is `any`, we have no types here
+          output[key] = val.address;
+          return output;
+        },
+        {}
+      );
+      if (this.config.litNetwork === LitNetwork.Custom) {
+        log('using custom contracts: ', logAddresses);
+      }
     }
 
     // Re-use staking contract instance from previous connect() executions that succeeded to improve performance

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -239,9 +239,9 @@ export class LitCore {
 
     if (bootstrapUrls.length <= 0) {
       throwError({
-        message: `bootstrapUrls is empty, which is invalid. Please check your network connection and try again.`,
-        errorKind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
-        errorCode: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
+        message: `Failed to get bootstrapUrls for network ${this.config.litNetwork}`,
+        errorKind: LIT_ERROR.INIT_ERROR.kind,
+        errorCode: LIT_ERROR.INIT_ERROR.name,
       });
     }
 
@@ -653,14 +653,6 @@ export class LitCore {
     // track connectedNodes for the new handshake operation
     const connectedNodes = new Set<string>();
     const serverKeys: Record<string, JsonHandshakeResponse> = {};
-
-    if (this.config.bootstrapUrls.length <= 0) {
-      throwError({
-        message: `Failed to get bootstrapUrls for network ${this.config.litNetwork}`,
-        errorKind: LIT_ERROR.INIT_ERROR.kind,
-        errorCode: LIT_ERROR.INIT_ERROR.name,
-      });
-    }
 
     let timeoutHandle: ReturnType<typeof setTimeout>;
     await Promise.race([

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -87,7 +87,6 @@ interface EpochCache {
 export type LitNodeClientConfigWithDefaults = Required<
   Pick<
     LitNodeClientConfig,
-    | 'bootstrapUrls'
     | 'alertWhenUnauthorized'
     | 'debug'
     | 'connectTimeout'
@@ -98,7 +97,9 @@ export type LitNodeClientConfigWithDefaults = Required<
 > &
   Partial<
     Pick<LitNodeClientConfig, 'storageProvider' | 'contractContext' | 'rpcUrl'>
-  >;
+  > & {
+    bootstrapUrls: string[];
+  };
 
 // On epoch change, we wait this many seconds for the nodes to update to the new epoch before using the new epoch #
 const EPOCH_PROPAGATION_DELAY = 30_000;

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -15,14 +15,15 @@ import {
   validateUnifiedAccessControlConditionsSchema,
 } from '@lit-protocol/access-control-conditions';
 import {
+  LIT_CHAINS,
+  LIT_CURVE,
+  LIT_ENDPOINT,
   LIT_ERROR,
   LIT_ERROR_CODE,
   LIT_NETWORKS,
   LitNetwork,
-  LIT_CURVE,
   StakingStates,
   version,
-  LIT_ENDPOINT,
 } from '@lit-protocol/constants';
 import { LitContracts } from '@lit-protocol/contracts-sdk';
 import {
@@ -43,10 +44,11 @@ import {
   sendRequest,
   throwError,
 } from '@lit-protocol/misc';
-
-import type {
+import {
   AuthSig,
+  BlockHashErrorResponse,
   CustomNetwork,
+  EthBlockhashInfo,
   FormattedMultipleAccs,
   HandshakeWithNode,
   JsonHandshakeResponse,
@@ -61,9 +63,8 @@ import type {
   SessionSigsMap,
   SuccessNodePromises,
   SupportedJsonRequests,
-  BlockHashErrorResponse,
-  EthBlockhashInfo,
 } from '@lit-protocol/types';
+
 import { composeLitUrl } from './endpoint-version';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -137,6 +138,15 @@ export class LitCore {
 
   // ========== Constructor ==========
   constructor(config: LitNodeClientConfig | CustomNetwork) {
+    if (!(config.litNetwork in LIT_NETWORKS)) {
+      return throwError({
+        message:
+          'Unsupported network has been provided please use a "litNetwork" option which is supported ("cayenne", "habanero", "manzano")',
+        errorKind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
+        errorCode: LIT_ERROR.INVALID_PARAM_TYPE.code,
+      });
+    }
+
     // Initialize default config based on litNetwork
     switch (config?.litNetwork) {
       case LitNetwork.Cayenne:
@@ -204,137 +214,45 @@ export class LitCore {
     return globalThis.logManager.getLogsForId(id);
   };
 
-  // ========== Scoped Class Helpers ==========
-  /**
-   * Asynchronously updates the configuration settings for the LitNodeClient.
-   * This function fetches the minimum node count and bootstrap URLs for the
-   * specified Lit network.
-   *
-   * It validates these values and updates the client's
-   * configuration accordingly.
-   *
-   * It also stashes a handle on the Staking Contract so that we can use it for polling for epoch-related state changes
-   *
-   * @throws Will throw an error if the minimum node count is invalid or if
-   *         the bootstrap URLs array is empty.
-   * @returns {Promise<void>} A promise that resolves when the configuration is updated.
-   */
-  setNewConfig = async (): Promise<void> => {
-    if (
-      this.config.litNetwork === LitNetwork.Manzano ||
-      this.config.litNetwork === LitNetwork.Habanero ||
-      this.config.litNetwork === LitNetwork.Cayenne
-    ) {
-      const minNodeCount = await LitContracts.getMinNodeCount(
-        this.config.litNetwork
-      );
-      const bootstrapUrls = await LitContracts.getValidators(
-        this.config.litNetwork
-      );
-
-      // Handle on staking contract is used to monitor epoch/validator changes
-      this._stakingContract = await LitContracts.getStakingContract(
-        this.config.litNetwork
-      );
-
-      log('Bootstrap urls: ', bootstrapUrls);
-      if (minNodeCount <= 0) {
-        throwError({
-          message: `minNodeCount is ${minNodeCount}, which is invalid. Please check your network connection and try again.`,
-          errorKind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
-          errorCode: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
-        });
-      }
-
-      if (bootstrapUrls.length <= 0) {
-        throwError({
-          message: `bootstrapUrls is empty, which is invalid. Please check your network connection and try again.`,
-          errorKind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
-          errorCode: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
-        });
-      }
-
-      this.config.minNodeCount = parseInt(minNodeCount, 10);
-      this.config.bootstrapUrls = bootstrapUrls;
-    } else if (
-      this.config.litNetwork === LitNetwork.Custom &&
-      this.config.bootstrapUrls.length < 1
-    ) {
-      log('using custom contracts: ', this.config.contractContext);
-
-      const minNodeCount = await LitContracts.getMinNodeCount(
-        this.config.litNetwork,
-        this.config.contractContext
-      );
-
-      const bootstrapUrls = await LitContracts.getValidators(
-        this.config.litNetwork,
-        this.config.contractContext
-      );
-
-      // Handle on staking contract is used to monitor epoch/validator changes
-      this._stakingContract = await LitContracts.getStakingContract(
-        this.config.litNetwork,
-        this.config.contractContext
-      );
-
-      log('Bootstrap urls: ', bootstrapUrls);
-      if (minNodeCount <= 0) {
-        throwError({
-          message: `minNodeCount is ${minNodeCount}, which is invalid. Please check your network connection and try again.`,
-          errorKind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
-          errorCode: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
-        });
-      }
-
-      if (bootstrapUrls.length <= 0) {
-        throwError({
-          message: `bootstrapUrls is empty, which is invalid. Please check your network connection and try again.`,
-          errorKind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
-          errorCode: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
-        });
-      }
-
-      this.config.minNodeCount = parseInt(minNodeCount, 10);
-      this.config.bootstrapUrls = bootstrapUrls;
-    } else if (
-      this.config.litNetwork === LitNetwork.Custom &&
-      this.config.bootstrapUrls.length >= 1 &&
-      this.config.rpcUrl
-    ) {
-      log('Using custom bootstrap urls:', this.config.bootstrapUrls);
-
-      // const provider = new ethers.providers.JsonRpcProvider(this.config.rpcUrl);
-
-      const minNodeCount = await LitContracts.getMinNodeCount(
+  private async _getValidatorData() {
+    const [minNodeCount, bootstrapUrls] = await Promise.all([
+      LitContracts.getMinNodeCount(
         this.config.litNetwork,
         this.config.contractContext,
-        this.config.rpcUrl!
-      );
-      this.config.minNodeCount = parseInt(minNodeCount, 10);
-
-      const bootstrapUrls = await LitContracts.getValidators(
+        this.config.rpcUrl
+      ),
+      LitContracts.getValidators(
         this.config.litNetwork,
         this.config.contractContext,
-        this.config.rpcUrl!
-      );
-      this.config.bootstrapUrls = bootstrapUrls;
+        this.config.rpcUrl
+      ),
+    ]);
 
-      this._stakingContract = await LitContracts.getStakingContract(
-        this.config.litNetwork,
-        this.config.contractContext,
-        this.config.rpcUrl!
-      );
-    } else {
-      return throwError({
-        message:
-          'Unsuported network has been provided please use a "litNetwork" option which is supported ("cayenne", "habanero", "manzano")',
-        errorKind: LIT_ERROR.INVALID_PARAM_TYPE.kind,
-        errorCode: LIT_ERROR.INVALID_PARAM_TYPE.code,
+    if (minNodeCount <= 0) {
+      throwError({
+        message: `minNodeCount is ${minNodeCount}, which is invalid. Please check your network connection and try again.`,
+        errorKind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+        errorCode: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
       });
     }
-  };
 
+    if (bootstrapUrls.length <= 0) {
+      throwError({
+        message: `bootstrapUrls is empty, which is invalid. Please check your network connection and try again.`,
+        errorKind: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.kind,
+        errorCode: LIT_ERROR.INVALID_ARGUMENT_EXCEPTION.name,
+      });
+    }
+
+    log('Bootstrap urls: ', bootstrapUrls);
+
+    return {
+      minNodeCount: parseInt(minNodeCount, 10),
+      bootstrapUrls,
+    };
+  }
+
+  // ========== Scoped Class Helpers ==========
   /** Schedule an update to the current epoch number for EPOCH_PROPAGATION_DELAY seconds from now
    * We don't immediately update this value on `NextValidatorSetLocked` state changes because we want to give the nodes
    * a few seconds to update to the new epoch before we start sending the new epoch number with requests
@@ -383,11 +301,11 @@ export class LitCore {
           log(
             'State found to be new validator set locked, checking validator set'
           );
-          const oldNodeUrls: string[] = [...this.config.bootstrapUrls].sort();
-          await this.setNewConfig();
-          const currentNodeUrls: string[] = this.config.bootstrapUrls.sort();
-          const delta: string[] = currentNodeUrls.filter((item) =>
-            oldNodeUrls.includes(item)
+          const existingNodeUrls: string[] = [...this.config.bootstrapUrls];
+          const { bootstrapUrls: newNodeUrls } = await this._getValidatorData();
+
+          const delta: string[] = newNodeUrls.filter((item) =>
+            existingNodeUrls.includes(item)
           );
           // if the sets differ we reconnect.
           if (delta.length > 1) {
@@ -563,7 +481,37 @@ export class LitCore {
     // Ensure we don't fire an existing network sync poll handler while we're in the midst of connecting anyway
     this._stopNetworkPolling();
 
-    await this.setNewConfig();
+    if (this.config.litNetwork === LitNetwork.Custom) {
+      log('using custom contracts: ', this.config.contractContext);
+    }
+
+    // Initialize a contractContext if we were not given one; this allows interaction against the staking contract
+    // to be handled locally from then on
+    if (!this.config.contractContext) {
+      this.config.contractContext = await LitContracts.getContractAddresses(
+        this.config.litNetwork,
+        new ethers.providers.JsonRpcProvider(
+          this.config.rpcUrl || LIT_CHAINS['lit'].rpcUrls[0]
+        )
+      );
+    }
+
+    // Re-use staking contract instance from previous connect() executions that succeeded to improve performance
+    // noinspection ES6MissingAwait - intentionally not `awaiting` so we can run this in parallel below
+    const getStakingContract =
+      this._stakingContract ||
+      LitContracts.getStakingContract(
+        this.config.litNetwork,
+        this.config.contractContext, // We've already primed the `contractContext`
+        this.config.rpcUrl
+      );
+
+    const [{ minNodeCount, bootstrapUrls }, stakingContract] =
+      await Promise.all([this._getValidatorData(), getStakingContract]);
+
+    this._stakingContract = stakingContract; // Note: This may be a no-op if it was already set from prior connect run
+    this.config.minNodeCount = minNodeCount;
+    this.config.bootstrapUrls = bootstrapUrls;
 
     // Already scheduled update for current epoch number (due to a recent epoch change)
     // Skip setting it right now, because we haven't waited long enough for nodes to propagate the new epoch

--- a/packages/pkp-base/src/lib/pkp-base.ts
+++ b/packages/pkp-base/src/lib/pkp-base.ts
@@ -8,6 +8,10 @@
  * initializing the class instances.
  */
 
+import { publicKeyConvert } from 'secp256k1';
+
+import { LitNodeClient } from '@lit-protocol/lit-node-client';
+import { logError } from '@lit-protocol/misc';
 import {
   AuthenticationProps,
   JsonExecutionSdkParams,
@@ -20,9 +24,6 @@ import {
   ExecuteJsResponse,
   SessionSigsMap,
 } from '@lit-protocol/types';
-import { LitNodeClient } from '@lit-protocol/lit-node-client';
-import { publicKeyConvert } from 'secp256k1';
-import { logError } from '@lit-protocol/misc';
 
 /**
  * Compresses a given public key.
@@ -105,12 +106,9 @@ export class PKPBase<T = PKPBaseDefaultParams> {
       (prop.litNodeClient as LitNodeClient) ||
       new LitNodeClient({
         litNetwork: prop.litNetwork ?? 'cayenne',
-        ...(prop.bootstrapUrls &&
-          prop.litNetwork === 'custom' && {
-            bootstrapUrls: prop.bootstrapUrls,
-          }),
-        ...(prop.bootstrapUrls &&
-          prop.litNetwork == 'custom' && { minNodeCount: prop.minNodeCount }),
+        ...(prop.minNodeCount && prop.litNetwork == 'custom'
+          ? { minNodeCount: prop.minNodeCount }
+          : {}),
         debug: this.debug,
         // minNodeCount:
         //   prop.bootstrapUrls && prop.litNetwork == 'custom'

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -3,6 +3,8 @@ import { Provider } from '@ethersproject/abstract-provider';
 import * as JSZip from 'jszip/dist/jszip.js';
 
 import { ILitNodeClient } from './ILitNodeClient';
+import { ISessionCapabilityObject, LitResourceAbilityRequest } from './models';
+import { SigningAccessControlConditionRequest } from './node-interfaces/node-interfaces';
 import {
   AcceptedFileType,
   AccessControlConditions,
@@ -18,8 +20,6 @@ import {
   SymmetricKey,
   UnifiedAccessControlConditions,
 } from './types';
-import { ISessionCapabilityObject, LitResourceAbilityRequest } from './models';
-import { SigningAccessControlConditionRequest } from './node-interfaces/node-interfaces';
 /** ---------- Access Control Conditions Interfaces ---------- */
 
 export interface ABIParams {
@@ -199,7 +199,7 @@ export interface LitNodeClientConfig {
   contractContext?: LitContractContext | LitContractResolverContext;
   storageProvider?: StorageProvider;
   defaultAuthCallback?: (authSigParams: AuthCallbackParams) => Promise<AuthSig>;
-  rpcUrl?: string | null;
+  rpcUrl?: string;
 }
 
 export type CustomNetwork = Pick<
@@ -237,7 +237,7 @@ pub struct JsonExecutionRequest {
   pub auth_sig: AuthSigItem,
   #[serde(default = "default_epoch")]
   pub epoch: u64,
-  
+
   pub ipfs_id: Option<String>,
   pub code: Option<String>,
     pub js_params: Option<Value>,
@@ -1871,19 +1871,17 @@ export type GetLitActionSessionSigs = CommonGetSessionSigsProps &
       })
   );
 
-export type SessionKeyCache = {
+export interface SessionKeyCache {
   value: SessionKeyPair;
   timestamp: number;
-};
+}
 
 export interface SignatureData {
   signature: string;
   derivedKeyId: string;
 }
 
-export type ClaimsList = {
-  [key: string]: SignatureData;
-}[];
+export type ClaimsList = Record<string, SignatureData>[];
 
 export interface MintWithAuthParams {
   /**
@@ -1920,8 +1918,8 @@ export interface MintWithAuthResponse<T> {
 
 export interface BlockHashErrorResponse {
   messages: string[];
-  reason: String;
-  codde: Number;
+  reason: string;
+  codde: number;
 }
 
 export interface EthBlockhashInfo {

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -193,7 +193,6 @@ export interface LitNodeClientConfig {
   alertWhenUnauthorized?: boolean;
   minNodeCount?: number;
   debug?: boolean;
-  bootstrapUrls?: string[];
   connectTimeout?: number;
   checkNodeAttestation?: boolean;
   contractContext?: LitContractContext | LitContractResolverContext;
@@ -204,7 +203,7 @@ export interface LitNodeClientConfig {
 
 export type CustomNetwork = Pick<
   LitNodeClientConfig,
-  'litNetwork' | 'bootstrapUrls' | 'contractContext' | 'checkNodeAttestation'
+  'litNetwork' | 'contractContext' | 'checkNodeAttestation'
 > &
   Partial<Pick<LitNodeClientConfig, 'minNodeCount'>>;
 
@@ -1211,7 +1210,6 @@ export interface PKPBaseProp {
   authContext?: AuthenticationProps;
   litNetwork?: any;
   debug?: boolean;
-  bootstrapUrls?: string[];
   minNodeCount?: number;
   litActionCode?: string;
   litActionIPFS?: string;


### PR DESCRIPTION
# Description

### Improves connect() performance by parallelizing some operations performed during connection to the LIT network.
- Solution leverages the existing `contractContext`functionality to maintain backwards compatibility with consumers who use that API
- Fixed `config.rpcUrl` being optional string, but also a union with `null` -- this conflicted with the definition of same in the contract SDK and it made no sense to default an optional parameter to `null` anyway 🤦  :)
- Moved verification of the `litNetwork` to the constructor rather than it being nestled inside of `setConfig()` where it would explode the first time someone actually connected with the client after configuring it with an invalid network
- Removed `setNewConfig`, which was an internal method that would leave the core / client in an inconsistent state if ever called outside of the `connect()` flow.
- Standardized initialization so that we no longer have different _looking_ branches that actually _behave identically_ for all networks.  It turns out `setConfig()` was much less complex in _practice_ than it looked at first glance.
- Note that this appears to remove the 'using custom `bootstrapUrls`' logic -- but this functionality was _already not functional_; we always overrode `config.bootstrapUrls` with values returned from the chain or the lit-general-worker during `connect()` processing.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Ran local tests against Habanero and Cayenn

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
