### PR TITLE
Bump versions to v6.1.0 pre-publish to NPM

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "useNx": true,
   "useWorkspaces": true,
-  "version": "6.1.0-beta.4"
+  "version": "6.1.0"
 }

--- a/packages/access-control-conditions/package.json
+++ b/packages/access-control-conditions/package.json
@@ -21,7 +21,7 @@
   "tags": [
     "universal"
   ],
-  "version": "6.1.0-beta.4",
+  "version": "6.1.0",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts"
 }

--- a/packages/auth-browser/package.json
+++ b/packages/auth-browser/package.json
@@ -30,7 +30,7 @@
   "tags": [
     "browser"
   ],
-  "version": "6.1.0-beta.4",
+  "version": "6.1.0",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts"
 }

--- a/packages/auth-helpers/package.json
+++ b/packages/auth-helpers/package.json
@@ -28,7 +28,7 @@
     "crypto": false,
     "stream": false
   },
-  "version": "6.1.0-beta.4",
+  "version": "6.1.0",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts"
 }

--- a/packages/bls-sdk/package.json
+++ b/packages/bls-sdk/package.json
@@ -27,7 +27,7 @@
   "buildOptions": {
     "genReact": false
   },
-  "version": "6.1.0-beta.4",
+  "version": "6.1.0",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts"
 }

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -20,7 +20,7 @@
   "tags": [
     "universal"
   ],
-  "version": "6.1.0-beta.4",
+  "version": "6.1.0",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts"
 }

--- a/packages/constants/src/lib/version.ts
+++ b/packages/constants/src/lib/version.ts
@@ -1,1 +1,1 @@
-export const version = '6.1.0-beta.4';
+export const version = '6.1.0';

--- a/packages/contracts-sdk/package.json
+++ b/packages/contracts-sdk/package.json
@@ -32,7 +32,7 @@
   "tags": [
     "universal"
   ],
-  "version": "6.1.0-beta.4",
+  "version": "6.1.0",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lit-protocol/core",
-  "version": "6.1.0-beta.4",
+  "version": "6.1.0",
   "type": "commonjs",
   "license": "MIT",
   "homepage": "https://github.com/Lit-Protocol/js-sdk",

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -21,7 +21,7 @@
   "tags": [
     "universal"
   ],
-  "version": "6.1.0-beta.4",
+  "version": "6.1.0",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts"
 }

--- a/packages/ecdsa-sdk/package.json
+++ b/packages/ecdsa-sdk/package.json
@@ -24,7 +24,7 @@
   "tags": [
     "universal"
   ],
-  "version": "6.1.0-beta.4",
+  "version": "6.1.0",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts"
 }

--- a/packages/encryption/package.json
+++ b/packages/encryption/package.json
@@ -25,7 +25,7 @@
     "crypto": false,
     "stream": false
   },
-  "version": "6.1.0-beta.4",
+  "version": "6.1.0",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts"
 }

--- a/packages/lit-auth-client/package.json
+++ b/packages/lit-auth-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lit-protocol/lit-auth-client",
-  "version": "6.1.0-beta.4",
+  "version": "6.1.0",
   "type": "commonjs",
   "license": "MIT",
   "homepage": "https://github.com/Lit-Protocol/js-sdk",

--- a/packages/lit-node-client-nodejs/package.json
+++ b/packages/lit-node-client-nodejs/package.json
@@ -24,7 +24,7 @@
   "tags": [
     "nodejs"
   ],
-  "version": "6.1.0-beta.4",
+  "version": "6.1.0",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts"
 }

--- a/packages/lit-node-client/package.json
+++ b/packages/lit-node-client/package.json
@@ -28,7 +28,7 @@
     "crypto": false,
     "stream": false
   },
-  "version": "6.1.0-beta.4",
+  "version": "6.1.0",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts"
 }

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lit-protocol/logger",
-  "version": "6.1.0-beta.4",
+  "version": "6.1.0",
   "type": "commonjs",
   "tags": [
     "universal"

--- a/packages/misc-browser/package.json
+++ b/packages/misc-browser/package.json
@@ -21,7 +21,7 @@
   "tags": [
     "browser"
   ],
-  "version": "6.1.0-beta.4",
+  "version": "6.1.0",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts"
 }

