### PR TITLE
feat: add node error inside sdk error v1 wrapper

### DIFF
--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -1178,11 +1178,11 @@ export class LitCore {
    * Throw node error
    *
    * @param { RejectedNodePromises } res
-   *
-   * @returns { void }
+   * @param { string } requestId
+   * @returns { never } This function should never return, it will throw an error
    *
    */
-  _throwNodeError = (res: RejectedNodePromises, requestId: string): void => {
+  _throwNodeError = (res: RejectedNodePromises, requestId: string): never => {
     if (res.error) {
       if (
         ((res.error.errorCode &&
@@ -1193,18 +1193,20 @@ export class LitCore {
         log('You are not authorized to access this content');
       }
 
-      throwError({
+      return throwError({
         ...res.error,
         message:
           res.error.message ||
-          'There was an error getting the signing shares from the nodes',
+          `There was an error getting the signing shares from the nodes. Response from the nodes: ${JSON.stringify(
+            res.error, null, 2
+          )}`,
         errorCode: res.error.errorCode || LIT_ERROR.UNKNOWN_ERROR.code,
         requestId,
-      } as NodeClientErrorV0 | NodeClientErrorV1);
+      });
     } else {
-      throwError({
-        message: `There was an error getting the signing shares from the nodes.  Response from the nodes: ${JSON.stringify(
-          res
+      return throwError({
+        message: `There was an error getting the signing shares from the nodes. Response from the nodes: ${JSON.stringify(
+          res, null, 2
         )}`,
         error: LIT_ERROR.UNKNOWN_ERROR,
         requestId,

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -1198,7 +1198,9 @@ export class LitCore {
         message:
           res.error.message ||
           `There was an error getting the signing shares from the nodes. Response from the nodes: ${JSON.stringify(
-            res.error, null, 2
+            res.error,
+            null,
+            2
           )}`,
         errorCode: res.error.errorCode || LIT_ERROR.UNKNOWN_ERROR.code,
         requestId,
@@ -1206,7 +1208,9 @@ export class LitCore {
     } else {
       return throwError({
         message: `There was an error getting the signing shares from the nodes. Response from the nodes: ${JSON.stringify(
-          res, null, 2
+          res,
+          null,
+          2
         )}`,
         error: LIT_ERROR.UNKNOWN_ERROR,
         requestId,

--- a/packages/misc/src/lib/misc.ts
+++ b/packages/misc/src/lib/misc.ts
@@ -168,7 +168,14 @@ class ErrorV1 extends GenericError {
   readonly status: number | undefined;
   readonly details: string[] | undefined;
 
-  constructor(message: string, errorKind: string, errorCode: string, status?: number, details?: string[], requestId?: string) {
+  constructor(
+    message: string,
+    errorKind: string,
+    errorCode: string,
+    status?: number,
+    details?: string[],
+    requestId?: string
+  ) {
     super(message, requestId);
     this.status = status;
     this.details = details;
@@ -190,27 +197,23 @@ export const throwErrorV1 = ({
   errorCode,
   requestId,
 }: NodeClientErrorV1): never => {
-  throw new ErrorV1(
-    message,
-    errorKind,
-    errorCode,
-    status,
-    details,
-    requestId
-  )
+  throw new ErrorV1(message, errorKind, errorCode, status, details, requestId);
 };
 
-export const throwGenericError = (e: { message?: string, requestId?: string }): never => {
-  throw new GenericError(e.message ?? 'Generic Error', e.requestId ?? 'No request ID found');
+export const throwGenericError = (e: {
+  message?: string;
+  requestId?: string;
+}): never => {
+  throw new GenericError(
+    e.message ?? 'Generic Error',
+    e.requestId ?? 'No request ID found'
+  );
 };
 
 export const isNodeClientErrorV1 = (
   nodeError: NodeClientErrorV0 | NodeClientErrorV1
 ): nodeError is NodeClientErrorV1 => {
-  return (
-    'errorCode' in nodeError &&
-    'errorKind' in nodeError
-  );
+  return 'errorCode' in nodeError && 'errorKind' in nodeError;
 };
 
 export const isNodeClientErrorV0 = (


### PR DESCRIPTION
# Description

This PR adds the node error data inside the error thrown in SDK wrappers. This way it is not lost in context and can be easily seen in console, not having to also search in network tab
![Screenshot from 2024-07-22 16-53-18](https://github.com/user-attachments/assets/84025fd8-b083-4b50-80fd-0d9fdd7c7c11)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Throw lit action error in a demo app and checking its console

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
