### PR TITLE
fix: throw error with stack

### DIFF
--- a/packages/misc/src/lib/misc.ts
+++ b/packages/misc/src/lib/misc.ts
@@ -162,6 +162,7 @@ export const throwErrorV1 = ({
   errorCode,
   requestId,
 }: NodeClientErrorV1): never => {
+  // TODO: to refactor such that we do not need a wrapper function to construct the error, since it gets added to all stack traces it does technically pollute.
   throw new Error(
     JSON.stringify({
       errorKind,

--- a/packages/misc/src/lib/misc.ts
+++ b/packages/misc/src/lib/misc.ts
@@ -162,6 +162,17 @@ export const throwErrorV1 = ({
   errorCode,
   requestId,
 }: NodeClientErrorV1): never => {
+  throw new Error(
+    JSON.stringify({
+      errorKind,
+      details,
+      status,
+      message,
+      errorCode,
+      requestId,
+    }) as any
+  );
+
   const errConstructorFunc = function (
     this: any,
     errorKind: string,

--- a/packages/misc/src/lib/misc.ts
+++ b/packages/misc/src/lib/misc.ts
@@ -163,7 +163,8 @@ export const throwErrorV1 = ({
   requestId,
 }: NodeClientErrorV1): never => {
   // TODO: to refactor such that we do not need a wrapper function to construct the error, since it gets added to all stack traces it does technically pollute.
-  throw new Error(
+  console.log(
+    `❌`,
     JSON.stringify({
       errorKind,
       details,
@@ -172,6 +173,32 @@ export const throwErrorV1 = ({
       errorCode,
       requestId,
     }) as any
+  );
+
+  const errConstructorFunc = function (
+    this: any,
+    errorKind: string,
+    status: number,
+    details: string[],
+    message?: string,
+    errorCode?: string,
+    requestId?: string
+  ) {
+    this.message = message;
+    this.errorCode = errorCode;
+    this.errorKind = errorKind;
+    this.status = status;
+    this.details = details;
+    this.requestId = requestId;
+  };
+
+  throw new (errConstructorFunc as any)(
+    errorKind,
+    status,
+    details,
+    message,
+    errorCode,
+    requestId
   );
 };
 

--- a/packages/misc/src/lib/misc.ts
+++ b/packages/misc/src/lib/misc.ts
@@ -172,32 +172,6 @@ export const throwErrorV1 = ({
       requestId,
     }) as any
   );
-
-  const errConstructorFunc = function (
-    this: any,
-    errorKind: string,
-    status: number,
-    details: string[],
-    message?: string,
-    errorCode?: string,
-    requestId?: string
-  ) {
-    this.message = message;
-    this.errorCode = errorCode;
-    this.errorKind = errorKind;
-    this.status = status;
-    this.details = details;
-    this.requestId = requestId;
-  };
-
-  throw new (errConstructorFunc as any)(
-    errorKind,
-    status,
-    details,
-    message,
-    errorCode,
-    requestId
-  );
 };
 
 export const throwGenericError = (e: any): never => {


### PR DESCRIPTION
# Description

This will show error stack when running tinny/local-tests

```
NETWORK=datil-test yarn test:local  --filter=testUseEoaSessionSigsToPkpSign
```

## Before
<img width="884" alt="image" src="https://github.com/user-attachments/assets/043f17b7-2db9-4203-9ea7-5763b71f0fe6">

## After

<img width="701" alt="image" src="https://github.com/user-attachments/assets/ecd55383-3b45-4252-a044-fd45e3f5f3ef">