--- a/packages/misc/package.json
+++ b/packages/misc/package.json
@@ -24,7 +24,7 @@
   "tags": [
     "universal"
   ],
-  "version": "6.1.0-beta.4",
+  "version": "6.1.0",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts"
 }

--- a/packages/nacl/package.json
+++ b/packages/nacl/package.json
@@ -21,7 +21,7 @@
     "access": "public",
     "directory": "../../dist/packages/nacl"
   },
-  "version": "6.1.0-beta.4",
+  "version": "6.1.0",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts"
 }

--- a/packages/pkp-base/package.json
+++ b/packages/pkp-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lit-protocol/pkp-base",
-  "version": "6.1.0-beta.4",
+  "version": "6.1.0",
   "type": "commonjs",
   "license": "MIT",
   "homepage": "https://github.com/Lit-Protocol/js-sdk",

--- a/packages/pkp-client/package.json
+++ b/packages/pkp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lit-protocol/pkp-client",
-  "version": "6.1.0-beta.4",
+  "version": "6.1.0",
   "type": "commonjs",
   "license": "MIT",
   "homepage": "https://github.com/Lit-Protocol/js-sdk",

--- a/packages/pkp-cosmos/package.json
+++ b/packages/pkp-cosmos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lit-protocol/pkp-cosmos",
-  "version": "6.1.0-beta.4",
+  "version": "6.1.0",
   "type": "commonjs",
   "license": "MIT",
   "homepage": "https://github.com/Lit-Protocol/js-sdk",

--- a/packages/pkp-ethers/package.json
+++ b/packages/pkp-ethers/package.json
@@ -20,7 +20,7 @@
   "tags": [
     "universal"
   ],
-  "version": "6.1.0-beta.4",
+  "version": "6.1.0",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts"
 }

--- a/packages/pkp-sui/package.json
+++ b/packages/pkp-sui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lit-protocol/pkp-sui",
-  "version": "6.1.0-beta.4",
+  "version": "6.1.0",
   "type": "commonjs",
   "license": "MIT",
   "homepage": "https://github.com/Lit-Protocol/js-sdk",

--- a/packages/pkp-walletconnect/package.json
+++ b/packages/pkp-walletconnect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lit-protocol/pkp-walletconnect",
-  "version": "6.1.0-beta.4",
+  "version": "6.1.0",
   "type": "commonjs",
   "license": "MIT",
   "homepage": "https://github.com/Lit-Protocol/js-sdk",

--- a/packages/sev-snp-utils-sdk/package.json
+++ b/packages/sev-snp-utils-sdk/package.json
@@ -27,7 +27,7 @@
   "buildOptions": {
     "genReact": false
   },
-  "version": "6.1.0-beta.4",
+  "version": "6.1.0",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts"
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -23,7 +23,7 @@
   "buildOptions": {
     "genReact": false
   },
-  "version": "6.1.0-beta.4",
+  "version": "6.1.0",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts"
 }

--- a/packages/uint8arrays/package.json
+++ b/packages/uint8arrays/package.json
@@ -21,7 +21,7 @@
   "tags": [
     "universal"
   ],
-  "version": "6.1.0-beta.4",
+  "version": "6.1.0",
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts"
 }

--- a/packages/wrapped-keys/package.json
+++ b/packages/wrapped-keys/package.json
@@ -23,7 +23,7 @@
   "buildOptions": {
     "genReact": false
   },
-  "version": "6.1.0-beta.4",
+  "version": "6.1.0",
   "scripts": {
     "bundle": "yarn node ./esbuild.config.js"
   },


### PR DESCRIPTION
# Description
- #515 has been merged, which was the last blocker for publishing v6.1.0
- This PR bumps NPM package versions to 6.1.0 for all packages as a final step pre-publish.
