### PR TITLE
Feature/lit 3593 js sdk add a map of network names to rpc url

### DIFF
--- a/packages/constants/src/lib/constants/constants.ts
+++ b/packages/constants/src/lib/constants/constants.ts
@@ -466,13 +466,21 @@ export const LIT_CHAINS: LITChain<LITEVMChain> = {
     type: null,
     vmType: 'EVM',
   },
+
+  /**
+   * Chainlist entry for the Chronicle Testnet.
+   * https://chainlist.org/chain/175177
+   */
   chronicleTestnet: {
     contractAddress: null,
     chainId: 175177,
     name: 'Chronicle - Lit Protocol Testnet',
-    symbol: 'testLPX',
+    symbol: 'tstLPX',
     decimals: 18,
-    rpcUrls: ['https://lit-protocol.calderachain.xyz/replica-http'],
+    rpcUrls: [
+      'https://lit-protocol.calderachain.xyz/replica-http',
+      'https://chain-rpc.litprotocol.com/http',
+    ],
     blockExplorerUrls: ['https://chain.litprotocol.com/'],
     type: null,
     vmType: 'EVM',
@@ -492,6 +500,11 @@ export const LIT_CHAINS: LITChain<LITEVMChain> = {
     type: null,
     vmType: 'EVM',
   },
+
+  /**
+   * Chainlist entry for the Chronicle Vesuvius Testnet.
+   * https://chainlist.org/chain/2311
+   */
   chronicleVesuviusTestnet: {
     contractAddress: null,
     chainId: 2311,
@@ -507,9 +520,12 @@ export const LIT_CHAINS: LITChain<LITEVMChain> = {
     contractAddress: null,
     chainId: 175177,
     name: 'Chronicle - Lit Protocol Testnet',
-    symbol: 'testLPX',
+    symbol: 'tstLit',
     decimals: 18,
-    rpcUrls: ['https://lit-protocol.calderachain.xyz/replica-http'],
+    rpcUrls: [
+      'https://lit-protocol.calderachain.xyz/replica-http',
+      'https://chain-rpc.litprotocol.com/http',
+    ],
     blockExplorerUrls: ['https://chain.litprotocol.com/'],
     type: null,
     vmType: 'EVM',
@@ -707,7 +723,6 @@ export const LIT_NETWORK = {
 
 /**
  * The type representing the keys of the LIT_NETWORK object.
- *
  */
 export type LIT_NETWORK_TYPES = keyof typeof LIT_NETWORK;
 
@@ -763,9 +778,6 @@ export const GENERAL_WORKER_URL_BY_NETWORK: {
 
 /**
  * URL constants for the staging worker by network.
- *
- * @remarks
- * This constant maps each network to its corresponding staging worker URL.
  */
 export const GENERAL_STAGING_WORKER_URL_BY_NETWORK: {
   [key in LIT_NETWORK_VALUES]: string;
@@ -782,7 +794,7 @@ export const GENERAL_STAGING_WORKER_URL_BY_NETWORK: {
 };
 
 /**
- * Mapping of network values to corresponding chain info.
+ * Mapping of network values to corresponding Metamask chain info.
  */
 export const METAMASK_CHAIN_INFO_BY_NETWORK: Record<
   LIT_NETWORK_VALUES,

--- a/packages/constants/src/lib/constants/constants.ts
+++ b/packages/constants/src/lib/constants/constants.ts
@@ -708,28 +708,11 @@ export const LIT_NETWORK = {
 /**
  * The type representing the keys of the LIT_NETWORK object.
  *
- * Possible values are:
- * - 'Cayenne'
- * - 'Manzano'
- * - 'Habanero'
- * - 'Custom'
- * - 'DatilDev'
- * - 'DatilTest'
- * etc.
  */
 export type LIT_NETWORK_TYPES = keyof typeof LIT_NETWORK;
 
 /**
  * The type representing the values of the LIT_NETWORK object.
- *
- * Possible values are:
- * - 'cayenne'
- * - 'manzano'
- * - 'habanero'
- * - 'custom'
- * - 'datil-dev'
- * - 'datil-test'
- * etc.
  */
 export type LIT_NETWORK_VALUES = (typeof LIT_NETWORK)[keyof typeof LIT_NETWORK];
 
@@ -751,32 +734,31 @@ export const RPC_URL_BY_NETWORK: { [key in LIT_NETWORK_VALUES]: string } = {
 /**
  * Mapping of network names to their corresponding relayer URLs.
  */
-export const RELAYER_URL_BY_NETWORK: Record<LIT_NETWORK_TYPES, string> = {
-  Cayenne: 'https://relayer-server-staging-cayenne.getlit.dev',
-  Manzano: 'https://manzano-relayer.getlit.dev',
-  Habanero: 'https://habanero-relayer.getlit.dev',
-  DatilDev: 'https://datil-dev-relayer.getlit.dev',
-  DatilTest: 'https://datil-test-relayer.getlit.dev',
-  Custom: 'http://localhost:3000',
-  Localhost: 'http://localhost:3000',
+export const RELAYER_URL_BY_NETWORK: { [key in LIT_NETWORK_VALUES]: string } = {
+  cayenne: 'https://relayer-server-staging-cayenne.getlit.dev',
+  manzano: 'https://manzano-relayer.getlit.dev',
+  habanero: 'https://habanero-relayer.getlit.dev',
+  'datil-dev': 'https://datil-dev-relayer.getlit.dev',
+  'datil-test': 'https://datil-test-relayer.getlit.dev',
+  custom: 'http://localhost:3000',
+  localhost: 'http://localhost:3000',
 };
 
 /**
  * URL mappings for general worker URLs by network.
  */
-export const GENERAL_WORKER_URL_BY_NETWORK: Record<
-  keyof typeof LIT_NETWORK,
-  string
-> = {
-  Cayenne: 'https://apis.getlit.dev/cayenne/contracts',
-  Manzano: 'https://apis.getlit.dev/manzano/contracts',
-  Habanero: 'https://apis.getlit.dev/habanero/contracts',
-  DatilDev: 'https://apis.getlit.dev/datil-dev/contracts',
-  DatilTest: 'https://apis.getlit.dev/datil-test/contracts',
+export const GENERAL_WORKER_URL_BY_NETWORK: {
+  [key in LIT_NETWORK_VALUES]: string;
+} = {
+  cayenne: 'https://apis.getlit.dev/cayenne/contracts',
+  manzano: 'https://apis.getlit.dev/manzano/contracts',
+  habanero: 'https://apis.getlit.dev/habanero/contracts',
+  'datil-dev': 'https://apis.getlit.dev/datil-dev/contracts',
+  'datil-test': 'https://apis.getlit.dev/datil-test/contracts',
 
   // just use cayenne abis for custom and localhost
-  Custom: 'https://apis.getlit.dev/cayenne/contracts',
-  Localhost: 'https://apis.getlit.dev/cayenne/contracts',
+  custom: 'https://apis.getlit.dev/cayenne/contracts',
+  localhost: 'https://apis.getlit.dev/cayenne/contracts',
 };
 
 /**
@@ -785,19 +767,18 @@ export const GENERAL_WORKER_URL_BY_NETWORK: Record<
  * @remarks
  * This constant maps each network to its corresponding staging worker URL.
  */
-export const GENERAL_STAGING_WORKER_URL_BY_NETWORK: Record<
-  keyof typeof LIT_NETWORK,
-  string
-> = {
-  Cayenne: 'https://staging.apis.getlit.dev/cayenne/contracts',
-  Manzano: 'https://staging.apis.getlit.dev/manzano/contracts',
-  Habanero: 'https://staging.apis.getlit.dev/habanero/contracts',
-  DatilDev: 'https://staging.apis.getlit.dev/datil-dev/contracts',
-  DatilTest: 'https://staging.apis.getlit.dev/datil-test/contracts',
+export const GENERAL_STAGING_WORKER_URL_BY_NETWORK: {
+  [key in LIT_NETWORK_VALUES]: string;
+} = {
+  cayenne: 'https://staging.apis.getlit.dev/cayenne/contracts',
+  manzano: 'https://staging.apis.getlit.dev/manzano/contracts',
+  habanero: 'https://staging.apis.getlit.dev/habanero/contracts',
+  'datil-dev': 'https://staging.apis.getlit.dev/datil-dev/contracts',
+  'datil-test': 'https://staging.apis.getlit.dev/datil-test/contracts',
 
   // just use cayenne abis for custom and localhost
-  Custom: 'https://apis.getlit.dev/cayenne/contracts',
-  Localhost: 'https://apis.getlit.dev/cayenne/contracts',
+  custom: 'https://apis.getlit.dev/cayenne/contracts',
+  localhost: 'https://apis.getlit.dev/cayenne/contracts',
 };
 
 /**

--- a/packages/constants/src/lib/constants/constants.ts
+++ b/packages/constants/src/lib/constants/constants.ts
@@ -784,7 +784,7 @@ export const GENERAL_STAGING_WORKER_URL_BY_NETWORK: {
 /**
  * Mapping of network values to corresponding chain info.
  */
-export const CHAIN_INFO_BY_NETWORK: Record<
+export const METAMASK_CHAIN_INFO_BY_NETWORK: Record<
   LIT_NETWORK_VALUES,
   | typeof metamaskChainInfo.chronicle
   | typeof metamaskChainInfo.chronicleVesuvius

--- a/packages/constants/src/lib/constants/constants.ts
+++ b/packages/constants/src/lib/constants/constants.ts
@@ -477,10 +477,14 @@ export const LIT_CHAINS: LITChain<LITEVMChain> = {
     type: null,
     vmType: 'EVM',
   },
+
+  /**
+   * @deprecated Will be removed in version 7.x. - Use `chronicleVesuviusTestnet` instead.
+   */
   datilDevnet: {
     contractAddress: null,
     chainId: 2311,
-    name: 'Vesuvius - Lit Protocol Devnet',
+    name: 'Chronicle Vesuvius - Lit Protocol Testnet',
     symbol: 'tstLit',
     decimals: 18,
     rpcUrls: ['https://vesuvius-rpc.litprotocol.com/'],
@@ -488,10 +492,10 @@ export const LIT_CHAINS: LITChain<LITEVMChain> = {
     type: null,
     vmType: 'EVM',
   },
-  datilTestnet: {
+  chronicleVesuviusTestnet: {
     contractAddress: null,
     chainId: 2311,
-    name: 'Vesuvius - Lit Protocol Testnet',
+    name: 'Chronicle Vesuvius - Lit Protocol Testnet',
     symbol: 'tstLit',
     decimals: 18,
     rpcUrls: ['https://vesuvius-rpc.litprotocol.com/'],
@@ -625,6 +629,42 @@ export const LIT_CHAINS: LITChain<LITEVMChain> = {
 export const LIT_CHAIN_RPC_URL = LIT_CHAINS['chronicleTestnet'].rpcUrls[0];
 
 /**
+ * Object containing information to submit to Metamask
+ */
+export const metamaskChainInfo = {
+  /**
+   * Information about the "chronicle" chain.
+   */
+  chronicle: {
+    chainId: LIT_CHAINS['chronicleTestnet'].chainId,
+    chainName: LIT_CHAINS['chronicleTestnet'].name,
+    nativeCurrency: {
+      name: LIT_CHAINS['chronicleTestnet'].symbol,
+      symbol: LIT_CHAINS['chronicleTestnet'].symbol,
+      decimals: LIT_CHAINS['chronicleTestnet'].decimals,
+    },
+    rpcUrls: LIT_CHAINS['chronicleTestnet'].rpcUrls,
+    blockExplorerUrls: LIT_CHAINS['chronicleTestnet'].blockExplorerUrls,
+    iconUrls: ['future'],
+  },
+  /**
+   * Information about the "chronicleVesuvius" chain.
+   */
+  chronicleVesuvius: {
+    chainId: LIT_CHAINS['chronicleVesuviusTestnet'].chainId,
+    chainName: LIT_CHAINS['chronicleVesuviusTestnet'].name,
+    nativeCurrency: {
+      name: LIT_CHAINS['chronicleVesuviusTestnet'].symbol,
+      symbol: LIT_CHAINS['chronicleVesuviusTestnet'].symbol,
+      decimals: LIT_CHAINS['chronicleVesuviusTestnet'].decimals,
+    },
+    rpcUrls: LIT_CHAINS['chronicleVesuviusTestnet'].rpcUrls,
+    blockExplorerUrls: LIT_CHAINS['chronicleVesuviusTestnet'].blockExplorerUrls,
+    iconUrls: ['future'],
+  },
+};
+
+/**
  * Constants representing the available LIT RPC endpoints.
  */
 export const LIT_RPC = {
@@ -655,14 +695,15 @@ export const LIT_EVM_CHAINS = LIT_CHAINS;
 /**
  * Represents the Lit Network constants.
  */
-export const LIT_NETWORK: { [key in keyof typeof LitNetwork]: string } = {
+export const LIT_NETWORK = {
   Cayenne: 'cayenne',
   Manzano: 'manzano',
   Habanero: 'habanero',
-  Custom: 'custom',
   DatilDev: 'datil-dev',
   DatilTest: 'datil-test',
-};
+  Custom: 'custom',
+  Localhost: 'localhost',
+} as const;
 
 /**
  * The type representing the keys of the LIT_NETWORK object.
@@ -690,20 +731,21 @@ export type LIT_NETWORK_TYPES = keyof typeof LIT_NETWORK;
  * - 'datil-test'
  * etc.
  */
-export type LIT_NETWORK_VALUES = (typeof LIT_NETWORK)[LIT_NETWORK_TYPES];
+export type LIT_NETWORK_VALUES = (typeof LIT_NETWORK)[keyof typeof LIT_NETWORK];
 
 /**
  * RPC URL by Network
  *
  * A mapping of network names to their corresponding RPC URLs.
  */
-export const RPC_URL_BY_NETWORK: Record<LIT_NETWORK_TYPES, string> = {
-  Cayenne: LIT_RPC.CHRONICLE,
-  Manzano: LIT_RPC.CHRONICLE,
-  Habanero: LIT_RPC.CHRONICLE,
-  DatilDev: LIT_RPC.CHRONICLE_VESUVIUS,
-  DatilTest: LIT_RPC.CHRONICLE_VESUVIUS,
-  Custom: LIT_RPC.LOCAL_ANVIL,
+export const RPC_URL_BY_NETWORK: { [key in LIT_NETWORK_VALUES]: string } = {
+  cayenne: LIT_RPC.CHRONICLE,
+  manzano: LIT_RPC.CHRONICLE,
+  habanero: LIT_RPC.CHRONICLE,
+  'datil-dev': LIT_RPC.CHRONICLE_VESUVIUS,
+  'datil-test': LIT_RPC.CHRONICLE_VESUVIUS,
+  custom: LIT_RPC.LOCAL_ANVIL,
+  localhost: LIT_RPC.LOCAL_ANVIL,
 };
 
 /**
@@ -716,6 +758,7 @@ export const RELAYER_URL_BY_NETWORK: Record<LIT_NETWORK_TYPES, string> = {
   DatilDev: 'https://datil-dev-relayer.getlit.dev',
   DatilTest: 'https://datil-test-relayer.getlit.dev',
   Custom: 'http://localhost:3000',
+  Localhost: 'http://localhost:3000',
 };
 
 /**
@@ -733,6 +776,7 @@ export const GENERAL_WORKER_URL_BY_NETWORK: Record<
 
   // just use cayenne abis for custom and localhost
   Custom: 'https://apis.getlit.dev/cayenne/contracts',
+  Localhost: 'https://apis.getlit.dev/cayenne/contracts',
 };
 
 /**
@@ -753,6 +797,24 @@ export const GENERAL_STAGING_WORKER_URL_BY_NETWORK: Record<
 
   // just use cayenne abis for custom and localhost
   Custom: 'https://apis.getlit.dev/cayenne/contracts',
+  Localhost: 'https://apis.getlit.dev/cayenne/contracts',
+};
+
+/**
+ * Mapping of network values to corresponding chain info.
+ */
+export const CHAIN_INFO_BY_NETWORK: Record<
+  LIT_NETWORK_VALUES,
+  | typeof metamaskChainInfo.chronicle
+  | typeof metamaskChainInfo.chronicleVesuvius
+> = {
+  cayenne: metamaskChainInfo.chronicle,
+  manzano: metamaskChainInfo.chronicle,
+  habanero: metamaskChainInfo.chronicle,
+  'datil-dev': metamaskChainInfo.chronicleVesuvius,
+  'datil-test': metamaskChainInfo.chronicleVesuvius,
+  custom: metamaskChainInfo.chronicleVesuvius,
+  localhost: metamaskChainInfo.chronicleVesuvius,
 };
 
 /**

--- a/packages/constants/src/lib/constants/constants.ts
+++ b/packages/constants/src/lib/constants/constants.ts
@@ -679,13 +679,13 @@ export const LIT_RPC = {
   CHRONICLE: 'https://chain-rpc.litprotocol.com/http',
 
   /**
-   * Vesuvius RPC endpoint - used for >= Datil-dev, Datil-test
+   * Chronicle Vesuvius RPC endpoint - used for >= Datil-dev, Datil-test
    * @deprecated Will be removed in version 7.x. - Use CHRONICLE_VESUVIUS instead
    */
   VESUVIUS: 'https://vesuvius-rpc.litprotocol.com',
 
   /**
-   * Vesuvius RPC endpoint - used for >= Datil-dev, Datil-test
+   * Chronicle Vesuvius RPC endpoint - used for >= Datil-dev, Datil-test
    */
   CHRONICLE_VESUVIUS: 'https://vesuvius-rpc.litprotocol.com',
 } as const;

--- a/packages/constants/src/lib/constants/constants.ts
+++ b/packages/constants/src/lib/constants/constants.ts
@@ -625,26 +625,135 @@ export const LIT_CHAINS: LITChain<LITEVMChain> = {
 export const LIT_CHAIN_RPC_URL = LIT_CHAINS['chronicleTestnet'].rpcUrls[0];
 
 /**
- * Enum representing the available LIT RPC endpoints.
+ * Constants representing the available LIT RPC endpoints.
  */
-export enum LIT_RPC {
+export const LIT_RPC = {
   /**
    * Local Anvil RPC endpoint.
    */
-  LOCAL_ANVIL = 'http://127.0.0.1:8545',
+  LOCAL_ANVIL: 'http://127.0.0.1:8545',
 
   /**
    * Chronicle RPC endpoint - Used for Cayenne, Manzano, Habanero
    */
-  CHRONICLE = 'https://chain-rpc.litprotocol.com/http',
+  CHRONICLE: 'https://chain-rpc.litprotocol.com/http',
+
+  /**
+   * Vesuvius RPC endpoint - used for >= Datil-dev, Datil-test
+   * @deprecated Will be removed in version 7.x. - Use CHRONICLE_VESUVIUS instead
+   */
+  VESUVIUS: 'https://vesuvius-rpc.litprotocol.com',
 
   /**
    * Vesuvius RPC endpoint - used for >= Datil-dev, Datil-test
    */
-  VESUVIUS = 'https://vesuvius-rpc.litprotocol.com',
-}
+  CHRONICLE_VESUVIUS: 'https://vesuvius-rpc.litprotocol.com',
+} as const;
 
 export const LIT_EVM_CHAINS = LIT_CHAINS;
+
+/**
+ * Represents the Lit Network constants.
+ */
+export const LIT_NETWORK: { [key in keyof typeof LitNetwork]: string } = {
+  Cayenne: 'cayenne',
+  Manzano: 'manzano',
+  Habanero: 'habanero',
+  Custom: 'custom',
+  DatilDev: 'datil-dev',
+  DatilTest: 'datil-test',
+};
+
+/**
+ * The type representing the keys of the LIT_NETWORK object.
+ *
+ * Possible values are:
+ * - 'Cayenne'
+ * - 'Manzano'
+ * - 'Habanero'
+ * - 'Custom'
+ * - 'DatilDev'
+ * - 'DatilTest'
+ * etc.
+ */
+export type LIT_NETWORK_TYPES = keyof typeof LIT_NETWORK;
+
+/**
+ * The type representing the values of the LIT_NETWORK object.
+ *
+ * Possible values are:
+ * - 'cayenne'
+ * - 'manzano'
+ * - 'habanero'
+ * - 'custom'
+ * - 'datil-dev'
+ * - 'datil-test'
+ * etc.
+ */
+export type LIT_NETWORK_VALUES = (typeof LIT_NETWORK)[LIT_NETWORK_TYPES];
+
+/**
+ * RPC URL by Network
+ *
+ * A mapping of network names to their corresponding RPC URLs.
+ */
+export const RPC_URL_BY_NETWORK: Record<LIT_NETWORK_TYPES, string> = {
+  Cayenne: LIT_RPC.CHRONICLE,
+  Manzano: LIT_RPC.CHRONICLE,
+  Habanero: LIT_RPC.CHRONICLE,
+  DatilDev: LIT_RPC.CHRONICLE_VESUVIUS,
+  DatilTest: LIT_RPC.CHRONICLE_VESUVIUS,
+  Custom: LIT_RPC.LOCAL_ANVIL,
+};
+
+/**
+ * Mapping of network names to their corresponding relayer URLs.
+ */
+export const RELAYER_URL_BY_NETWORK: Record<LIT_NETWORK_TYPES, string> = {
+  Cayenne: 'https://relayer-server-staging-cayenne.getlit.dev',
+  Manzano: 'https://manzano-relayer.getlit.dev',
+  Habanero: 'https://habanero-relayer.getlit.dev',
+  DatilDev: 'https://datil-dev-relayer.getlit.dev',
+  DatilTest: 'https://datil-test-relayer.getlit.dev',
+  Custom: 'http://localhost:3000',
+};
+
+/**
+ * URL mappings for general worker URLs by network.
+ */
+export const GENERAL_WORKER_URL_BY_NETWORK: Record<
+  keyof typeof LIT_NETWORK,
+  string
+> = {
+  Cayenne: 'https://apis.getlit.dev/cayenne/contracts',
+  Manzano: 'https://apis.getlit.dev/manzano/contracts',
+  Habanero: 'https://apis.getlit.dev/habanero/contracts',
+  DatilDev: 'https://apis.getlit.dev/datil-dev/contracts',
+  DatilTest: 'https://apis.getlit.dev/datil-test/contracts',
+
+  // just use cayenne abis for custom and localhost
+  Custom: 'https://apis.getlit.dev/cayenne/contracts',
+};
+
+/**
+ * URL constants for the staging worker by network.
+ *
+ * @remarks
+ * This constant maps each network to its corresponding staging worker URL.
+ */
+export const GENERAL_STAGING_WORKER_URL_BY_NETWORK: Record<
+  keyof typeof LIT_NETWORK,
+  string
+> = {
+  Cayenne: 'https://staging.apis.getlit.dev/cayenne/contracts',
+  Manzano: 'https://staging.apis.getlit.dev/manzano/contracts',
+  Habanero: 'https://staging.apis.getlit.dev/habanero/contracts',
+  DatilDev: 'https://staging.apis.getlit.dev/datil-dev/contracts',
+  DatilTest: 'https://staging.apis.getlit.dev/datil-test/contracts',
+
+  // just use cayenne abis for custom and localhost
+  Custom: 'https://apis.getlit.dev/cayenne/contracts',
+};
 
 /**
  * Solana Chains supported by the LIT protocol.  Use the chain name as a key in this object.
@@ -839,11 +948,30 @@ export const TELEM_API_URL = 'https://lit-general-worker.getlit.dev';
 // ========== RLI Delegation ==========
 export const SIWE_DELEGATION_URI = 'lit:capability:delegation';
 
+/**
+ * @deprecated Will be removed in version 7.x. - Use RELAYER_URL_BY_NETWORK.Cayenne instead
+ */
 export const RELAY_URL_CAYENNE =
   'https://relayer-server-staging-cayenne.getlit.dev';
+
+/**
+ * @deprecated Will be removed in version 7.x. - Use RELAYER_URL_BY_NETWORK.Habanero instead
+ */
 export const RELAY_URL_HABANERO = 'https://habanero-relayer.getlit.dev';
+
+/**
+ * @deprecated Will be removed in version 7.x. - Use RELAYER_URL_BY_NETWORK.Manzano instead
+ */
 export const RELAY_URL_MANZANO = 'https://manzano-relayer.getlit.dev';
+
+/**
+ * @deprecated Will be removed in version 7.x. - Use RELAYER_URL_BY_NETWORK.DatilDev instead
+ */
 export const RELAY_URL_DATIL_DEV = 'https://datil-dev-relayer.getlit.dev';
+
+/**
+ * @deprecated Will be removed in version 7.x. - Use RELAYER_URL_BY_NETWORK.DatilTest instead
+ */
 export const RELAY_URL_DATIL_TEST = 'https://datil-test-relayer.getlit.dev';
 
 // ========== Lit Actions ==========

--- a/packages/contracts-sdk/src/lib/contracts-sdk.ts
+++ b/packages/contracts-sdk/src/lib/contracts-sdk.ts
@@ -13,11 +13,7 @@ import {
   MintWithAuthResponse,
 } from '@lit-protocol/types';
 import bs58 from 'bs58';
-import {
-  BytesLike,
-  ContractReceipt,
-  ethers
-} from 'ethers';
+import { BytesLike, ContractReceipt, ethers } from 'ethers';
 import { decToHex, hexToDec, intToIP } from './hex2dec';
 
 // ----- autogen:import-data:start  -----
@@ -55,7 +51,8 @@ import {
   AuthMethodType,
   CHAIN_INFO_BY_NETWORK,
   GENERAL_WORKER_URL_BY_NETWORK,
-  RPC_URL_BY_NETWORK
+  LIT_NETWORK_VALUES,
+  RPC_URL_BY_NETWORK,
 } from '@lit-protocol/constants';
 import { LogManager, Logger } from '@lit-protocol/logger';
 import { computeAddress } from 'ethers/lib/utils';
@@ -68,10 +65,7 @@ import {
   IPFSHash,
   getBytes32FromMultihash,
 } from './helpers/getBytes32FromMultihash';
-import {
-  calculateUTCMidnightExpiration,
-  requestsToKilosecond
-} from './utils';
+import { calculateUTCMidnightExpiration, requestsToKilosecond } from './utils';
 
 // const DEFAULT_RPC = 'https://lit-protocol.calderachain.xyz/replica-http';
 // const DEFAULT_READ_RPC = 'https://lit-protocol.calderachain.xyz/replica-http';
@@ -948,11 +942,9 @@ export class LitContracts {
   };
 
   private static async _resolveContractContext(
-    network: LIT_NETWORKS_KEYS
+    network: LIT_NETWORK_VALUES
     // context?: LitContractContext | LitContractResolverContext
   ) {
-    let data;
-
     const fetchData = async (url: string) => {
       try {
         return await fetch(url).then((res) => res.json());
@@ -961,32 +953,14 @@ export class LitContracts {
       }
     };
 
-    switch (network) {
-      case 'cayenne':
-        data = await fetchData(GENERAL_WORKER_URL_BY_NETWORK.Cayenne);
-        break;
-      case 'manzano':
-        data = await fetchData(GENERAL_WORKER_URL_BY_NETWORK.Manzano);
-        break;
-      case 'habanero':
-        data = await fetchData(GENERAL_WORKER_URL_BY_NETWORK.Habanero);
-        break;
-      case 'datil-dev':
-        data = await fetchData(GENERAL_WORKER_URL_BY_NETWORK.DatilDev);
-        break;
-      case 'datil-test':
-        data = await fetchData(GENERAL_WORKER_URL_BY_NETWORK.DatilTest);
-        break;
-      case 'custom':
-      case 'localhost':
-        // just use cayenne abis for custom and localhost
-        data = await fetchData(GENERAL_WORKER_URL_BY_NETWORK.Cayenne);
-        break;
-      default:
-        throw new Error(
-          `[_resolveContractContext] Unsupported network: ${network}`
-        );
+    // -- check if it's supported network
+    if (!GENERAL_WORKER_URL_BY_NETWORK[network]) {
+      throw new Error(
+        `[_resolveContractContext] Unsupported network: ${network}`
+      );
     }
+
+    const data = await fetchData(GENERAL_WORKER_URL_BY_NETWORK[network]);
 
     if (!data) {
       throw new Error('[_resolveContractContext] No data found');

--- a/packages/contracts-sdk/src/lib/contracts-sdk.ts
+++ b/packages/contracts-sdk/src/lib/contracts-sdk.ts
@@ -49,7 +49,7 @@ import * as stakingBalancesContract from '../abis/StakingBalances.sol/StakingBal
 import {
   AuthMethodScope,
   AuthMethodType,
-  CHAIN_INFO_BY_NETWORK,
+  METAMASK_CHAIN_INFO_BY_NETWORK,
   GENERAL_WORKER_URL_BY_NETWORK,
   LIT_NETWORK_VALUES,
   RPC_URL_BY_NETWORK,
@@ -268,7 +268,7 @@ export class LitContracts {
         return '0x' + decimal.toString(16);
       }
 
-      let chainInfo = CHAIN_INFO_BY_NETWORK[this.network];
+      const chainInfo = METAMASK_CHAIN_INFO_BY_NETWORK[this.network];
 
       const metamaskChainInfo = {
         ...chainInfo,

--- a/packages/contracts-sdk/src/lib/contracts-sdk.ts
+++ b/packages/contracts-sdk/src/lib/contracts-sdk.ts
@@ -70,6 +70,7 @@ import {
 import {
   AuthMethodScope,
   AuthMethodType,
+  GENERAL_WORKER_URL_BY_NETWORK,
   LIT_CHAINS,
   LIT_RPC,
 } from '@lit-protocol/constants';
@@ -984,15 +985,6 @@ export class LitContracts {
     // context?: LitContractContext | LitContractResolverContext
   ) {
     let data;
-    const CAYENNE_API =
-      'https://lit-general-worker.getlit.dev/contract-addresses';
-    const MANZANO_API =
-      'https://lit-general-worker.getlit.dev/manzano-contract-addresses';
-    const HABANERO_API =
-      'https://lit-general-worker.getlit.dev/habanero-contract-addresses';
-    const DATIL_DEV_API =
-      'https://lit-general-worker.getlit.dev/datil-dev/contracts';
-    const DATIL_TEST_API = 'https://apis.getlit.dev/datil-test/contracts';
 
     const fetchData = async (url: string) => {
       try {
@@ -1004,24 +996,24 @@ export class LitContracts {
 
     switch (network) {
       case 'cayenne':
-        data = await fetchData(CAYENNE_API);
+        data = await fetchData(GENERAL_WORKER_URL_BY_NETWORK.Cayenne);
         break;
       case 'manzano':
-        data = await fetchData(MANZANO_API);
+        data = await fetchData(GENERAL_WORKER_URL_BY_NETWORK.Manzano);
         break;
       case 'habanero':
-        data = await fetchData(HABANERO_API);
+        data = await fetchData(GENERAL_WORKER_URL_BY_NETWORK.Habanero);
         break;
       case 'datil-dev':
-        data = await fetchData(DATIL_DEV_API);
+        data = await fetchData(GENERAL_WORKER_URL_BY_NETWORK.DatilDev);
         break;
       case 'datil-test':
-        data = await fetchData(DATIL_TEST_API);
+        data = await fetchData(GENERAL_WORKER_URL_BY_NETWORK.DatilTest);
         break;
       case 'custom':
       case 'localhost':
         // just use cayenne abis for custom and localhost
-        data = await fetchData(CAYENNE_API);
+        data = await fetchData(GENERAL_WORKER_URL_BY_NETWORK.Cayenne);
         break;
       default:
         throw new Error(

--- a/packages/lit-auth-client/src/lib/lit-auth-client.ts
+++ b/packages/lit-auth-client/src/lib/lit-auth-client.ts
@@ -2,22 +2,22 @@ import { ethers } from 'ethers';
 
 import {
   AuthMethodType,
-  LIT_RPC,
   ProviderType,
   RELAYER_URL_BY_NETWORK,
+  RPC_URL_BY_NETWORK,
 } from '@lit-protocol/constants';
 import { LitNodeClient } from '@lit-protocol/lit-node-client';
-import { bootstrapLogManager, getLoggerbyId, log } from '@lit-protocol/misc';
+import { bootstrapLogManager, log } from '@lit-protocol/misc';
 import {
+  AuthMethod,
   EthWalletProviderOptions,
   IRelay,
   LitAuthClientOptions,
-  OAuthProviderOptions,
-  StytchOtpProviderOptions,
-  ProviderOptions,
-  WebAuthnProviderOptions,
-  AuthMethod,
   MintRequestBody,
+  OAuthProviderOptions,
+  ProviderOptions,
+  StytchOtpProviderOptions,
+  WebAuthnProviderOptions,
 } from '@lit-protocol/types';
 
 import AppleProvider from './providers/AppleProvider';
@@ -153,10 +153,7 @@ export class LitAuthClient {
     // Set RPC URL
     this.rpcUrl =
       options?.rpcUrl ||
-      this.litNodeClient.config.litNetwork === 'datil-dev' ||
-      this.litNodeClient.config.litNetwork === 'datil-test'
-        ? LIT_RPC.VESUVIUS
-        : LIT_RPC.CHRONICLE;
+      RPC_URL_BY_NETWORK[this.litNodeClient.config.litNetwork];
     log('rpc url: ', this.rpcUrl);
     log('relay config: ', options.litRelayConfig);
     log('relay instance: ', this.relay);

--- a/packages/lit-auth-client/src/lib/lit-auth-client.ts
+++ b/packages/lit-auth-client/src/lib/lit-auth-client.ts
@@ -4,11 +4,7 @@ import {
   AuthMethodType,
   LIT_RPC,
   ProviderType,
-  RELAY_URL_CAYENNE,
-  RELAY_URL_DATIL_DEV,
-  RELAY_URL_DATIL_TEST,
-  RELAY_URL_HABANERO,
-  RELAY_URL_MANZANO,
+  RELAYER_URL_BY_NETWORK,
 } from '@lit-protocol/constants';
 import { LitNodeClient } from '@lit-protocol/lit-node-client';
 import { bootstrapLogManager, getLoggerbyId, log } from '@lit-protocol/misc';
@@ -118,19 +114,19 @@ export class LitAuthClient {
 
       switch (this.litNodeClient.config.litNetwork) {
         case 'cayenne':
-          url = RELAY_URL_CAYENNE;
+          url = RELAYER_URL_BY_NETWORK.Cayenne;
           break;
         case 'habanero':
-          url = RELAY_URL_HABANERO;
+          url = RELAYER_URL_BY_NETWORK.Habanero;
           break;
         case 'manzano':
-          url = RELAY_URL_MANZANO;
+          url = RELAYER_URL_BY_NETWORK.Manzano;
           break;
         case 'datil-dev':
-          url = RELAY_URL_DATIL_DEV;
+          url = RELAYER_URL_BY_NETWORK.DatilDev;
           break;
         case 'datil-test':
-          url = RELAY_URL_DATIL_TEST;
+          url = RELAYER_URL_BY_NETWORK.DatilTest;
           break;
       }
 

--- a/packages/lit-auth-client/src/lib/lit-auth-client.ts
+++ b/packages/lit-auth-client/src/lib/lit-auth-client.ts
@@ -136,6 +136,11 @@ export class LitAuthClient {
     this.rpcUrl =
       options?.rpcUrl ||
       RPC_URL_BY_NETWORK[this.litNodeClient.config.litNetwork];
+
+    if (!this.rpcUrl) {
+      throw new Error('No RPC URL provided');
+    }
+
     log('rpc url: ', this.rpcUrl);
     log('relay config: ', options.litRelayConfig);
     log('relay instance: ', this.relay);

--- a/packages/lit-auth-client/src/lib/lit-auth-client.ts
+++ b/packages/lit-auth-client/src/lib/lit-auth-client.ts
@@ -110,7 +110,7 @@ export class LitAuthClient {
         );
       }
 
-      let url = RELAYER_URL_BY_NETWORK[this.litNodeClient.config.litNetwork];
+      const url = RELAYER_URL_BY_NETWORK[this.litNodeClient.config.litNetwork];
 
       this.relay = new LitRelay({
         relayUrl: url,

--- a/packages/lit-auth-client/src/lib/lit-auth-client.ts
+++ b/packages/lit-auth-client/src/lib/lit-auth-client.ts
@@ -110,25 +110,7 @@ export class LitAuthClient {
         );
       }
 
-      let url;
-
-      switch (this.litNodeClient.config.litNetwork) {
-        case 'cayenne':
-          url = RELAYER_URL_BY_NETWORK.Cayenne;
-          break;
-        case 'habanero':
-          url = RELAYER_URL_BY_NETWORK.Habanero;
-          break;
-        case 'manzano':
-          url = RELAYER_URL_BY_NETWORK.Manzano;
-          break;
-        case 'datil-dev':
-          url = RELAYER_URL_BY_NETWORK.DatilDev;
-          break;
-        case 'datil-test':
-          url = RELAYER_URL_BY_NETWORK.DatilTest;
-          break;
-      }
+      let url = RELAYER_URL_BY_NETWORK[this.litNodeClient.config.litNetwork];
 
       this.relay = new LitRelay({
         relayUrl: url,

--- a/packages/misc/src/lib/misc.ts
+++ b/packages/misc/src/lib/misc.ts
@@ -662,22 +662,13 @@ export const defaultMintClaimCallback: MintCallback<
   RelayClaimProcessor
 > = async (
   params: ClaimResult<RelayClaimProcessor>,
-  network: LIT_NETWORK_VALUES = 'cayenne'
+  network: string = 'cayenne'
 ): Promise<string> => {
   try {
     const AUTH_CLAIM_PATH = '/auth/claim';
 
-    const AUTH_CLAIM_URL_BY_NETWORK: Record<LIT_NETWORK_TYPES, string> = {
-      Cayenne: RELAYER_URL_BY_NETWORK.Cayenne + AUTH_CLAIM_PATH,
-      Manzano: RELAYER_URL_BY_NETWORK.Manzano + AUTH_CLAIM_PATH,
-      Habanero: RELAYER_URL_BY_NETWORK.Habanero + AUTH_CLAIM_PATH,
-      DatilDev: RELAYER_URL_BY_NETWORK.DatilDev + AUTH_CLAIM_PATH,
-      DatilTest: RELAYER_URL_BY_NETWORK.DatilTest + AUTH_CLAIM_PATH,
-      Custom: RELAYER_URL_BY_NETWORK.Cayenne + AUTH_CLAIM_PATH,
-    };
-
-    const relayUrl: LIT_NETWORK_VALUES =
-      AUTH_CLAIM_URL_BY_NETWORK[network as LIT_NETWORK_TYPES];
+    const relayUrl: string =
+      RELAYER_URL_BY_NETWORK[network as LIT_NETWORK_VALUES] + AUTH_CLAIM_PATH;
 
     if (!params.relayUrl && !relayUrl) {
       throw new Error(

--- a/packages/misc/src/lib/misc.ts
+++ b/packages/misc/src/lib/misc.ts
@@ -3,14 +3,12 @@ import {
   ILitError,
   LIT_AUTH_SIG_CHAIN_KEYS,
   LIT_CHAINS,
-  LIT_ENDPOINT,
   LIT_ERROR,
+  LIT_NETWORK,
+  LIT_NETWORK_TYPES,
+  LIT_NETWORK_VALUES,
   LitNetwork,
-  RELAY_URL_CAYENNE,
-  RELAY_URL_DATIL_DEV,
-  RELAY_URL_DATIL_TEST,
-  RELAY_URL_HABANERO,
-  RELAY_URL_MANZANO,
+  RELAYER_URL_BY_NETWORK,
 } from '@lit-protocol/constants';
 
 import {
@@ -664,28 +662,26 @@ export const defaultMintClaimCallback: MintCallback<
   RelayClaimProcessor
 > = async (
   params: ClaimResult<RelayClaimProcessor>,
-  network: string = 'cayenne'
+  network: LIT_NETWORK_VALUES = 'cayenne'
 ): Promise<string> => {
   try {
-    let relayUrl: string = '';
+    const AUTH_CLAIM_PATH = '/auth/claim';
 
-    switch (network) {
-      case LitNetwork.Cayenne:
-        relayUrl = RELAY_URL_CAYENNE + '/auth/claim';
-        break;
-      case LitNetwork.Habanero:
-        relayUrl = RELAY_URL_HABANERO + 'auth/claim';
-        break;
-      case LitNetwork.Manzano:
-        relayUrl = RELAY_URL_MANZANO + 'auth/claim';
-        break;
-      case LitNetwork.DatilDev:
-        relayUrl = RELAY_URL_DATIL_DEV + '/auth/claim';
-        break;
-        break;
-      case LitNetwork.DatilTest:
-        relayUrl = RELAY_URL_DATIL_TEST + '/auth/claim';
-        break;
+    const AUTH_CLAIM_URL_BY_NETWORK: Record<LIT_NETWORK_TYPES, string> = {
+      Cayenne: RELAYER_URL_BY_NETWORK.Cayenne + AUTH_CLAIM_PATH,
+      Manzano: RELAYER_URL_BY_NETWORK.Manzano + AUTH_CLAIM_PATH,
+      Habanero: RELAYER_URL_BY_NETWORK.Habanero + AUTH_CLAIM_PATH,
+      DatilDev: RELAYER_URL_BY_NETWORK.DatilDev + AUTH_CLAIM_PATH,
+      DatilTest: RELAYER_URL_BY_NETWORK.DatilTest + AUTH_CLAIM_PATH,
+      Custom: RELAYER_URL_BY_NETWORK.Cayenne + AUTH_CLAIM_PATH,
+    };
+
+    const relayUrl : LIT_NETWORK_VALUES = AUTH_CLAIM_URL_BY_NETWORK[network as LIT_NETWORK_TYPES];
+
+    if (!params.relayUrl && !relayUrl) {
+      throw new Error(
+        'No relayUrl provided and no default relayUrl found for network'
+      );
     }
 
     const url = params.relayUrl ? params.relayUrl : relayUrl;

--- a/packages/misc/src/lib/misc.ts
+++ b/packages/misc/src/lib/misc.ts
@@ -668,7 +668,7 @@ export const defaultMintClaimCallback: MintCallback<
     const AUTH_CLAIM_PATH = '/auth/claim';
 
     const relayUrl: string =
-      RELAYER_URL_BY_NETWORK[network as LIT_NETWORK_VALUES] + AUTH_CLAIM_PATH;
+      RELAYER_URL_BY_NETWORK[network as LIT_NETWORK_VALUES];
 
     if (!params.relayUrl && !relayUrl) {
       throw new Error(
@@ -676,8 +676,9 @@ export const defaultMintClaimCallback: MintCallback<
       );
     }
 
-    const url = params.relayUrl ? params.relayUrl : relayUrl;
-    const response = await fetch(url, {
+    const relayUrlWithPath = relayUrl + AUTH_CLAIM_PATH;
+
+    const response = await fetch(relayUrlWithPath, {
       method: 'POST',
       body: JSON.stringify(params),
       headers: {

--- a/packages/misc/src/lib/misc.ts
+++ b/packages/misc/src/lib/misc.ts
@@ -676,7 +676,8 @@ export const defaultMintClaimCallback: MintCallback<
       Custom: RELAYER_URL_BY_NETWORK.Cayenne + AUTH_CLAIM_PATH,
     };
 
-    const relayUrl : LIT_NETWORK_VALUES = AUTH_CLAIM_URL_BY_NETWORK[network as LIT_NETWORK_TYPES];
+    const relayUrl: LIT_NETWORK_VALUES =
+      AUTH_CLAIM_URL_BY_NETWORK[network as LIT_NETWORK_TYPES];
 
     if (!params.relayUrl && !relayUrl) {
       throw new Error(


### PR DESCRIPTION
# Description

This PR introduces a mapping of network names to their respective RPC URLs, relayer URLs, general worker URLs, metamask chain infos. It consolidates and organizes the URL endpoints to improve code maintainability and readability.

Context: https://github.com/LIT-Protocol/js-sdk/pull/523#pullrequestreview-2170217103

