### PR TITLE
Feat/faucet mapper to constants pkg

### DIFF
--- a/packages/constants/src/lib/constants/constants.ts
+++ b/packages/constants/src/lib/constants/constants.ts
@@ -697,7 +697,7 @@ export const LIT_NETWORK = {
   DatilTest: 'datil-test',
   Custom: 'custom',
   Localhost: 'localhost',
-};
+} as const;
 
 /**
  * The type representing the keys of the LIT_NETWORK object.

--- a/packages/constants/src/lib/constants/constants.ts
+++ b/packages/constants/src/lib/constants/constants.ts
@@ -770,7 +770,6 @@ export const HTTP_BY_NETWORK: Record<
   habanero: HTTPS,
   'datil-dev': HTTPS,
   'datil-test': HTTPS,
-  internalDev: HTTPS,
   custom: HTTP, // default, can be changed by config
   localhost: HTTP, // default, can be changed by config
 };

--- a/packages/constants/src/lib/constants/mappers.ts
+++ b/packages/constants/src/lib/constants/mappers.ts
@@ -40,3 +40,20 @@ export const GENERAL_WORKER_URL_BY_NETWORK: {
   custom: 'https://apis.getlit.dev/cayenne/contracts',
   localhost: 'https://apis.getlit.dev/cayenne/contracts',
 };
+
+const CHRONICLE_FAUCET_URL = 'https://chronicle-faucet-app.vercel.app';
+const YELLOWSTONE_FAUCET_URL =
+  'https://chronicle-yellowstone-faucet.getlit.dev';
+
+/**
+ * URL mapping for faucet endpoints based on network.
+ */
+export const FAUCET_URL_BY_NETWORK: {
+  [key in Exclude<LIT_NETWORK_VALUES, 'custom' | 'localhost'>]: string;
+} = {
+  cayenne: CHRONICLE_FAUCET_URL,
+  manzano: CHRONICLE_FAUCET_URL,
+  habanero: CHRONICLE_FAUCET_URL,
+  'datil-dev': YELLOWSTONE_FAUCET_URL,
+  'datil-test': YELLOWSTONE_FAUCET_URL,
+};

--- a/packages/misc/src/lib/misc.ts
+++ b/packages/misc/src/lib/misc.ts
@@ -677,14 +677,15 @@ export const defaultMintClaimCallback: MintCallback<
   RelayClaimProcessor
 > = async (
   params: ClaimResult<RelayClaimProcessor>,
-  network: LIT_NETWORK_VALUES = 'cayenne'
+  network: string
 ): Promise<string> => {
-  isSupportedLitNetwork(network);
+  isSupportedLitNetwork(network as LIT_NETWORK_VALUES);
 
   try {
     const AUTH_CLAIM_PATH = '/auth/claim';
 
-    const relayUrl: string = params.relayUrl || RELAYER_URL_BY_NETWORK[network];
+    const relayUrl: string =
+      params.relayUrl || RELAYER_URL_BY_NETWORK[network as LIT_NETWORK_VALUES];
 
     if (!relayUrl) {
       throw new Error(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,24 +10,15 @@
     "importHelpers": true,
     "target": "ES2020",
     "module": "ES2020",
-    "lib": [
-      "ES2020",
-      "dom",
-      "ES2021.String"
-    ],
+    "lib": ["ES2020", "dom", "ES2021.String"],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "paths": {
-      "@lit-protocol/*": [
-        "packages/*/src"
-      ]
+      "@lit-protocol/*": ["packages/*/src"]
     }
   },
-  "exclude": [
-    "node_modules",
-    "tmp"
-  ]
+  "exclude": ["node_modules", "tmp"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,15 +10,24 @@
     "importHelpers": true,
     "target": "ES2020",
     "module": "ES2020",
-    "lib": ["ES2020", "dom", "ES2021.String"],
+    "lib": [
+      "ES2020",
+      "dom",
+      "ES2021.String"
+    ],
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "paths": {
-      "@lit-protocol/*": ["packages/*/src"]
+      "@lit-protocol/*": [
+        "packages/*/src"
+      ]
     }
   },
-  "exclude": ["node_modules", "tmp"]
+  "exclude": [
+    "node_modules",
+    "tmp"
+  ]
 }


### PR DESCRIPTION
# Description

- feat(constants.ts): The `const LIT_NETWORK` is now asserted `as const` to ensure immutability and narrower/precise typing, which allows TypeScript to enforce more specific types for the values and ensures that these constants are used safely throughout the monorepo.
- remove(constants.ts): Removed the`internalDev` key from the `HTTP_BY_NETWORK` object. This key was not part of the defined `LIT_NETWORK_VALUES`.
- feat(constants.ts): New Faucet URL Mapping:
	•	Added new constants for `CHRONICLE_FAUCET_URL` and `YELLOWSTONE_FAUCET_URL`.
	•	Introduced `FAUCET_URL_BY_NETWORK` to `mapper.ts` to map networks to their respective faucet URLs, excluding the `custom` and `localhost` networks. 
- fix(misc.ts): Updated the `defaultMintClaimCallback` function to use `string` for the network param and cast it to `LIT_NETWORK_VALUES`, and use the function `isSupportedNetwork` instead. That's because the interface `MintCallback` type is in the `types` package, if we import the `constants` to `types` it will cause circular dependency issue.