### PR TITLE
check timestamps of BLS session sigs

### DIFF
--- a/packages/lit-node-client-nodejs/src/lib/helpers/validate-bls-session-sig.ts
+++ b/packages/lit-node-client-nodejs/src/lib/helpers/validate-bls-session-sig.ts
@@ -1,6 +1,7 @@
 import { AuthSig } from '@lit-protocol/types';
 import { uint8arrayToString } from '@lit-protocol/uint8arrays';
 import { ethers } from 'ethers';
+import { SiweError, SiweErrorType, SiweMessage } from 'siwe';
 
 const LIT_SESSION_SIGNED_MESSAGE_PREFIX = 'lit_session:';
 
@@ -18,7 +19,8 @@ export const blsSessionSigVerify = (
   // TODO: refactor type with merger of PR 'https://github.com/LIT-Protocol/js-sdk/pull/503`
   verifier: (public_key: any, message: any, signature: any) => void,
   networkPubKey: string,
-  authSig: AuthSig
+  authSig: AuthSig,
+  authSigSiweMessage: SiweMessage
 ): void => {
   let sigJson = JSON.parse(authSig.sig);
   // we do not nessesarly need to use ethers here but was a quick way
@@ -31,6 +33,34 @@ export const blsSessionSigVerify = (
     ethers.utils.sha256(prefixedEncoded)
   );
   const signatureBytes = Buffer.from(sigJson.ProofOfPossession, `hex`);
+
+  /** Check time or now */
+  const checkTime = new Date();
+
+  if (!authSigSiweMessage.expirationTime || !authSigSiweMessage.notBefore) {
+    throw new Error(
+      'Invalid SIWE message. Missing expirationTime or notBefore.'
+    );
+  }
+
+  // check timestamp of SIWE
+  const expirationDate = new Date(authSigSiweMessage.expirationTime);
+  if (checkTime.getTime() >= expirationDate.getTime()) {
+    throw new SiweError(
+      SiweErrorType.EXPIRED_MESSAGE,
+      `${checkTime.toISOString()} < ${expirationDate.toISOString()}`,
+      `${checkTime.toISOString()} >= ${expirationDate.toISOString()}`
+    );
+  }
+
+  const notBefore = new Date(authSigSiweMessage.notBefore);
+  if (checkTime.getTime() < notBefore.getTime()) {
+    throw new SiweError(
+      SiweErrorType.NOT_YET_VALID_MESSAGE,
+      `${checkTime.toISOString()} >= ${notBefore.toISOString()}`,
+      `${checkTime.toISOString()} < ${notBefore.toISOString()}`
+    );
+  }
 
   verifier(
     networkPubKey,

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -518,7 +518,7 @@ export class LitNodeClientNodeJs
     // it will fail. If the  algo is not defined we can assume that it was an EOA wallet signing the message so we can use SIWE.
     if (authSig.algo === `ed25519` || authSig.algo === undefined) {
       try {
-        await authSigSiweMessage.validate(authSig.sig);
+        await authSigSiweMessage.verify(authSig.sig);
       } catch (e) {
         log(`Error while verifying ECDSA signature: `, e);
         return true;
@@ -528,7 +528,8 @@ export class LitNodeClientNodeJs
         blsSessionSigVerify(
           blsSdk.verify_signature,
           this.networkPubKey!,
-          authSig
+          authSig,
+          authSigSiweMessage
         );
       } catch (e) {
         log(`Error while verifying bls signature: `, e);


### PR DESCRIPTION
A user found a bug where the SDK was sending an expired BLS session sig.  I discovered that we aren't checking the expiration when we are checking if we need to resign the session key.  We do this check for ECDSA, because it's built into SIWE, but we can't use SIWE verification for the BLS session sig, because SIWE doesn't understand BLS.  

So we're checking the sig already, and this PR just copy/pastes the timestamp verification code from the SIWE repo here: https://github.com/spruceid/siwe/blob/main/packages/siwe/lib/client.ts#L289

This makes it so that we check the expiration and issued at time, and then throw an error if they're not valid.  The calling function (`checkNeedToResignSessionKey()`) catches errors and will try to re-sign if the SIWE is expired.