### PR TITLE
feat: add custom `nodeProtocol` and enable `https` for port `443`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,4 +55,4 @@ jobs:
         run: yarn build:dev
       - name: Run End to End Tests
         if: steps.build.outputs.exit_code == 0
-        run: yarn test:local --filter=testUseEoaSessionSigsToExecuteJsSigning,testUseEoaSessionSigsToPkpSign,testUsePkpSessionSigsToExecuteJsSigning,testUsePkpSessionSigsToPkpSign,testUseValidLitActionCodeGeneratedSessionSigsToPkpSign,testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsSigning,testDelegatingCapacityCreditsNFTToAnotherWalletToExecuteJs,testEthAuthSigToEncryptDecryptString,testExecuteJsSignAndCombineEcdsa,testExecutJsDecryptAndCombine,testExecuteJsBroadcastAndCollect  --exclude=Parallel
+        run: yarn test:local

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
       NETWORK: datil-dev
       DEBUG: true
       MAX_ATTEMPTS: 3
+      CHUNK_SIZE: 9
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
@@ -55,4 +56,4 @@ jobs:
         run: yarn build:dev
       - name: Run End to End Tests
         if: steps.build.outputs.exit_code == 0
-        run: yarn test:local
+        run: yarn test:local --filter=testUseEoaSessionSigsToExecuteJsSigning,testUseEoaSessionSigsToPkpSign,testUsePkpSessionSigsToExecuteJsSigning,testUsePkpSessionSigsToPkpSign,testUseValidLitActionCodeGeneratedSessionSigsToPkpSign,testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsSigning,testDelegatingCapacityCreditsNFTToAnotherWalletToExecuteJs,testEthAuthSigToEncryptDecryptString,testExecuteJsSignAndCombineEcdsa,testExecutJsDecryptAndCombine,testExecuteJsBroadcastAndCollect --exclude=Parallel

--- a/packages/constants/src/lib/constants/constants.ts
+++ b/packages/constants/src/lib/constants/constants.ts
@@ -789,8 +789,8 @@ export const METAMASK_CHAIN_INFO_BY_NETWORK: Record<
   localhost: metamaskChainInfo.yellowstone,
 };
 
-const HTTP = 'http://';
-const HTTPS = 'https://';
+export const HTTP = 'http://';
+export const HTTPS = 'https://';
 
 /**
  * Mapping of network values to corresponding http protocol.
@@ -804,8 +804,9 @@ export const HTTP_BY_NETWORK: Record<
   habanero: HTTPS,
   'datil-dev': HTTPS,
   'datil-test': HTTPS,
-  custom: HTTP,
-  localhost: HTTP,
+  internalDev: HTTPS, 
+  custom: HTTP, // default, can be changed by config
+  localhost: HTTP, // default, can be changed by config
 };
 
 /**

--- a/packages/constants/src/lib/constants/constants.ts
+++ b/packages/constants/src/lib/constants/constants.ts
@@ -804,7 +804,7 @@ export const HTTP_BY_NETWORK: Record<
   habanero: HTTPS,
   'datil-dev': HTTPS,
   'datil-test': HTTPS,
-  internalDev: HTTPS, 
+  internalDev: HTTPS,
   custom: HTTP, // default, can be changed by config
   localhost: HTTP, // default, can be changed by config
 };

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -24,6 +24,8 @@ import {
   LitNetwork,
   StakingStates,
   version,
+  HTTP,
+  HTTPS,
 } from '@lit-protocol/constants';
 import { LitContracts } from '@lit-protocol/contracts-sdk';
 import {
@@ -100,7 +102,7 @@ export type LitNodeClientConfigWithDefaults = Required<
   > & {
     bootstrapUrls: string[];
   } & {
-    nodeProtocol?: `http://` | `https://` | null;
+    nodeProtocol?: typeof HTTP | typeof HTTPS | null;
   };
 
 // On epoch change, we wait this many seconds for the nodes to update to the new epoch before using the new epoch #

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -101,7 +101,7 @@ export type LitNodeClientConfigWithDefaults = Required<
     bootstrapUrls: string[];
   } & {
     nodeProtocol?: `http://` | `https://` | null;
-  }
+  };
 
 // On epoch change, we wait this many seconds for the nodes to update to the new epoch before using the new epoch #
 const EPOCH_PROPAGATION_DELAY = 30_000;

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -99,7 +99,9 @@ export type LitNodeClientConfigWithDefaults = Required<
     Pick<LitNodeClientConfig, 'storageProvider' | 'contractContext' | 'rpcUrl'>
   > & {
     bootstrapUrls: string[];
-  };
+  } & {
+    nodeProtocol?: `http://` | `https://` | null;
+  }
 
 // On epoch change, we wait this many seconds for the nodes to update to the new epoch before using the new epoch #
 const EPOCH_PROPAGATION_DELAY = 30_000;
@@ -131,6 +133,7 @@ export class LitCore {
     litNetwork: 'cayenne', // Default to cayenne network. will be replaced by custom config.
     minNodeCount: 2, // Default value, should be replaced
     bootstrapUrls: [], // Default value, should be replaced
+    nodeProtocol: null,
   };
   connectedNodes = new Set<string>();
   serverKeys: Record<string, JsonHandshakeResponse> = {};
@@ -234,7 +237,8 @@ export class LitCore {
       LitContracts.getValidators(
         this.config.litNetwork,
         this.config.contractContext,
-        this.config.rpcUrl
+        this.config.rpcUrl,
+        this.config.nodeProtocol
       ),
     ]);
 


### PR DESCRIPTION
# Description

- Introducing `nodeProtocol` to customise the HTTP protocol for node connections
- Added a check to determine if port is 443, if so use HTTPS
