### PR TITLE
Hwrdtm/datil dev support

### DIFF
--- a/local-tests/setup/tinny-config.ts
+++ b/local-tests/setup/tinny-config.ts
@@ -5,6 +5,7 @@ export enum LIT_TESTNET {
   LOCALCHAIN = 'localchain',
   MANZANO = 'manzano',
   CAYENNE = 'cayenne',
+  DATIL_DEV = 'datil-dev',
 }
 
 export interface ProcessEnvs {
@@ -18,6 +19,7 @@ export interface ProcessEnvs {
    * - `LIT_TESTNET.LOCALCHAIN`
    * - `LIT_TESTNET.MANZANO`
    * - `LIT_TESTNET.CAYENNE`
+   * - `LIT_TESTNET.DATIL_DEV`
    */
   NETWORK: LIT_TESTNET;
 

--- a/local-tests/setup/tinny-environment.ts
+++ b/local-tests/setup/tinny-environment.ts
@@ -13,6 +13,8 @@ import { ethers } from 'ethers';
 import { createSiweMessage, generateAuthSig } from '@lit-protocol/auth-helpers';
 import { ShivaClient, TestnetClient } from './shiva-client';
 
+import networkContext from './networkContext.datilDev.json';
+
 export class TinnyEnvironment {
   public network: LIT_TESTNET;
 
@@ -196,7 +198,8 @@ export class TinnyEnvironment {
     console.log('[𐬺🧪 Tinny Environment𐬺] Setting up LitNodeClient');
 
     if (this.network === LIT_TESTNET.LOCALCHAIN) {
-      const networkContext = this._testnet.ContractContext;
+      // const networkContext = this._testnet.ContractContext;
+      // const networkContext = import('./networks/localchain.json');
       this.litNodeClient = new LitNodeClient({
         litNetwork: 'custom',
         rpcUrl: this.processEnvs.LIT_RPC_URL,
@@ -317,10 +320,10 @@ export class TinnyEnvironment {
       return;
     }
     if (this.network === LIT_TESTNET.LOCALCHAIN) {
-      this._testnet = await this._shivaClient.startTestnetManager();
-      // wait for the testnet to be active before we start the tests.
-      await this._testnet.pollTestnetForActive();
-      await this._testnet.getTestnetConfig();
+      // this._testnet = await this._shivaClient.startTestnetManager();
+      // // wait for the testnet to be active before we start the tests.
+      // await this._testnet.pollTestnetForActive();
+      // await this._testnet.getTestnetConfig();
     }
 
     await this.setupLitNodeClient();
@@ -380,7 +383,7 @@ export class TinnyEnvironment {
      * ====================================
      */
     if (this.network === LIT_TESTNET.LOCALCHAIN) {
-      const networkContext = this._testnet.ContractContext;
+      // const networkContext = this._testnet.ContractContext;
       this.contractsClient = new LitContracts({
         signer: wallet,
         debug: this.processEnvs.DEBUG,

--- a/local-tests/setup/tinny-person.ts
+++ b/local-tests/setup/tinny-person.ts
@@ -14,6 +14,8 @@ import { LIT_TESTNET, PKPInfo, TinnyEnvConfig } from './tinny-config';
 import { EthWalletProvider } from '@lit-protocol/lit-auth-client';
 import { AuthMethodScope } from '@lit-protocol/constants';
 
+import networkContext from './networkContext.datilDev.json';
+
 export class TinnyPerson {
   public privateKey: string;
   public wallet: ethers.Wallet;
@@ -101,7 +103,7 @@ export class TinnyPerson {
     //  * ====================================
     //  */
     if (this.envConfig.network === LIT_TESTNET.LOCALCHAIN) {
-      const networkContext = this.envConfig.contractContext;
+      // const networkContext = this.envConfig.contractContext;
       this.contractsClient = new LitContracts({
         signer: this.wallet,
         debug: this.envConfig.processEnvs.DEBUG,

--- a/local-tests/tests/testCosmosAuthSigToEncryptDecryptString.ts
+++ b/local-tests/tests/testCosmosAuthSigToEncryptDecryptString.ts
@@ -9,6 +9,7 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
  * ❌ NETWORK=cayenne yarn test:local --filter=testCosmosAuthSigToEncryptDecryptString
  * ❌ NETWORK=manzano yarn test:local --filter=testCosmosAuthSigToEncryptDecryptString
  * ❌ NETWORK=localchain yarn test:local --filter=testCosmosAuthSigToEncryptDecryptString
+ * ❌ NETWORK=datil-dev yarn test:local --filter=testCosmosAuthSigToEncryptDecryptString
  */
 export const testCosmosAuthSigToEncryptDecryptString = async (
   devEnv: TinnyEnvironment
@@ -18,6 +19,7 @@ export const testCosmosAuthSigToEncryptDecryptString = async (
   devEnv.setUnavailable(LIT_TESTNET.CAYENNE);
   devEnv.setUnavailable(LIT_TESTNET.LOCALCHAIN);
   devEnv.setUnavailable(LIT_TESTNET.MANZANO);
+  devEnv.setUnavailable(LIT_TESTNET.DATIL_DEV);
 
   const accs = AccessControlConditions.getCosmosBasicAccessControlConditions({
     userAddress: devEnv.bareCosmosAuthSig.address,

--- a/local-tests/tests/testExecuteJsBroadcastAndCollect.ts
+++ b/local-tests/tests/testExecuteJsBroadcastAndCollect.ts
@@ -8,6 +8,7 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
  * ✅ NETWORK=cayenne yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptString
  * ❌ NOT AVAILABLE IN MANZANO
  * ✅ NETWORK=localchain yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptString
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptString
  *
  */
 export const testExecuteJsBroadcastAndCollect = async (

--- a/local-tests/tests/testExecuteJsDecryptAndCombine.ts
+++ b/local-tests/tests/testExecuteJsDecryptAndCombine.ts
@@ -16,6 +16,7 @@ import * as accessControlConditions from '@lit-protocol/access-control-condition
  * ✅ NETWORK=cayenne yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptString
  * ❌ NOT AVAILABLE IN MANZANO
  * ✅ NETWORK=localchain yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptString
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptString
  *
  */
 export const testExecutJsDecryptAndCombine = async (

--- a/local-tests/tests/testUseInvalidLitActionCodeToGenerateSessionSigs.ts
+++ b/local-tests/tests/testUseInvalidLitActionCodeToGenerateSessionSigs.ts
@@ -7,6 +7,7 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
  * ✅ NETWORK=cayenne yarn test:local --filter=testUseInvalidLitActionCodeToGenerateSessionSigs
  * ❌ NOT AVAILABLE IN MANZANO
  * ✅ NETWORK=localchain yarn test:local --filter=testUseInvalidLitActionCodeToGenerateSessionSigs
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUseInvalidLitActionCodeToGenerateSessionSigs
  */
 export const testUseInvalidLitActionCodeToGenerateSessionSigs = async (
   devEnv: TinnyEnvironment

--- a/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptFile.ts
+++ b/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptFile.ts
@@ -13,6 +13,7 @@ import { getLitActionSessionSigs } from 'local-tests/setup/session-sigs/get-lit-
  * ✅ NETWORK=cayenne yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptFile
  * ✅ NETWORK=manzano yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptFile
  * ✅ NETWORK=localchain yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptFile
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptFile
  */
 export const testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptFile =
   async (devEnv: TinnyEnvironment) => {

--- a/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptString.ts
+++ b/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptString.ts
@@ -12,6 +12,7 @@ import { log } from '@lit-protocol/misc';
  * ✅ NETWORK=cayenne yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptString
  * ❌ NOT AVAILABLE IN MANZANO
  * ✅ NETWORK=localchain yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptString
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptString
  *
  */
 export const testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptString =

--- a/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptZip.ts
+++ b/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptZip.ts
@@ -9,9 +9,10 @@ import { log } from '@lit-protocol/misc';
 
 /**
  * Test Commands:
- * ❌ Not supported in Cayenne
+ * ✅ NETWORK=cayenne yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptZip
  * ❌ Not supported in Manzano
  * ✅ NETWORK=localchain yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptZip
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptZip
  */
 export const testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptZip =
   async (devEnv: TinnyEnvironment) => {

--- a/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsClaimKeys.ts
+++ b/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsClaimKeys.ts
@@ -15,9 +15,10 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
  * - Then: The claim operation should successfully return signatures, derived key IDs, and validate the existence and structure of claimed results.
  * *
  * Test Commands:
- * ❌ Not supported in Cayenne
+ * ✅ NETWORK=cayenne yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsClaimMultipleKeys
  * ❌ Not supported in Manzano
  * ✅ NETWORK=localchain yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsClaimKeys
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsClaimKeys
  */
 export const testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsClaimKeys =
   async (devEnv: TinnyEnvironment) => {

--- a/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsClaimMultipleKeys.ts
+++ b/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsClaimMultipleKeys.ts
@@ -13,9 +13,10 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
  * - Then: The claim operation should successfully return signatures, derived key IDs, and validate the existence and structure of claimed results.
  * *
  * Test Commands:
- * ❌ Not supported in Cayenne
+ * ✅ NETWORK=cayenne yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsClaimMultipleKeys
  * ❌ Not supported in Manzano
  * ✅ NETWORK=localchain yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsClaimMultipleKeys
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsClaimMultipleKeys
  */
 export const testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsClaimMultipleKeys =
   async (devEnv: TinnyEnvironment) => {

--- a/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsConsoleLog.ts
+++ b/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsConsoleLog.ts
@@ -7,9 +7,10 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ❌ Not supported on cayenne
+ * ✅ NETWORK=cayenne yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsConsoleLog
  * ❌ Not supported on manzano
  * ✅ NETWORK=localchain yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsConsoleLog
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsConsoleLog
  */
 export const testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsConsoleLog =
   async (devEnv: TinnyEnvironment) => {

--- a/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsJsonResponse.ts
+++ b/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsJsonResponse.ts
@@ -5,9 +5,10 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ❌ Not supported on cayenne
+ * ✅ NETWORK=cayenne yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsJsonResponse
  * ❌ Not supported on manzano
  * ✅ NETWORK=localchain yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsJsonResponse
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsJsonResponse
  */
 export const testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsJsonResponse =
   async (devEnv: TinnyEnvironment) => {

--- a/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsSigning.ts
+++ b/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsSigning.ts
@@ -11,6 +11,7 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
  * ✅ NETWORK=cayenne yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsSigning
  * ❌ NOT AVAILABLE IN HABANERO
  * ✅ NETWORK=localchain yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsSigning
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsSigning
  */
 export const testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsSigning =
   async (devEnv: TinnyEnvironment) => {

--- a/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsSigningInParallel.ts
+++ b/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsSigningInParallel.ts
@@ -9,6 +9,7 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
  * ✅ NETWORK=cayenne yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsSigningInParallel
  * ❌ Not available in Habanero
  * ✅ NETWORK=localchain yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsSigningInParallel
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsSigningInParallel
  */
 export const testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsSigningInParallel =
   async (devEnv: TinnyEnvironment) => {

--- a/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToPkpSign.ts
+++ b/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToPkpSign.ts
@@ -11,6 +11,7 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
  * ✅ NETWORK=cayenne yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToPkpSign
  * ❌ NOT AVAILABLE IN HABANERO
  * ✅ NETWORK=localchain yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToPkpSign
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToPkpSign
  *
  **/
 export const testUseValidLitActionCodeGeneratedSessionSigsToPkpSign = async (

--- a/packages/constants/src/lib/constants/constants.ts
+++ b/packages/constants/src/lib/constants/constants.ts
@@ -477,6 +477,17 @@ export const LIT_CHAINS: LITChain<LITEVMChain> = {
     type: null,
     vmType: 'EVM',
   },
+  datilDevnet: {
+    contractAddress: null,
+    chainId: 2311,
+    name: 'Chronicle - Lit Protocol V1 Devnet',
+    symbol: 'tstLIT',
+    decimals: 18,
+    rpcUrls: ['https://vesuvius-rpc.litprotocol.com/'],
+    blockExplorerUrls: ['https://vesuvius-explorer.litprotocol.com/'],
+    type: null,
+    vmType: 'EVM',
+  },
   lit: {
     contractAddress: null,
     chainId: 175177,
@@ -761,6 +772,7 @@ export const LIT_NETWORKS: { [key in LitNetwork]: string[] } & {
 } = {
   [LitNetwork.Cayenne]: [],
   [LitNetwork.Manzano]: [],
+  [LitNetwork.DatilDev]: [],
   [LitNetwork.Habanero]: [],
   [LitNetwork.Custom]: [],
   // FIXME: Remove localhost and internalDev; replaced with 'custom' type networks
@@ -802,6 +814,8 @@ export const RELAY_URL_CAYENNE =
   'https://relayer-server-staging-cayenne.getlit.dev';
 export const RELAY_URL_HABANERO = 'https://habanero-relayer.getlit.dev';
 export const RELAY_URL_MANZANO = 'https://manzano-relayer.getlit.dev';
+export const RELAY_URL_DATIL_DEV =
+  'https://relayer-server-datil-dev.getlit.dev';
 
 // ========== Lit Actions ==========
 export const LIT_ACTION_IPFS_HASH =

--- a/packages/constants/src/lib/enums.ts
+++ b/packages/constants/src/lib/enums.ts
@@ -58,6 +58,7 @@ export enum LitNetwork {
   Manzano = 'manzano',
   Habanero = 'habanero',
   Custom = 'custom',
+  DatilDev = 'datil-dev',
 }
 
 /**

--- a/packages/contracts-sdk/src/lib/contracts-sdk.ts
+++ b/packages/contracts-sdk/src/lib/contracts-sdk.ts
@@ -114,7 +114,13 @@ export class LitContracts {
   connected: boolean = false;
   isPKP: boolean = false;
   debug: boolean = false;
-  network: 'cayenne' | 'manzano' | 'habanero' | 'custom' | 'localhost';
+  network:
+    | 'cayenne'
+    | 'manzano'
+    | 'habanero'
+    | 'custom'
+    | 'localhost'
+    | 'datil-dev';
   customContext?: LitContractContext | LitContractResolverContext;
 
   static logger: Logger = LogManager.Instance.get('contract-sdk');
@@ -190,7 +196,13 @@ export class LitContracts {
       storeOrUseStorageKey?: boolean;
     };
     debug?: boolean;
-    network?: 'cayenne' | 'custom' | 'localhost' | 'manzano' | 'habanero';
+    network?:
+      | 'cayenne'
+      | 'custom'
+      | 'localhost'
+      | 'manzano'
+      | 'habanero'
+      | 'datil-dev';
   }) {
     // this.provider = args?.provider;
     this.customContext = args?.customContext;
@@ -572,7 +584,13 @@ export class LitContracts {
   };
 
   public static async getStakingContract(
-    network: 'cayenne' | 'manzano' | 'habanero' | 'custom' | 'localhost',
+    network:
+      | 'cayenne'
+      | 'manzano'
+      | 'habanero'
+      | 'custom'
+      | 'localhost'
+      | 'datil-dev',
     context?: LitContractContext | LitContractResolverContext,
     rpcUrl?: string
   ) {
@@ -757,7 +775,13 @@ export class LitContracts {
   }
 
   public static async getContractAddresses(
-    network: 'cayenne' | 'custom' | 'localhost' | 'manzano' | 'habanero',
+    network:
+      | 'cayenne'
+      | 'custom'
+      | 'localhost'
+      | 'manzano'
+      | 'habanero'
+      | 'datil-dev',
     provider: ethers.providers.JsonRpcProvider,
     context?: LitContractContext | LitContractResolverContext
   ) {
@@ -855,7 +879,13 @@ export class LitContracts {
   }
 
   public static getMinNodeCount = async (
-    network: 'cayenne' | 'manzano' | 'habanero' | 'custom' | 'localhost',
+    network:
+      | 'cayenne'
+      | 'manzano'
+      | 'habanero'
+      | 'custom'
+      | 'localhost'
+      | 'datil-dev',
     context?: LitContractContext | LitContractResolverContext,
     rpcUrl?: string
   ) => {
@@ -874,7 +904,13 @@ export class LitContracts {
   };
 
   public static getValidators = async (
-    network: 'cayenne' | 'manzano' | 'habanero' | 'custom' | 'localhost',
+    network:
+      | 'cayenne'
+      | 'manzano'
+      | 'habanero'
+      | 'custom'
+      | 'localhost'
+      | 'datil-dev',
     context?: LitContractContext | LitContractResolverContext,
     rpcUrl?: string
   ): Promise<string[]> => {
@@ -934,7 +970,13 @@ export class LitContracts {
   };
 
   private static async _resolveContractContext(
-    network: 'cayenne' | 'manzano' | 'habanero' | 'custom' | 'localhost',
+    network:
+      | 'cayenne'
+      | 'manzano'
+      | 'habanero'
+      | 'custom'
+      | 'localhost'
+      | 'datil-dev',
     context?: LitContractContext | LitContractResolverContext
   ) {
     let data;

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -150,6 +150,7 @@ export class LitCore {
 
     // Initialize default config based on litNetwork
     switch (config?.litNetwork) {
+      case LitNetwork.DatilDev:
       case LitNetwork.Cayenne:
         this.config = {
           ...this.config,

--- a/packages/misc/src/lib/misc.ts
+++ b/packages/misc/src/lib/misc.ts
@@ -7,6 +7,7 @@ import {
   LIT_ERROR,
   LitNetwork,
   RELAY_URL_CAYENNE,
+  RELAY_URL_DATIL_DEV,
   RELAY_URL_HABANERO,
   RELAY_URL_MANZANO,
 } from '@lit-protocol/constants';
@@ -676,6 +677,10 @@ export const defaultMintClaimCallback: MintCallback<
         break;
       case LitNetwork.Manzano:
         relayUrl = RELAY_URL_MANZANO + 'auth/claim';
+        break;
+      case LitNetwork.DatilDev:
+        relayUrl = RELAY_URL_DATIL_DEV + '/auth/claim';
+        break;
     }
 
     const url = params.relayUrl ? params.relayUrl : relayUrl;

--- a/packages/types/src/lib/types.ts
+++ b/packages/types/src/lib/types.ts
@@ -123,6 +123,7 @@ export type LITChain<T> = {
 
 export type LIT_NETWORKS_KEYS =
   | 'cayenne'
+  | 'datil-dev'
   | 'localhost'
   | 'custom'
   | 'habanero'


### PR DESCRIPTION
# Description

Work towards LIT-3404.

This PR:
- Implements changes to support `datil-dev` as a Lit network, both in the core packages and also in the `local-tests` (Tinny). **More importantly, this PR is INCOMPLETE ⚠️ ⚠️ ⚠️**. It currently uses a hack to load in the network context for running against Datil-dev.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Run `DEBUG=true NETWORK=localchain LIT_RPC_URL=https://vesuvius-rpc.litprotocol.com yarn test:local` to run against Datil-dev. 

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

# Datil Dev Network Context

[networkContext.datilDev.json](https://github.com/user-attachments/files/15908466/networkContext.datilDev.json)
