### PR TITLE
fix: LIT-3607 - Use StaticJsonRpcProvider to improve performance of RPC requests

### DIFF
--- a/local-tests/setup/shiva-client.ts
+++ b/local-tests/setup/shiva-client.ts
@@ -84,7 +84,7 @@ export class TestnetClient {
     const networkContext = {
       abi: JSON.parse(contractResolverAbi),
       resolverAddress: contractResolverAddress,
-      provider: new ethers.providers.JsonRpcProvider(
+      provider: new ethers.providers.StaticJsonRpcProvider(
         `http://${testNetConfig.rpcUrl}`
       ),
       environment: 0, // test deployment uses env value 0 in test common

--- a/local-tests/setup/tinny-person.ts
+++ b/local-tests/setup/tinny-person.ts
@@ -31,7 +31,7 @@ export class TinnyPerson {
     ethers.utils.keccak256([1, 2, 3, 4, 5])
   );
 
-  public provider: ethers.providers.JsonRpcProvider;
+  public provider: ethers.providers.StaticJsonRpcProvider;
 
   public envConfig: TinnyEnvConfig;
 
@@ -45,7 +45,9 @@ export class TinnyPerson {
     this.envConfig = envConfig;
 
     this.privateKey = privateKey;
-    this.provider = new ethers.providers.JsonRpcProvider(this.envConfig.rpc);
+    this.provider = new ethers.providers.StaticJsonRpcProvider(
+      this.envConfig.rpc
+    );
     this.wallet = new ethers.Wallet(privateKey, this.provider);
   }
 

--- a/packages/contracts-sdk/src/lib/addresses.ts
+++ b/packages/contracts-sdk/src/lib/addresses.ts
@@ -1,12 +1,12 @@
+import { rawSecp256k1PubkeyToRawAddress } from '@cosmjs/amino';
+import { Secp256k1 } from '@cosmjs/crypto';
+import { toBech32 } from '@cosmjs/encoding';
 import * as bitcoinjs from 'bitcoinjs-lib';
 import { Contract, ethers } from 'ethers';
 import { computeAddress } from 'ethers/lib/utils';
-import { PKPNFTData } from '../abis/PKPNFT.sol/PKPNFTData';
-import { toBech32 } from '@cosmjs/encoding';
-import { Secp256k1 } from '@cosmjs/crypto';
 
-import { rawSecp256k1PubkeyToRawAddress } from '@cosmjs/amino';
-export type TokenInfo = {
+import { PKPNFTData } from '../abis/PKPNFT.sol/PKPNFTData';
+export interface TokenInfo {
   tokenId: string;
   publicKey: string;
   publicKeyBuffer: Buffer;
@@ -14,7 +14,7 @@ export type TokenInfo = {
   btcAddress: string;
   cosmosAddress: string;
   isNewPKP: boolean;
-};
+}
 
 export const derivedAddresses = async ({
   publicKey,
@@ -64,7 +64,9 @@ export const derivedAddresses = async ({
         if (cachedPkpJSON[pkpTokenId]) {
           publicKey = cachedPkpJSON[pkpTokenId];
         } else {
-          const provider = new ethers.providers.JsonRpcProvider(defaultRPCUrl);
+          const provider = new ethers.providers.StaticJsonRpcProvider(
+            defaultRPCUrl
+          );
 
           const contract = new Contract(
             pkpContractAddress,
@@ -89,7 +91,7 @@ export const derivedAddresses = async ({
           cachedPkpJSON[pkpTokenId] = publicKey;
           localStorage.setItem(CACHE_KEY, JSON.stringify(cachedPkpJSON));
         } else {
-          const cachedPkpJSON: { [key: string]: any } = {};
+          const cachedPkpJSON: Record<string, any> = {};
           cachedPkpJSON[pkpTokenId] = publicKey;
           localStorage.setItem(CACHE_KEY, JSON.stringify(cachedPkpJSON));
         }

--- a/packages/contracts-sdk/src/lib/contracts-sdk.spec.ts
+++ b/packages/contracts-sdk/src/lib/contracts-sdk.spec.ts
@@ -1,10 +1,7 @@
 import { LitContracts } from './contracts-sdk';
-import { ethers } from 'ethers';
-import { LitContract } from '../../../types/src/lib/types';
 
 describe('contractsSdk', () => {
   let litContracts: LitContracts;
-  let litContracts_privateKeySigner: LitContracts;
 
   beforeEach(() => {
     litContracts = new LitContracts();
@@ -29,8 +26,6 @@ describe('contractsSdk', () => {
   });
 
   it('Test that  connection from custom context resolves contracts in correct mapping', async () => {
-    const DEFAULT_RPC = 'https://chain-rpc.litprotocol.com/http';
-    const provider = new ethers.providers.JsonRpcProvider(DEFAULT_RPC);
     litContracts = new LitContracts({
       customContext: {
         Allowlist: {

--- a/packages/contracts-sdk/src/lib/contracts-sdk.ts
+++ b/packages/contracts-sdk/src/lib/contracts-sdk.ts
@@ -103,7 +103,7 @@ const GAS_LIMIT = ethers.utils.hexlify(5000000); // Adjust as needed
 // The class has a number of properties that represent the smart contract instances, such as accessControlConditionsContract, litTokenContract, pkpNftContract, etc. These smart contract instances are created by passing the contract address, ABI, and provider to the ethers.Contract constructor.
 // The class also has a utils object with helper functions for converting between hexadecimal and decimal representation of numbers, as well as functions for working with multihashes and timestamps.
 export class LitContracts {
-  provider: ethers.providers.JsonRpcProvider | any;
+  provider: ethers.providers.StaticJsonRpcProvider | any;
   rpc: string;
   rpcs: string[];
   signer: ethers.Signer | ethers.Wallet;
@@ -180,7 +180,7 @@ export class LitContracts {
 
   // make the constructor args optional
   constructor(args?: {
-    provider?: ethers.providers.JsonRpcProvider | any;
+    provider?: ethers.providers.StaticJsonRpcProvider | any;
     customContext?: LitContractContext | LitContractResolverContext;
     rpcs?: string[] | any;
     rpc?: string | any;
@@ -301,7 +301,7 @@ export class LitContracts {
     // ----------------------------------------------
     else if (isNode()) {
       this.log("----- We're in node! -----");
-      this.provider = new ethers.providers.JsonRpcProvider(this.rpc);
+      this.provider = new ethers.providers.StaticJsonRpcProvider(this.rpc);
     }
 
     // ======================================
@@ -579,12 +579,12 @@ export class LitContracts {
     context?: LitContractContext | LitContractResolverContext,
     rpcUrl?: string
   ) {
-    let provider: ethers.providers.JsonRpcProvider;
+    let provider: ethers.providers.StaticJsonRpcProvider;
     rpcUrl = RPC_URL_BY_NETWORK[network];
     if (context && 'provider' in context!) {
       provider = context.provider;
     } else {
-      provider = new ethers.providers.JsonRpcProvider(rpcUrl);
+      provider = new ethers.providers.StaticJsonRpcProvider(rpcUrl);
     }
 
     if (network === 'datil-dev' || network === 'datil-test') {
@@ -647,7 +647,7 @@ export class LitContracts {
 
   private static async _getContractsFromResolver(
     context: LitContractResolverContext,
-    provider: ethers.providers.JsonRpcProvider,
+    provider: ethers.providers.StaticJsonRpcProvider,
     contractNames?: (keyof LitContractContext)[]
   ): Promise<LitContractContext> {
     const resolverContract = new ethers.Contract(
@@ -766,7 +766,7 @@ export class LitContracts {
 
   public static async getContractAddresses(
     network: LIT_NETWORKS_KEYS,
-    provider: ethers.providers.JsonRpcProvider,
+    provider: ethers.providers.StaticJsonRpcProvider,
     context?: LitContractContext | LitContractResolverContext
   ) {
     let contractData;
@@ -1356,7 +1356,7 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
   //   if (isBrowser()) {
   //     provider = new ethers.providers.Web3Provider(window.ethereum, 'any');
   //   } else {
-  //     provider = new ethers.providers.JsonRpcProvider(this.rpc);
+  //     provider = new ethers.providers.StaticJsonRpcProvider(this.rpc);
   //   }
   //   const signer = new ethers.Wallet(privateKey, provider);
 
@@ -1369,7 +1369,7 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
   //   if (isBrowser()) {
   //     provider = new ethers.providers.Web3Provider(window.ethereum, 'any');
   //   } else {
-  //     provider = new ethers.providers.JsonRpcProvider(this.rpc);
+  //     provider = new ethers.providers.StaticJsonRpcProvider(this.rpc);
   //   }
   //   const signer = new ethers.Wallet(privateKey, provider);
 

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -15,13 +15,13 @@ import {
   validateUnifiedAccessControlConditionsSchema,
 } from '@lit-protocol/access-control-conditions';
 import {
-  LIT_CHAINS,
   LIT_CURVE,
   LIT_ENDPOINT,
   LIT_ERROR,
   LIT_ERROR_CODE,
   LIT_NETWORKS,
   LitNetwork,
+  RPC_URL_BY_NETWORK,
   StakingStates,
   version,
 } from '@lit-protocol/constants';
@@ -439,10 +439,6 @@ export class LitCore {
    */
   getLatestBlockhash = async (): Promise<string> => {
     await this._syncBlockhash();
-    console.log(
-      `querying latest blockhash current value is `,
-      this.latestBlockhash
-    );
     if (!this.latestBlockhash) {
       throw new Error(
         `latestBlockhash is not available. Received: "${this.latestBlockhash}"`
@@ -488,15 +484,14 @@ export class LitCore {
     if (!this.config.contractContext) {
       this.config.contractContext = await LitContracts.getContractAddresses(
         this.config.litNetwork,
-        new ethers.providers.JsonRpcProvider(
-          this.config.rpcUrl || LIT_CHAINS['lit'].rpcUrls[0]
+        new ethers.providers.StaticJsonRpcProvider(
+          this.config.rpcUrl || RPC_URL_BY_NETWORK[this.config.litNetwork]
         )
       );
     } else if (
       !this.config.contractContext.Staking &&
       !this.config.contractContext.resolverAddress
     ) {
-      console.log(this.config.contractContext);
       throw new Error(
         'The provided contractContext was missing the "Staking" contract`'
       );

--- a/packages/pkp-ethers/src/lib/pkp-ethers.ts
+++ b/packages/pkp-ethers/src/lib/pkp-ethers.ts
@@ -35,7 +35,7 @@ import {
 import { Wordlist } from '@ethersproject/wordlists';
 import { ethers, version, Wallet } from 'ethers';
 
-import { LIT_CHAINS } from '@lit-protocol/constants';
+import { RPC_URL_BY_NETWORK } from '@lit-protocol/constants';
 import { PKPBase } from '@lit-protocol/pkp-base';
 import {
   PKPClientHelpers,
@@ -51,7 +51,6 @@ import {
   ETHSignature,
   ETHTxRes,
 } from './pkp-ethers-types';
-import { RPC_URL_BY_NETWORK } from '@lit-protocol/constants';
 
 const logger = new Logger(version);
 
@@ -68,7 +67,7 @@ export class PKPEthersWallet
   readonly address!: string;
   readonly _isSigner!: boolean;
 
-  rpcProvider: ethers.providers.JsonRpcProvider;
+  rpcProvider: ethers.providers.StaticJsonRpcProvider;
   provider!: Provider;
 
   // -- manual tx settings --
@@ -88,16 +87,12 @@ export class PKPEthersWallet
       prop.rpc || RPC_URL_BY_NETWORK[prop.litNodeClient.config.litNetwork];
 
     if (!rpcUrl) {
-      throw new Error('No RPC URL provided');
+      throw new Error(
+        `No RPC URL provided, and none could be found for ${prop.litNodeClient.config.litNetwork}`
+      );
     }
 
-    this.rpcProvider = new ethers.providers.JsonRpcProvider(rpcUrl);
-
-    if (!rpcUrl) {
-      throw new Error('rpcUrl is required');
-    }
-
-    this.rpcProvider = new ethers.providers.JsonRpcProvider(rpcUrl);
+    this.rpcProvider = new ethers.providers.StaticJsonRpcProvider(rpcUrl);
     this.provider = prop.provider ?? this.rpcProvider;
 
     defineReadOnly(this, '_isSigner', true);
@@ -114,7 +109,7 @@ export class PKPEthersWallet
   };
 
   setRpc = async (rpc: string): Promise<void> => {
-    this.rpcProvider = new ethers.providers.JsonRpcProvider(rpc);
+    this.rpcProvider = new ethers.providers.StaticJsonRpcProvider(rpc);
   };
 
   handleRequest = async <T = ETHSignature | ETHTxRes>(


### PR DESCRIPTION
Reference issue - https://github.com/ethers-io/ethers.js/issues/901 Cuts our RPC request time costs approximately in half by eliminating a sequential call to get `chainId` from every(!) contract call we make

# Description

Replaced ethers JSONRPCProvider instances with StaticJSONRPCProvider
This eliminates unnecessary RPC calls to get `chainId` every time we use one of our contract methods.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Ran localtests against datil-dev, datil-test and cayenne

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes