### PR TITLE
fix(core): contract context

### DIFF
--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -491,7 +491,11 @@ export class LitCore {
           this.config.rpcUrl || LIT_CHAINS['lit'].rpcUrls[0]
         )
       );
-    } else if (!this.config.contractContext.Staking) {
+    } else if (
+      !this.config.contractContext.Staking &&
+      !this.config.contractContext.resolverAddress
+    ) {
+      console.log(this.config.contractContext);
       throw new Error(
         'The provided contractContext was missing the "Staking" contract`'
       );


### PR DESCRIPTION
Fixes a small bug from pr #502 where we would not respect the `contractResolver` address if provided which breaks some local development flows.
