### PR TITLE
fix: Workaround for ethers.js bug in webpack environments

### DIFF
--- a/packages/contracts-sdk/src/lib/contracts-sdk.ts
+++ b/packages/contracts-sdk/src/lib/contracts-sdk.ts
@@ -584,8 +584,8 @@ export class LitContracts {
     if (context && 'provider' in context!) {
       provider = context.provider;
     } else {
-      provider = new ethers.providers.JsonRpcProvider({
-        rpcUrl,
+      provider = new ethers.providers.StaticJsonRpcProvider({
+        url: rpcUrl,
         skipFetchSetup: true,
       });
     }

--- a/packages/contracts-sdk/src/lib/contracts-sdk.ts
+++ b/packages/contracts-sdk/src/lib/contracts-sdk.ts
@@ -584,7 +584,10 @@ export class LitContracts {
     if (context && 'provider' in context!) {
       provider = context.provider;
     } else {
-      provider = new ethers.providers.JsonRpcProvider(rpcUrl);
+      provider = new ethers.providers.JsonRpcProvider({
+        rpcUrl,
+        skipFetchSetup: true,
+      });
     }
 
     if (network === 'datil-dev' || network === 'datil-test') {


### PR DESCRIPTION


# Description

I was getting the following issue when trying to connect in a nodejs server-side webpack environment (in Next.js):
```
Error: could not detect network (event="noNetwork", code=NETWORK_ERROR, version=providers/5.7.2)
```

After doing some searching and testing, I figured out it was an bug from ethers.js with webpack. I tried the workaround from [https://github.com/ethers-io/ethers.js/issues/3536#issuecomment-1323302238](https://github.com/ethers-io/ethers.js/issues/3536#issuecomment-1323302238) and it fixed the issue. This PR only changes one line of code.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Try running it in Next.js server side with and without this change. You will see the difference.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
