### PR TITLE
Feat: Update Wrapped keys Export to use Lit Actions

### DIFF
--- a/local-tests/tests/wrapped-keys/testExportWrappedKey.ts
+++ b/local-tests/tests/wrapped-keys/testExportWrappedKey.ts
@@ -52,6 +52,7 @@ export const testExportWrappedKey = async (devEnv: TinnyEnvironment) => {
   const { decryptedPrivateKey } = await exportPrivateKey({
     pkpSessionSigs: pkpSessionSigsExport,
     litNodeClient: devEnv.litNodeClient,
+    network: 'solana',
   });
 
   if (decryptedPrivateKey !== privateKey) {

--- a/local-tests/tests/wrapped-keys/testGenerateEthereumWrappedKey.ts
+++ b/local-tests/tests/wrapped-keys/testGenerateEthereumWrappedKey.ts
@@ -49,10 +49,10 @@ export const testGenerateEthereumWrappedKey = async (
 
   console.log(pkpSessionSigsExport);
 
-  // FIXME: Export broken as we can't decrypt data encrypted inside a Lit Action
   const { decryptedPrivateKey } = await exportPrivateKey({
     pkpSessionSigs: pkpSessionSigsExport,
     litNodeClient: devEnv.litNodeClient,
+    network: 'evm',
   });
 
   const wallet = new ethers.Wallet(decryptedPrivateKey);

--- a/local-tests/tests/wrapped-keys/testGenerateSolanaWrappedKey.ts
+++ b/local-tests/tests/wrapped-keys/testGenerateSolanaWrappedKey.ts
@@ -4,7 +4,7 @@ import { api } from '@lit-protocol/wrapped-keys';
 import { getPkpSessionSigs } from 'local-tests/setup/session-sigs/get-pkp-session-sigs';
 import nacl from 'tweetnacl';
 import bs58 from 'bs58';
-import { ethers } from 'ethers';
+import { Keypair } from '@solana/web3.js';
 
 const { generatePrivateKey, signMessageWithEncryptedKey, exportPrivateKey } =
   api;
@@ -83,16 +83,18 @@ export const testGenerateSolanaWrappedKey = async (
     new Date(Date.now() + 1000 * 60 * 10).toISOString()
   ); // 10 mins expiry
 
-  // FIXME: Export broken as we can't decrypt data encrypted inside a Lit Action
   const { decryptedPrivateKey } = await exportPrivateKey({
     pkpSessionSigs: pkpSessionSigsExport,
     litNodeClient: devEnv.litNodeClient,
+    network: 'solana',
   });
 
-  const wallet = new ethers.Wallet(decryptedPrivateKey);
-  const decryptedPublicKey = wallet.publicKey;
+  const solanaKeyPair = Keypair.fromSecretKey(
+    Buffer.from(decryptedPrivateKey, 'hex')
+  );
+  const decryptedPublicKey = solanaKeyPair.publicKey;
 
-  if (decryptedPublicKey !== generatedPublicKey) {
+  if (decryptedPublicKey.toString() !== generatedPublicKey) {
     throw new Error(
       `Decrypted decryptedPublicKey: ${decryptedPublicKey} doesn't match with the original generatedPublicKey: ${generatedPublicKey}`
     );

--- a/packages/wrapped-keys/esbuild.config.js
+++ b/packages/wrapped-keys/esbuild.config.js
@@ -26,9 +26,7 @@ const esbuild = require('esbuild');
     inject: ['./buffer.shim.js'],
   });
   await esbuild.build({
-    entryPoints: [
-      './src/lib/litActions/common/src/exportPrivateKey.js',
-    ],
+    entryPoints: ['./src/lib/litActions/common/src/exportPrivateKey.js'],
     bundle: true,
     minify: true,
     sourcemap: false,

--- a/packages/wrapped-keys/esbuild.config.js
+++ b/packages/wrapped-keys/esbuild.config.js
@@ -25,4 +25,14 @@ const esbuild = require('esbuild');
     outdir: './src/lib/litActions/ethereum/dist',
     inject: ['./buffer.shim.js'],
   });
+  await esbuild.build({
+    entryPoints: [
+      './src/lib/litActions/common/src/exportPrivateKey.js',
+    ],
+    bundle: true,
+    minify: true,
+    sourcemap: false,
+    outdir: './src/lib/litActions/common/dist',
+    inject: ['./buffer.shim.js'],
+  });
 })();

--- a/packages/wrapped-keys/src/lib/api/export-private-key.ts
+++ b/packages/wrapped-keys/src/lib/api/export-private-key.ts
@@ -2,10 +2,7 @@ import { exportPrivateKeyWithLitAction } from '../lit-actions-client';
 
 import { fetchPrivateKeyMetadata } from '../service-client';
 import { ExportPrivateKeyParams, ExportPrivateKeyResult } from '../types';
-import {
-  getFirstSessionSig,
-  getPkpAccessControlCondition,
-} from '../utils';
+import { getFirstSessionSig, getPkpAccessControlCondition } from '../utils';
 import { getLitActionCid } from '../lit-actions-client/utils';
 
 /**
@@ -20,7 +17,6 @@ import { getLitActionCid } from '../lit-actions-client/utils';
 export async function exportPrivateKey(
   params: ExportPrivateKeyParams
 ): Promise<ExportPrivateKeyResult> {
-
   const { litNodeClient, network, pkpSessionSigs } = params;
 
   const sessionSig = getFirstSessionSig(pkpSessionSigs);

--- a/packages/wrapped-keys/src/lib/api/export-private-key.ts
+++ b/packages/wrapped-keys/src/lib/api/export-private-key.ts
@@ -1,55 +1,43 @@
-import { decryptToString } from '@lit-protocol/encryption';
+import { exportPrivateKeyWithLitAction } from '../lit-actions-client';
 
-import { CHAIN_ETHEREUM, LIT_PREFIX } from '../constants';
 import { fetchPrivateKeyMetadata } from '../service-client';
 import { ExportPrivateKeyParams, ExportPrivateKeyResult } from '../types';
 import {
   getFirstSessionSig,
   getPkpAccessControlCondition,
-  getPkpAddressFromSessionSig,
 } from '../utils';
+import { getLitActionCid } from '../lit-actions-client/utils';
 
-/** Exports a previously persisted private key from the wrapped keys service for direct use by the caller, along with the keys metadata
+/**
+ * Exports a previously persisted private key from the wrapped keys service for direct use by the caller, along with the keys metadata.
+ * This method fetches the encrypted key from the wrapped keys service, then executes a Lit Action that decrypts the key inside the LIT action and
+ * removes the salt from the decrypted key.
  *
  * @param { ExportPrivateKeyParams } params Parameters required to export the private key
+ *
+ * @returns { Promise<ExportPrivateKeyResult> } - The decrypted private key of the Wrapped Key along with all the associated key info and LIT PKP Address associated with the Wrapped Key
  */
 export async function exportPrivateKey(
   params: ExportPrivateKeyParams
 ): Promise<ExportPrivateKeyResult> {
-  const { pkpSessionSigs, litNodeClient } = params;
+
+  const { litNodeClient, network, pkpSessionSigs } = params;
 
   const sessionSig = getFirstSessionSig(pkpSessionSigs);
-  const pkpAddress = getPkpAddressFromSessionSig(sessionSig);
-  const allowPkpAddressToDecrypt = getPkpAccessControlCondition(pkpAddress);
-
-  const privateKeyMetadata = await fetchPrivateKeyMetadata({
+  const storedKeyMetadata = await fetchPrivateKeyMetadata({
     sessionSig,
     litNetwork: litNodeClient.config.litNetwork,
   });
 
-  const { ciphertext, dataToEncryptHash, ...privateKeyMetadataMinusEncrypted } =
-    privateKeyMetadata;
-
-  const decryptedPrivateKey = await decryptToString(
-    {
-      accessControlConditions: [allowPkpAddressToDecrypt],
-      chain: CHAIN_ETHEREUM,
-      ciphertext,
-      dataToEncryptHash,
-      sessionSigs: pkpSessionSigs,
-    },
-    litNodeClient
+  const allowPkpAddressToDecrypt = getPkpAccessControlCondition(
+    storedKeyMetadata.pkpAddress
   );
 
-  // It will be of the form lit_<privateKey>
-  if (!decryptedPrivateKey.startsWith(LIT_PREFIX)) {
-    throw new Error(
-      `PKey was not encrypted with salt; all wrapped keys must be prefixed with '${LIT_PREFIX}'`
-    );
-  }
-
-  return {
-    decryptedPrivateKey: decryptedPrivateKey.slice(LIT_PREFIX.length),
-    ...privateKeyMetadataMinusEncrypted,
-  };
+  return exportPrivateKeyWithLitAction({
+    ...params,
+    litActionIpfsCid: getLitActionCid(network, 'exportPrivateKey'),
+    accessControlConditions: [allowPkpAddressToDecrypt],
+    pkpSessionSigs,
+    storedKeyMetadata,
+  });
 }

--- a/packages/wrapped-keys/src/lib/lit-actions-client/constants.ts
+++ b/packages/wrapped-keys/src/lib/lit-actions-client/constants.ts
@@ -13,6 +13,10 @@ const LIT_ACTION_CID_REPOSITORY: LitCidRepository = Object.freeze({
     evm: 'QmaoPMSqcze3NW3KSA75ecWSkcmWT1J7kVr8LyJPCKRvHd',
     solana: 'QmdRBXYLYvcNHrChmsZ2jFDY8dA99CcSdqHo3p1ES3UThL',
   }),
+  exportPrivateKey: Object.freeze({
+    evm: 'Qmb5ZAm1EZRL7dYTtyYxkPxx4kBmoCjjzcgdrJH9cKMXxR',
+    solana: 'Qmb5ZAm1EZRL7dYTtyYxkPxx4kBmoCjjzcgdrJH9cKMXxR',
+  }),
 });
 
 export { LIT_ACTION_CID_REPOSITORY };

--- a/packages/wrapped-keys/src/lib/lit-actions-client/constants.ts
+++ b/packages/wrapped-keys/src/lib/lit-actions-client/constants.ts
@@ -6,8 +6,10 @@ const LIT_ACTION_CID_REPOSITORY: LitCidRepository = Object.freeze({
     solana: 'QmSi9GL2weCFEP1SMAUw5PDpZRr436Zt3tLUNrSECPA5dT',
   }),
   signMessage: Object.freeze({
-    evm: 'QmTMGcyp77NeppGaqF2DmE1F8GXTSxQYzXCrbE7hNudUWx',
-    solana: 'QmUxnWS8VU9QwZRdyfwsEtvhJZcvcdrannjokgZoA1sesy',
+    // evm: 'QmTMGcyp77NeppGaqF2DmE1F8GXTSxQYzXCrbE7hNudUWx',
+    evm: 'QmTbyRQJTK83nsuFizZZsSLtTgbK7jgLZYbEKRtUAQEwAX',
+    // solana: 'QmUxnWS8VU9QwZRdyfwsEtvhJZcvcdrannjokgZoA1sesy',
+    solana: 'QmNfC9oEsj72hEvLSviDMYG97omne2XBs3mn3SXsRAsJBq',
   }),
   generateEncryptedKey: Object.freeze({
     evm: 'QmaoPMSqcze3NW3KSA75ecWSkcmWT1J7kVr8LyJPCKRvHd',

--- a/packages/wrapped-keys/src/lib/lit-actions-client/constants.ts
+++ b/packages/wrapped-keys/src/lib/lit-actions-client/constants.ts
@@ -2,14 +2,12 @@ import { LitCidRepository } from './types';
 
 const LIT_ACTION_CID_REPOSITORY: LitCidRepository = Object.freeze({
   signTransaction: Object.freeze({
-    evm: 'QmdYUhPCCK5hpDWMK1NiDLNLG6RZQy61QE4J7dBm1Y2nbA',
-    solana: 'QmSi9GL2weCFEP1SMAUw5PDpZRr436Zt3tLUNrSECPA5dT',
+    evm: 'QmSsgmy1N1zFZ5yNPCY7QWQZwrYRLuYUJF1VDygJc7L26o',
+    solana: 'QmdkcMmrtqWSQ8VrPr8KwzuzZnAxGJoVDeZP3NKTWCMZCg',
   }),
   signMessage: Object.freeze({
-    // evm: 'QmTMGcyp77NeppGaqF2DmE1F8GXTSxQYzXCrbE7hNudUWx',
-    evm: 'QmTbyRQJTK83nsuFizZZsSLtTgbK7jgLZYbEKRtUAQEwAX',
-    // solana: 'QmUxnWS8VU9QwZRdyfwsEtvhJZcvcdrannjokgZoA1sesy',
-    solana: 'QmNfC9oEsj72hEvLSviDMYG97omne2XBs3mn3SXsRAsJBq',
+    evm: 'QmWVW51FBH5j3wwaMVy8MR1QyzJgEjuaPh1yqwSGXRCENx',
+    solana: 'QmSPcfFhLofjhNDd5ZdVbhw53zmbR8oV4C2585Bm7C8izH',
   }),
   generateEncryptedKey: Object.freeze({
     evm: 'QmaoPMSqcze3NW3KSA75ecWSkcmWT1J7kVr8LyJPCKRvHd',

--- a/packages/wrapped-keys/src/lib/lit-actions-client/export-private-key.ts
+++ b/packages/wrapped-keys/src/lib/lit-actions-client/export-private-key.ts
@@ -3,8 +3,7 @@ import { AccessControlConditions } from '@lit-protocol/types';
 import { postLitActionValidation } from './utils';
 import { ExportPrivateKeyParams, StoredKeyMetadata } from '../types';
 
-interface SignMessageWithLitActionParams
-  extends ExportPrivateKeyParams {
+interface SignMessageWithLitActionParams extends ExportPrivateKeyParams {
   accessControlConditions: AccessControlConditions;
   storedKeyMetadata: StoredKeyMetadata;
   litActionIpfsCid: string;
@@ -21,7 +20,12 @@ export async function exportPrivateKeyWithLitAction(
     storedKeyMetadata,
   } = args;
 
-  const { pkpAddress, ciphertext, dataToEncryptHash, ...storeKeyMetadataMinusEncryptedAndPkp } = storedKeyMetadata;
+  const {
+    pkpAddress,
+    ciphertext,
+    dataToEncryptHash,
+    ...storeKeyMetadataMinusEncryptedAndPkp
+  } = storedKeyMetadata;
   const result = await litNodeClient.executeJs({
     sessionSigs: pkpSessionSigs,
     ipfsId: litActionIpfsCid,
@@ -33,7 +37,7 @@ export async function exportPrivateKeyWithLitAction(
     },
   });
 
-  const decryptedPrivateKey =  postLitActionValidation(result);
+  const decryptedPrivateKey = postLitActionValidation(result);
 
   return {
     decryptedPrivateKey,

--- a/packages/wrapped-keys/src/lib/lit-actions-client/export-private-key.ts
+++ b/packages/wrapped-keys/src/lib/lit-actions-client/export-private-key.ts
@@ -1,0 +1,43 @@
+import { AccessControlConditions } from '@lit-protocol/types';
+
+import { postLitActionValidation } from './utils';
+import { ExportPrivateKeyParams, StoredKeyMetadata } from '../types';
+
+interface SignMessageWithLitActionParams
+  extends ExportPrivateKeyParams {
+  accessControlConditions: AccessControlConditions;
+  storedKeyMetadata: StoredKeyMetadata;
+  litActionIpfsCid: string;
+}
+
+export async function exportPrivateKeyWithLitAction(
+  args: SignMessageWithLitActionParams
+) {
+  const {
+    accessControlConditions,
+    litNodeClient,
+    pkpSessionSigs,
+    litActionIpfsCid,
+    storedKeyMetadata,
+  } = args;
+
+  const { pkpAddress, ciphertext, dataToEncryptHash, ...storeKeyMetadataMinusEncryptedAndPkp } = storedKeyMetadata;
+  const result = await litNodeClient.executeJs({
+    sessionSigs: pkpSessionSigs,
+    ipfsId: litActionIpfsCid,
+    jsParams: {
+      pkpAddress,
+      ciphertext,
+      dataToEncryptHash,
+      accessControlConditions,
+    },
+  });
+
+  const decryptedPrivateKey =  postLitActionValidation(result);
+
+  return {
+    decryptedPrivateKey,
+    pkpAddress,
+    ...storeKeyMetadataMinusEncryptedAndPkp,
+  };
+}

--- a/packages/wrapped-keys/src/lib/lit-actions-client/index.ts
+++ b/packages/wrapped-keys/src/lib/lit-actions-client/index.ts
@@ -1,9 +1,11 @@
 import { generateKeyWithLitAction } from './generate-key';
 import { signMessageWithLitAction } from './sign-message';
 import { signTransactionWithLitAction } from './sign-transaction';
+import { exportPrivateKeyWithLitAction } from './export-private-key';
 
 export {
   generateKeyWithLitAction,
   signTransactionWithLitAction,
   signMessageWithLitAction,
+  exportPrivateKeyWithLitAction,
 };

--- a/packages/wrapped-keys/src/lib/lit-actions-client/types.ts
+++ b/packages/wrapped-keys/src/lib/lit-actions-client/types.ts
@@ -3,7 +3,8 @@ import { Network } from '../types';
 export type LitActionType =
   | 'signTransaction'
   | 'signMessage'
-  | 'generateEncryptedKey';
+  | 'generateEncryptedKey'
+  | 'exportPrivateKey';
 
 export type LitCidRepositoryEntry = Readonly<Record<Network, string>>;
 

--- a/packages/wrapped-keys/src/lib/litActions/common/src/exportPrivateKey.js
+++ b/packages/wrapped-keys/src/lib/litActions/common/src/exportPrivateKey.js
@@ -35,9 +35,9 @@ const { removeSaltFromDecryptedKey } = require('../../utils');
   }
 
   try {
-      const privateKey = removeSaltFromDecryptedKey(decryptedPrivateKey);
-      Lit.Actions.setResponse({ response: privateKey });
+    const privateKey = removeSaltFromDecryptedKey(decryptedPrivateKey);
+    Lit.Actions.setResponse({ response: privateKey });
   } catch (err) {
-      Lit.Actions.setResponse({ response: err.message });
+    Lit.Actions.setResponse({ response: err.message });
   }
 })();

--- a/packages/wrapped-keys/src/lib/litActions/common/src/exportPrivateKey.js
+++ b/packages/wrapped-keys/src/lib/litActions/common/src/exportPrivateKey.js
@@ -1,0 +1,43 @@
+const { removeSaltFromDecryptedKey } = require('../../utils');
+
+/**
+ *
+ * Exports the private key after decrypting and removing the salt from it.
+ *
+ * @jsParam pkpAddress - The Eth address of the PKP which is associated with the Wrapped Key
+ * @jsParam ciphertext - For the encrypted Wrapped Key
+ * @jsParam dataToEncryptHash - For the encrypted Wrapped Key
+ * @jsParam accessControlConditions - The access control condition that allows only the pkpAddress to decrypt the Wrapped Key
+ *
+ * @returns { Promise<string> } - Returns a decrypted private key.
+ */
+
+(async () => {
+  let decryptedPrivateKey;
+  try {
+    decryptedPrivateKey = await Lit.Actions.decryptToSingleNode({
+      accessControlConditions,
+      ciphertext,
+      dataToEncryptHash,
+      chain: 'ethereum',
+      authSig: null,
+    });
+  } catch (err) {
+    const errorMessage =
+      'Error: When decrypting to a single node- ' + err.message;
+    Lit.Actions.setResponse({ response: errorMessage });
+    return;
+  }
+
+  if (!decryptedPrivateKey) {
+    // Exit the nodes which don't have the decryptedData
+    return;
+  }
+
+  try {
+      const privateKey = removeSaltFromDecryptedKey(decryptedPrivateKey);
+      Lit.Actions.setResponse({ response: privateKey });
+  } catch (err) {
+      Lit.Actions.setResponse({ response: err.message });
+  }
+})();

--- a/packages/wrapped-keys/src/lib/litActions/ethereum/src/signMessageWithEthereumEncryptedKey.js
+++ b/packages/wrapped-keys/src/lib/litActions/ethereum/src/signMessageWithEthereumEncryptedKey.js
@@ -36,6 +36,7 @@ const { removeSaltFromDecryptedKey } = require('../../utils');
   }
 
   const privateKey = removeSaltFromDecryptedKey(decryptedPrivateKey);
+  const wallet = new ethers.Wallet(privateKey);
 
   try {
     const signature = await wallet.signMessage(messageToSign);

--- a/packages/wrapped-keys/src/lib/litActions/ethereum/src/signMessageWithEthereumEncryptedKey.js
+++ b/packages/wrapped-keys/src/lib/litActions/ethereum/src/signMessageWithEthereumEncryptedKey.js
@@ -35,7 +35,14 @@ const { removeSaltFromDecryptedKey } = require('../../utils');
     return;
   }
 
-  const privateKey = removeSaltFromDecryptedKey(decryptedPrivateKey);
+  let privateKey;
+  try {
+    privateKey = removeSaltFromDecryptedKey(decryptedPrivateKey);
+    Lit.Actions.setResponse({ response: privateKey });
+  } catch (err) {
+    Lit.Actions.setResponse({ response: err.message });
+    return;
+  }
   const wallet = new ethers.Wallet(privateKey);
 
   try {

--- a/packages/wrapped-keys/src/lib/litActions/ethereum/src/signTransactionWithEthereumEncryptedKey.js
+++ b/packages/wrapped-keys/src/lib/litActions/ethereum/src/signTransactionWithEthereumEncryptedKey.js
@@ -63,7 +63,14 @@ const { removeSaltFromDecryptedKey } = require('../../utils');
     return;
   }
 
-  const privateKey = removeSaltFromDecryptedKey(decryptedPrivateKey);
+  let privateKey;
+  try {
+    privateKey = removeSaltFromDecryptedKey(decryptedPrivateKey);
+    Lit.Actions.setResponse({ response: privateKey });
+  } catch (err) {
+    Lit.Actions.setResponse({ response: err.message });
+    return;
+  }
   const wallet = new ethers.Wallet(privateKey);
 
   let nonce;

--- a/packages/wrapped-keys/src/lib/litActions/solana/src/signMessageWithSolanaEncryptedKey.js
+++ b/packages/wrapped-keys/src/lib/litActions/solana/src/signMessageWithSolanaEncryptedKey.js
@@ -39,7 +39,14 @@ const { removeSaltFromDecryptedKey } = require('../../utils');
     return;
   }
 
-  const privateKey = removeSaltFromDecryptedKey(decryptedPrivateKey);
+  let privateKey;
+  try {
+    privateKey = removeSaltFromDecryptedKey(decryptedPrivateKey);
+    Lit.Actions.setResponse({ response: privateKey });
+  } catch (err) {
+    Lit.Actions.setResponse({ response: err.message });
+    return;
+  }
   const solanaKeyPair = Keypair.fromSecretKey(Buffer.from(privateKey, 'hex'));
 
   let signature;

--- a/packages/wrapped-keys/src/lib/litActions/solana/src/signTransactionWithSolanaEncryptedKey.js
+++ b/packages/wrapped-keys/src/lib/litActions/solana/src/signTransactionWithSolanaEncryptedKey.js
@@ -62,7 +62,14 @@ const { removeSaltFromDecryptedKey } = require('../../utils');
     return;
   }
 
-  const privateKey = removeSaltFromDecryptedKey(decryptedPrivateKey);
+  let privateKey;
+  try {
+    privateKey = removeSaltFromDecryptedKey(decryptedPrivateKey);
+    Lit.Actions.setResponse({ response: privateKey });
+  } catch (err) {
+    Lit.Actions.setResponse({ response: err.message });
+    return;
+  }
 
   const solanaKeyPair = Keypair.fromSecretKey(
     Uint8Array.from(Buffer.from(privateKey, 'hex'))

--- a/packages/wrapped-keys/src/lib/litActions/utils.js
+++ b/packages/wrapped-keys/src/lib/litActions/utils.js
@@ -3,7 +3,7 @@ import { LIT_PREFIX } from '../constants';
 export function removeSaltFromDecryptedKey(decryptedPrivateKey) {
   if (!decryptedPrivateKey.startsWith(LIT_PREFIX)) {
     throw new Error(
-      `PKey was not encrypted with salt; all wrapped keys must be prefixed with '${LIT_PREFIX}'`
+      `Error: PKey was not encrypted with salt; all wrapped keys must be prefixed with '${LIT_PREFIX}'`
     );
   }
 

--- a/packages/wrapped-keys/src/lib/types.ts
+++ b/packages/wrapped-keys/src/lib/types.ts
@@ -70,7 +70,8 @@ export type StoreEncryptedKeyMetadataParams = BaseApiParams &
  * @extends BaseApiParams
  *
  */
-export type ExportPrivateKeyParams = BaseApiParams;
+export type ExportPrivateKeyParams = BaseApiParams &
+  ApiParamsSupportedNetworks;
 
 /** Includes the decrypted private key and metadata that was stored alongside it in the wrapped keys service
  *

--- a/packages/wrapped-keys/src/lib/types.ts
+++ b/packages/wrapped-keys/src/lib/types.ts
@@ -70,8 +70,7 @@ export type StoreEncryptedKeyMetadataParams = BaseApiParams &
  * @extends BaseApiParams
  *
  */
-export type ExportPrivateKeyParams = BaseApiParams &
-  ApiParamsSupportedNetworks;
+export type ExportPrivateKeyParams = BaseApiParams & ApiParamsSupportedNetworks;
 
 /** Includes the decrypted private key and metadata that was stored alongside it in the wrapped keys service
  *


### PR DESCRIPTION
# Description

Currently Wrapped Keys export feature simply decrypts the private key on the client. This PR updates the export to happen via a Lit Action and returns the decrypted key from inside the Lit Action. Exporting through a Lit Action also allows us to add more restrictions on the export feature like allow decryption only inside certain permitted Lit Actions which is not currently the case.

Also fixed the following:
1. `signMessageWithEthereumEncryptedKey` Lit Action was **not** initializing the Ethers wallet with the decrypted private key. This was accidentally left out in this commit: https://github.com/LIT-Protocol/js-sdk/pull/515/commits/2fbd86136198fc194133f805ccdd51feb4345a6f#diff-cfa4907cf70adeff456099de1858fb36fb1d13060b43e6357f6c932c679f815fL41
2. All the Lit Actions are using `removeSaltFromDecryptedKey()` which throws an error if the private key isn't prefixed with "lit_". But when invoked inside a Lit Action we don't support it with a try/catch block which causes the Lit Action to crash and  doesn't show the error to the user. Updated all the Lit Actions to show this error to the client.
    1. Published all the Lit Actions with the above fix and updated the Ipfs Cids in the `constants` file

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

It has been tested with three Tinny tests

- [X] `testExportWrappedKey`: Import an existing key, export it and compares the private keys
- [X] `testGenerateSolanaWrappedKey`: Generate a Solana key, export it and compare the derived publicKeys
- [X] `testGenerateEthereumWrappedKey`: Generate a Solana key, export it and compare the derived publicKeys

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
