### PR TITLE
add padding to LitPkpResource

### DIFF
--- a/packages/auth-helpers/src/lib/resources.ts
+++ b/packages/auth-helpers/src/lib/resources.ts
@@ -84,7 +84,16 @@ export class LitPKPResource extends LitResourceBase implements ILitResource {
    * PKP token ID.
    */
   constructor(resource: string) {
-    super(resource);
+    // the nodes expect a 32 byte token id in hex.
+    // in some cases, if the token id is smaller than 32 bytes,
+    // the nodes will throw an error.
+    // so we pad the token id with leading zeros to make it 32 bytes.
+    let fixedResource = resource;
+    const hexRegex = /[0-9A-Fa-f]{6}/g;
+    if (resource !== '*' && resource.length < 64 && hexRegex.test(resource)) {
+      fixedResource = resource.padStart(64, '0');
+    }
+    super(fixedResource);
   }
 
   isValidLitAbility(litAbility: LitAbility): boolean {

--- a/packages/auth-helpers/src/lib/resources.ts
+++ b/packages/auth-helpers/src/lib/resources.ts
@@ -88,10 +88,16 @@ export class LitPKPResource extends LitResourceBase implements ILitResource {
     // in some cases, if the token id is smaller than 32 bytes,
     // the nodes will throw an error.
     // so we pad the token id with leading zeros to make it 32 bytes.
-    let fixedResource = resource;
+    let fixedResource = resource.startsWith('0x')
+      ? resource.slice(2)
+      : resource;
     const hexRegex = /[0-9A-Fa-f]{6}/g;
-    if (resource !== '*' && resource.length < 64 && hexRegex.test(resource)) {
-      fixedResource = resource.padStart(64, '0');
+    if (
+      fixedResource !== '*' &&
+      fixedResource.length < 64 &&
+      hexRegex.test(fixedResource)
+    ) {
+      fixedResource = fixedResource.padStart(64, '0');
     }
     super(fixedResource);
   }

--- a/packages/auth-helpers/src/lib/resources.ts
+++ b/packages/auth-helpers/src/lib/resources.ts
@@ -6,6 +6,7 @@ import {
 } from '@lit-protocol/types';
 import { hashAccessControlConditions } from '@lit-protocol/access-control-conditions';
 import { uint8arrayToString } from '@lit-protocol/uint8arrays';
+import { formatPKPResource } from './utils';
 
 abstract class LitResourceBase {
   abstract resourcePrefix: LitResourcePrefix;
@@ -84,21 +85,7 @@ export class LitPKPResource extends LitResourceBase implements ILitResource {
    * PKP token ID.
    */
   constructor(resource: string) {
-    // the nodes expect a 32 byte token id in hex.
-    // in some cases, if the token id is smaller than 32 bytes,
-    // the nodes will throw an error.
-    // so we pad the token id with leading zeros to make it 32 bytes.
-    let fixedResource = resource.startsWith('0x')
-      ? resource.slice(2)
-      : resource;
-    const hexRegex = /[0-9A-Fa-f]{6}/g;
-    if (
-      fixedResource !== '*' &&
-      fixedResource.length < 64 &&
-      hexRegex.test(fixedResource)
-    ) {
-      fixedResource = fixedResource.padStart(64, '0');
-    }
+    const fixedResource = formatPKPResource(resource);
     super(fixedResource);
   }
 

--- a/packages/auth-helpers/src/lib/utils.spec.ts
+++ b/packages/auth-helpers/src/lib/utils.spec.ts
@@ -1,0 +1,73 @@
+import { formatPKPResource } from './utils';
+
+describe('formatPKPResource', () => {
+  it('should remove the 0x prefix', () => {
+    const resource = '0x123abc';
+    const result = formatPKPResource(resource);
+    expect(result).toBe(
+      '0000000000000000000000000000000000000000000000000000000000123abc'
+    );
+    expect(result.length).toBe(64);
+  });
+
+  it('should pad the resource to 64 hex characters when length is less', () => {
+    const resource = '123abc';
+    const result = formatPKPResource(resource);
+    expect(result).toBe(
+      '0000000000000000000000000000000000000000000000000000000000123abc'
+    );
+    expect(result.length).toBe(64);
+  });
+
+  it('should not alter a valid 64-character hex string', () => {
+    const resource =
+      '123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123a';
+    const result = formatPKPResource(resource);
+    expect(result).toBe(resource);
+    expect(result.length).toBe(64);
+  });
+
+  it('should return the same string if input is a wildcard "*"', () => {
+    const resource = '*';
+    const result = formatPKPResource(resource);
+    expect(result).toBe('*');
+    expect(result.length).toBe(1);
+  });
+
+  it('should return the original string for invalid hex characters', () => {
+    const resource = 'xyz123';
+    const result = formatPKPResource(resource);
+    expect(result).toBe('xyz123');
+    expect(result.length).toBe(6);
+  });
+
+  it('should not alter a string that is exactly 64 hex characters', () => {
+    const resource = 'a'.repeat(64);
+    const result = formatPKPResource(resource);
+    expect(result).toBe(resource);
+    expect(result.length).toBe(64);
+  });
+
+  it('should handle hex strings shorter than 64 characters correctly', () => {
+    const resource = '1';
+    const result = formatPKPResource(resource);
+    expect(result).toBe(
+      '0000000000000000000000000000000000000000000000000000000000000001'
+    );
+    expect(result.length).toBe(64);
+  });
+
+  it('should return a 64-character string when input contains non-hex characters but matches hex pattern partially', () => {
+    const resource = '123xyz';
+    const result = formatPKPResource(resource);
+    expect(result).toBe('123xyz');
+    expect(result.length).toBe(6);
+  });
+
+  it('should throw an error if the input exceeds 64 characters', () => {
+    const resource = '1'.repeat(70);
+    expect(() => formatPKPResource(resource)).toThrowError(
+      'Resource ID exceeds 64 characters (32 bytes) in length.'
+    );
+  });
+});

--- a/packages/auth-helpers/src/lib/utils.ts
+++ b/packages/auth-helpers/src/lib/utils.ts
@@ -1,0 +1,40 @@
+/**
+ * Formats the resource ID to a 32-byte hex string.
+ *
+ * - Takes out '0x' and makes the string 64 characters long.
+ * - Adds zeros to make short strings 64 characters.
+ * - Doesn't change valid 64-character hex strings.
+ * - Returns '*' as is.
+ * - Returns the original if it has bad hex characters.
+ * - Doesn't change 64-character strings.
+ * - Adds zeros to make short hex strings 64 characters.
+ * - Returns the original if it partly matches hex.
+ * - Throws an error if the string is too long.
+ *
+ * @param resource The identifier for the resource. This should be the PKP token ID.
+ * @returns A 32-byte hex string representing the resource ID.
+ * @throws Will throw an error if the input exceeds 64 characters.
+ */
+export function formatPKPResource(resource: string): string {
+  // Remove the '0x' prefix if present
+  let fixedResource = resource.startsWith('0x') ? resource.slice(2) : resource;
+
+  // Throw an error if the resource length exceeds 64 characters
+  if (fixedResource.length > 64) {
+    throw new Error('Resource ID exceeds 64 characters (32 bytes) in length.');
+  }
+
+  /**
+   * The pattern matches any sequence of 6 characters that are
+   * either digits (0-9) or letters A-F (both uppercase and lowercase).
+   */
+  const hexRegex = /^[0-9A-Fa-f]+$/;
+
+  // Ensure the resource is a valid hex string and not a wildcard '*'
+  if (fixedResource !== '*' && hexRegex.test(fixedResource)) {
+    // Pad the resource ID with leading zeros to make it 32 bytes (64 hex characters)
+    fixedResource = fixedResource.padStart(64, '0');
+  }
+
+  return fixedResource;
+}


### PR DESCRIPTION
This PR adds 
* auto-padding of leading 0's to the LitPKPResource id to make it a 32 byte hex string.
* remove 0x prefix if it's present.  a lot of users get burned by this.

This is the result of a user report.  The user sent this in a request, as their resource ability requests: 

```
"resourceAbilityRequests\":[{\"resource\":{\"resource\":\"694d50052e0ca3e79e432024bc43ad654acd8ba0919e6ac820b720962bb2e4\",\"resourcePrefix\":\"lit-pkp\"},\"ability\":\"pkp-signing\"}]
```

They got an error back:

```
validation error: Could not find requested resource PKPNFT(PKPNFTResource { token_id: "00694d50052e0ca3e79e432024bc43ad654acd8ba0919e6ac820b720962bb2e4" }) in the resourceAbilityRequests
```


The core problem seems to be, that in the nodes, we calculate the tokenId from the PKP Pubkey via a keccak256() hash.  keccak256() is a 32 byte hash, which is where the extra problematic "00" comes from.  In this case, the thing being hashed was the PKP pubkey `0x04ecddcf4b32be0a6387b107ad3d839ffbe4164fe7a3a9e055740fe4acbb7c639f6943793ba46d1630c3f42fab4ff21b077797e9106664e3a66c72aaea6b6751ad` and when you run `ethers.utils.keccak256()` with that pubkey string, it returns '0x00694d50052e0ca3e79e432024bc43ad654acd8ba0919e6ac820b720962bb2e4'.  



