### PR TITLE
LIT-3688 - Handle more cases for talking to the lit nodes across epoch transitions

### DIFF
--- a/local-tests/setup/tinny-environment.ts
+++ b/local-tests/setup/tinny-environment.ts
@@ -18,6 +18,7 @@ import { TinnyPerson } from './tinny-person';
 import { ethers } from 'ethers';
 import { createSiweMessage, generateAuthSig } from '@lit-protocol/auth-helpers';
 import { ShivaClient, TestnetClient } from './shiva-client';
+import { toErrorWithMessage } from './tinny-utils';
 
 console.log('Loading env vars from dot config...');
 console.log('Done loading env', process.env['DEBUG']);
@@ -364,9 +365,18 @@ export class TinnyEnvironment {
       this._contractContext = context;
     }
 
-    await this.setupLitNodeClient();
-    await this.setupSuperCapacityDelegationAuthSig();
-    await this.setupBareEthAuthSig();
+    try {
+      await this.setupLitNodeClient();
+      await this.setupSuperCapacityDelegationAuthSig();
+      await this.setupBareEthAuthSig();
+    } catch (e) {
+      const err = toErrorWithMessage(e);
+      console.log(
+        `[𐬺🧪 Tinny Environment𐬺] Failed to init() tinny ${err.message}`
+      );
+      console.log(err.stack);
+      process.exit(1);
+    }
   }
 
   /**

--- a/local-tests/setup/tinny-environment.ts
+++ b/local-tests/setup/tinny-environment.ts
@@ -344,28 +344,31 @@ export class TinnyEnvironment {
    * Init
    */
   async init() {
-    if (this.processEnvs.NO_SETUP) {
-      console.log('[𐬺🧪 Tinny Environment𐬺] Skipping setup');
-      return;
-    }
-    if (this.network === LIT_TESTNET.LOCALCHAIN && this.processEnvs.USE_SHIVA) {
-      this.testnet = await this._shivaClient.startTestnetManager();
-      // wait for the testnet to be active before we start the tests.
-      let state = await this.testnet.pollTestnetForActive();
-      if (state === `UNKNOWN`) {
-        console.log(
-          'Testnet state found to be Unknown meaning there was an error with testnet creation. shutting down'
-        );
-        throw new Error(`Error while creating testnet, aborting test run`);
+    try {
+      if (this.processEnvs.NO_SETUP) {
+        console.log('[𐬺🧪 Tinny Environment𐬺] Skipping setup');
+        return;
+      }
+      if (
+        this.network === LIT_TESTNET.LOCALCHAIN &&
+        this.processEnvs.USE_SHIVA
+      ) {
+        this.testnet = await this._shivaClient.startTestnetManager();
+        // wait for the testnet to be active before we start the tests.
+        let state = await this.testnet.pollTestnetForActive();
+        if (state === `UNKNOWN`) {
+          console.log(
+            'Testnet state found to be Unknown meaning there was an error with testnet creation. shutting down'
+          );
+          throw new Error(`Error while creating testnet, aborting test run`);
+        }
+
+        await this.testnet.getTestnetConfig();
+      } else if (this.network === LIT_TESTNET.LOCALCHAIN) {
+        const context = await import('./networkContext.json');
+        this._contractContext = context;
       }
 
-      await this.testnet.getTestnetConfig();
-    } else if (this.network === LIT_TESTNET.LOCALCHAIN) {
-      const context = await import('./networkContext.json');
-      this._contractContext = context;
-    }
-
-    try {
       await this.setupLitNodeClient();
       await this.setupSuperCapacityDelegationAuthSig();
       await this.setupBareEthAuthSig();

--- a/local-tests/setup/tinny-utils.ts
+++ b/local-tests/setup/tinny-utils.ts
@@ -63,3 +63,25 @@ export function withTimeout<T>(
   );
   return Promise.race([promise, timeout]);
 }
+
+function isErrorWithMessage(error: unknown): error is Error {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'message' in error &&
+    typeof (error as Record<string, unknown>).message === 'string'
+  );
+}
+
+// eslint-disable-next-line import/prefer-default-export
+export function toErrorWithMessage(maybeError: unknown): Error {
+  if (isErrorWithMessage(maybeError)) return maybeError as Error;
+
+  try {
+    return new Error(JSON.stringify(maybeError));
+  } catch {
+    // fallback in case there's an error stringifying the maybeError
+    // like with circular references for example.
+    return new Error(String(maybeError));
+  }
+}

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -860,7 +860,7 @@ export class LitCore {
     }
 
     try {
-      const epoch = this._stakingContract['epoch']();
+      const epoch = await this._stakingContract['epoch']();
 
       // when we transition to the new epoch, we don't store the start time.  but we
       // set the endTime to the current timestamp + epochLength.

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -106,7 +106,7 @@ export type LitNodeClientConfigWithDefaults = Required<
   };
 
 // On epoch change, we wait this many seconds for the nodes to update to the new epoch before using the new epoch #
-const EPOCH_PROPAGATION_DELAY = 30_000;
+const EPOCH_PROPAGATION_DELAY = 15_000;
 // This interval is responsible for keeping latest block hash up to date
 const BLOCKHASH_SYNC_INTERVAL = 30_000;
 
@@ -890,7 +890,7 @@ export class LitCore {
     if (!this._epochCache.currentNumber) {
       return null;
     }
-    // if the epoch started less than 30s ago (aka EPOCH_PROPAGATION_DELAY), use the previous epoch number
+    // if the epoch started less than 15s ago (aka EPOCH_PROPAGATION_DELAY), use the previous epoch number
     // this gives the nodes time to sync with the chain and see the new epoch before we try to use it
     if (
       this._epochCache.startTime &&

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -877,7 +877,7 @@ export class LitCore {
       };
     } catch (error) {
       return throwError({
-        message: `[setCurrentEpochNumber] Error getting current epoch number: ${error}`,
+        message: `[_fetchCurrentEpochState] Error getting current epoch number: ${error}`,
         errorKind: LIT_ERROR.UNKNOWN_ERROR.kind,
         errorCode: LIT_ERROR.UNKNOWN_ERROR.name,
       });

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -153,7 +153,7 @@ export class LitCore {
   private _connectingPromise: null | Promise<void> = null;
   private _epochCache: EpochCache = {
     currentNumber: null,
-    epochStartTime: null,
+    startTime: null,
   };
   private _blockHashUrl =
     'https://block-indexer.litgateway.com/get_most_recent_valid_block';
@@ -860,12 +860,13 @@ export class LitCore {
 
   private async setCurrentEpochNumber() {
     if (!this._stakingContract) {
-      return throwError({
+      throwError({
         message:
           'Unable to fetch current epoch number; no staking contract configured. Did you forget to `connect()`?',
         errorKind: LIT_ERROR.INIT_ERROR.kind,
         errorCode: LIT_ERROR.INIT_ERROR.name,
       });
+      return;
     }
 
     try {

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -267,9 +267,7 @@ export class LitCore {
       // We always want to track the most recent epoch number on _all_ networks
       this._epochState = await this._fetchCurrentEpochState();
 
-      if (
-        CENTRALISATION_BY_NETWORK[this.config.litNetwork] === 'decentralised'
-      ) {
+      if (CENTRALISATION_BY_NETWORK[this.config.litNetwork] !== 'centralised') {
         // We don't need to handle node urls changing on centralised networks, since their validator sets are static
         try {
           log(

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -15,6 +15,7 @@ import {
   validateUnifiedAccessControlConditionsSchema,
 } from '@lit-protocol/access-control-conditions';
 import {
+  CENTRALISATION_BY_NETWORK,
   HTTP,
   HTTPS,
   LIT_CURVE,
@@ -115,15 +116,6 @@ const NETWORKS_REQUIRING_SEV: string[] = [
   LitNetwork.Habanero,
   LitNetwork.Manzano,
   LitNetwork.DatilTest,
-];
-
-// The only network we consider entirely static, and thus ignore EPOCH changes for, is Cayenne
-const NETWORKS_WITH_EPOCH_CHANGES: string[] = [
-  LitNetwork.DatilDev,
-  LitNetwork.DatilTest,
-  LitNetwork.Habanero,
-  LitNetwork.Manzano,
-  LitNetwork.Custom,
 ];
 
 export class LitCore {
@@ -275,8 +267,10 @@ export class LitCore {
       // We always want to track the most recent epoch number on _all_ networks
       this._epochState = await this._fetchCurrentEpochState();
 
-      if (NETWORKS_WITH_EPOCH_CHANGES.includes(this.config.litNetwork)) {
-        // But we don't need to handle node urls changing on Cayenne, since it is static
+      if (
+        CENTRALISATION_BY_NETWORK[this.config.litNetwork] === 'decentralised'
+      ) {
+        // We don't need to handle node urls changing on centralised networks, since their validator sets are static
         try {
           log(
             'State found to be new validator set locked, checking validator set'


### PR DESCRIPTION
This PR essentially says:

if now < epoch start time + 30s, use `epoch number - 1`.  

if now >= epoch start time + 30s, then use `epoch number`

So, when an epoch transitions, we need to wait 30s before we start using it.  This is because, during that time, the nodes are in a transitionary state, and some may think they're on the next epoch, and some on the previous epoch.  By waiting 30s to send the new epoch, we give the nodes time to retrieve the new state.  Once 30s has elapsed, the nodes should all have seen and advanced to the new epoch, and it should be safe to send the new epoch.


So this PR removes the setTimeout that sets the new epoch number.  Instead, it looks at the epoch transition time from the chain, and starts to use the new epoch 30s after that has elapsed.  

This is better than the current system because it handles more cases.  

Suppose the user just connected via the SDK, and the epoch transitioned 1s ago.  If we use this new epoch number, and some nodes have not seen it yet, their signatures will fail.  This new strategy also works if the user is already connected via the SDK, and then the epoch transitions via the event listener.  