### PR TITLE
feat: extract `formatPKPResource` and add unit tests

### DIFF
--- a/packages/auth-helpers/src/lib/resources.ts
+++ b/packages/auth-helpers/src/lib/resources.ts
@@ -6,6 +6,7 @@ import {
 } from '@lit-protocol/types';
 import { hashAccessControlConditions } from '@lit-protocol/access-control-conditions';
 import { uint8arrayToString } from '@lit-protocol/uint8arrays';
+import { formaPKPResource } from './utils';
 
 abstract class LitResourceBase {
   abstract resourcePrefix: LitResourcePrefix;
@@ -84,21 +85,7 @@ export class LitPKPResource extends LitResourceBase implements ILitResource {
    * PKP token ID.
    */
   constructor(resource: string) {
-    // the nodes expect a 32 byte token id in hex.
-    // in some cases, if the token id is smaller than 32 bytes,
-    // the nodes will throw an error.
-    // so we pad the token id with leading zeros to make it 32 bytes.
-    let fixedResource = resource.startsWith('0x')
-      ? resource.slice(2)
-      : resource;
-    const hexRegex = /[0-9A-Fa-f]{6}/g;
-    if (
-      fixedResource !== '*' &&
-      fixedResource.length < 64 &&
-      hexRegex.test(fixedResource)
-    ) {
-      fixedResource = fixedResource.padStart(64, '0');
-    }
+    const fixedResource = formaPKPResource(resource);
     super(fixedResource);
   }
 

--- a/packages/auth-helpers/src/lib/resources.ts
+++ b/packages/auth-helpers/src/lib/resources.ts
@@ -6,7 +6,7 @@ import {
 } from '@lit-protocol/types';
 import { hashAccessControlConditions } from '@lit-protocol/access-control-conditions';
 import { uint8arrayToString } from '@lit-protocol/uint8arrays';
-import { formaPKPResource } from './utils';
+import { formatPKPResource } from './utils';
 
 abstract class LitResourceBase {
   abstract resourcePrefix: LitResourcePrefix;
@@ -85,7 +85,7 @@ export class LitPKPResource extends LitResourceBase implements ILitResource {
    * PKP token ID.
    */
   constructor(resource: string) {
-    const fixedResource = formaPKPResource(resource);
+    const fixedResource = formatPKPResource(resource);
     super(fixedResource);
   }
 

--- a/packages/auth-helpers/src/lib/utils.spec.ts
+++ b/packages/auth-helpers/src/lib/utils.spec.ts
@@ -1,0 +1,73 @@
+import { formaPKPResource } from './utils'; // Adjust the import path as necessary
+
+describe('formaPKPResource', () => {
+  it('should remove the 0x prefix', () => {
+    const resource = '0x123abc';
+    const result = formaPKPResource(resource);
+    expect(result).toBe(
+      '0000000000000000000000000000000000000000000000000000000000123abc'
+    );
+    expect(result.length).toBe(64);
+  });
+
+  it('should pad the resource to 64 hex characters when length is less', () => {
+    const resource = '123abc';
+    const result = formaPKPResource(resource);
+    expect(result).toBe(
+      '0000000000000000000000000000000000000000000000000000000000123abc'
+    );
+    expect(result.length).toBe(64);
+  });
+
+  it('should not alter a valid 64-character hex string', () => {
+    const resource =
+      '123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123a';
+    const result = formaPKPResource(resource);
+    expect(result).toBe(resource);
+    expect(result.length).toBe(64);
+  });
+
+  it('should return the same string if input is a wildcard "*"', () => {
+    const resource = '*';
+    const result = formaPKPResource(resource);
+    expect(result).toBe('*');
+    expect(result.length).toBe(1);
+  });
+
+  it('should return the original string for invalid hex characters', () => {
+    const resource = 'xyz123';
+    const result = formaPKPResource(resource);
+    expect(result).toBe('xyz123');
+    expect(result.length).toBe(6);
+  });
+
+  it('should not alter a string that is exactly 64 hex characters', () => {
+    const resource = 'a'.repeat(64);
+    const result = formaPKPResource(resource);
+    expect(result).toBe(resource);
+    expect(result.length).toBe(64);
+  });
+
+  it('should handle hex strings shorter than 64 characters correctly', () => {
+    const resource = '1';
+    const result = formaPKPResource(resource);
+    expect(result).toBe(
+      '0000000000000000000000000000000000000000000000000000000000000001'
+    );
+    expect(result.length).toBe(64);
+  });
+
+  it('should return a 64-character string when input contains non-hex characters but matches hex pattern partially', () => {
+    const resource = '123xyz';
+    const result = formaPKPResource(resource);
+    expect(result).toBe('123xyz');
+    expect(result.length).toBe(6);
+  });
+
+  it('should throw an error if the input exceeds 64 characters', () => {
+    const resource = '1'.repeat(70);
+    expect(() => formaPKPResource(resource)).toThrowError(
+      'Resource ID exceeds 64 characters (32 bytes) in length.'
+    );
+  });
+});

--- a/packages/auth-helpers/src/lib/utils.spec.ts
+++ b/packages/auth-helpers/src/lib/utils.spec.ts
@@ -1,9 +1,9 @@
-import { formaPKPResource } from './utils';
+import { formatPKPResource } from './utils';
 
-describe('formaPKPResource', () => {
+describe('formatPKPResource', () => {
   it('should remove the 0x prefix', () => {
     const resource = '0x123abc';
-    const result = formaPKPResource(resource);
+    const result = formatPKPResource(resource);
     expect(result).toBe(
       '0000000000000000000000000000000000000000000000000000000000123abc'
     );
@@ -12,7 +12,7 @@ describe('formaPKPResource', () => {
 
   it('should pad the resource to 64 hex characters when length is less', () => {
     const resource = '123abc';
-    const result = formaPKPResource(resource);
+    const result = formatPKPResource(resource);
     expect(result).toBe(
       '0000000000000000000000000000000000000000000000000000000000123abc'
     );
@@ -22,35 +22,35 @@ describe('formaPKPResource', () => {
   it('should not alter a valid 64-character hex string', () => {
     const resource =
       '123abc123abc123abc123abc123abc123abc123abc123abc123abc123abc123a';
-    const result = formaPKPResource(resource);
+    const result = formatPKPResource(resource);
     expect(result).toBe(resource);
     expect(result.length).toBe(64);
   });
 
   it('should return the same string if input is a wildcard "*"', () => {
     const resource = '*';
-    const result = formaPKPResource(resource);
+    const result = formatPKPResource(resource);
     expect(result).toBe('*');
     expect(result.length).toBe(1);
   });
 
   it('should return the original string for invalid hex characters', () => {
     const resource = 'xyz123';
-    const result = formaPKPResource(resource);
+    const result = formatPKPResource(resource);
     expect(result).toBe('xyz123');
     expect(result.length).toBe(6);
   });
 
   it('should not alter a string that is exactly 64 hex characters', () => {
     const resource = 'a'.repeat(64);
-    const result = formaPKPResource(resource);
+    const result = formatPKPResource(resource);
     expect(result).toBe(resource);
     expect(result.length).toBe(64);
   });
 
   it('should handle hex strings shorter than 64 characters correctly', () => {
     const resource = '1';
-    const result = formaPKPResource(resource);
+    const result = formatPKPResource(resource);
     expect(result).toBe(
       '0000000000000000000000000000000000000000000000000000000000000001'
     );
@@ -59,14 +59,14 @@ describe('formaPKPResource', () => {
 
   it('should return a 64-character string when input contains non-hex characters but matches hex pattern partially', () => {
     const resource = '123xyz';
-    const result = formaPKPResource(resource);
+    const result = formatPKPResource(resource);
     expect(result).toBe('123xyz');
     expect(result.length).toBe(6);
   });
 
   it('should throw an error if the input exceeds 64 characters', () => {
     const resource = '1'.repeat(70);
-    expect(() => formaPKPResource(resource)).toThrowError(
+    expect(() => formatPKPResource(resource)).toThrowError(
       'Resource ID exceeds 64 characters (32 bytes) in length.'
     );
   });

--- a/packages/auth-helpers/src/lib/utils.spec.ts
+++ b/packages/auth-helpers/src/lib/utils.spec.ts
@@ -1,4 +1,4 @@
-import { formaPKPResource } from './utils'; // Adjust the import path as necessary
+import { formaPKPResource } from './utils';
 
 describe('formaPKPResource', () => {
   it('should remove the 0x prefix', () => {

--- a/packages/auth-helpers/src/lib/utils.ts
+++ b/packages/auth-helpers/src/lib/utils.ts
@@ -10,7 +10,7 @@
  * - Adds zeros to make short hex strings 64 characters.
  * - Returns the original if it partly matches hex.
  * - Throws an error if the string is too long.
- * 
+ *
  * @param resource The identifier for the resource. This should be the PKP token ID.
  * @returns A 32-byte hex string representing the resource ID.
  * @throws Will throw an error if the input exceeds 64 characters.
@@ -24,10 +24,10 @@ export function formaPKPResource(resource: string): string {
     throw new Error('Resource ID exceeds 64 characters (32 bytes) in length.');
   }
 
-/**
- * The pattern matches any sequence of 6 characters that are
- * either digits (0-9) or letters A-F (both uppercase and lowercase).
- */
+  /**
+   * The pattern matches any sequence of 6 characters that are
+   * either digits (0-9) or letters A-F (both uppercase and lowercase).
+   */
   const hexRegex = /^[0-9A-Fa-f]+$/;
 
   // Ensure the resource is a valid hex string and not a wildcard '*'

--- a/packages/auth-helpers/src/lib/utils.ts
+++ b/packages/auth-helpers/src/lib/utils.ts
@@ -13,7 +13,10 @@ export function formaPKPResource(resource: string): string {
     throw new Error('Resource ID exceeds 64 characters (32 bytes) in length.');
   }
 
-  // Regex to validate hex strings
+/**
+ * The pattern matches any sequence of 6 characters that are
+ * either digits (0-9) or letters A-F (both uppercase and lowercase).
+ */
   const hexRegex = /^[0-9A-Fa-f]+$/;
 
   // Ensure the resource is a valid hex string and not a wildcard '*'

--- a/packages/auth-helpers/src/lib/utils.ts
+++ b/packages/auth-helpers/src/lib/utils.ts
@@ -1,5 +1,16 @@
 /**
  * Formats the resource ID to a 32-byte hex string.
+ *
+ * - Takes out '0x' and makes the string 64 characters long.
+ * - Adds zeros to make short strings 64 characters.
+ * - Doesn't change valid 64-character hex strings.
+ * - Returns '*' as is.
+ * - Returns the original if it has bad hex characters.
+ * - Doesn't change 64-character strings.
+ * - Adds zeros to make short hex strings 64 characters.
+ * - Returns the original if it partly matches hex.
+ * - Throws an error if the string is too long.
+ * 
  * @param resource The identifier for the resource. This should be the PKP token ID.
  * @returns A 32-byte hex string representing the resource ID.
  * @throws Will throw an error if the input exceeds 64 characters.

--- a/packages/auth-helpers/src/lib/utils.ts
+++ b/packages/auth-helpers/src/lib/utils.ts
@@ -1,0 +1,26 @@
+/**
+ * Formats the resource ID to a 32-byte hex string.
+ * @param resource The identifier for the resource. This should be the PKP token ID.
+ * @returns A 32-byte hex string representing the resource ID.
+ * @throws Will throw an error if the input exceeds 64 characters.
+ */
+export function formaPKPResource(resource: string): string {
+  // Remove the '0x' prefix if present
+  let fixedResource = resource.startsWith('0x') ? resource.slice(2) : resource;
+
+  // Throw an error if the resource length exceeds 64 characters
+  if (fixedResource.length > 64) {
+    throw new Error('Resource ID exceeds 64 characters (32 bytes) in length.');
+  }
+
+  // Define a regex to validate hex strings
+  const hexRegex = /^[0-9A-Fa-f]+$/;
+
+  // Ensure the resource is a valid hex string and not a wildcard '*'
+  if (fixedResource !== '*' && hexRegex.test(fixedResource)) {
+    // Pad the resource ID with leading zeros to make it 32 bytes (64 hex characters)
+    fixedResource = fixedResource.padStart(64, '0');
+  }
+
+  return fixedResource;
+}

--- a/packages/auth-helpers/src/lib/utils.ts
+++ b/packages/auth-helpers/src/lib/utils.ts
@@ -15,7 +15,7 @@
  * @returns A 32-byte hex string representing the resource ID.
  * @throws Will throw an error if the input exceeds 64 characters.
  */
-export function formaPKPResource(resource: string): string {
+export function formatPKPResource(resource: string): string {
   // Remove the '0x' prefix if present
   let fixedResource = resource.startsWith('0x') ? resource.slice(2) : resource;
 

--- a/packages/auth-helpers/src/lib/utils.ts
+++ b/packages/auth-helpers/src/lib/utils.ts
@@ -13,7 +13,7 @@ export function formaPKPResource(resource: string): string {
     throw new Error('Resource ID exceeds 64 characters (32 bytes) in length.');
   }
 
-  // Define a regex to validate hex strings
+  // Regex to validate hex strings
   const hexRegex = /^[0-9A-Fa-f]+$/;
 
   // Ensure the resource is a valid hex string and not a wildcard '*'


### PR DESCRIPTION
# Description

Extract the function out and add unit tests for this https://github.com/LIT-Protocol/js-sdk/pull/562

---
1. Takes out '0x' and makes the string 64 characters long.
2. Adds zeros to make short strings 64 characters.
3. Don't change valid 64-character hex strings.
4. Returns '*' as is.
5. Returns the original if it has bad hex characters.
6. Doesn't change 64-character strings.
7. Adds zeros to make short hex strings 64 characters.
8. Returns the original if it partly matches hex.
9. Throws an error if the string is too long.