### PR TITLE
feat: replace hardcoded gas limit with calculated one including margin

### DIFF
--- a/packages/contracts-sdk/src/lib/contracts-sdk.ts
+++ b/packages/contracts-sdk/src/lib/contracts-sdk.ts
@@ -105,7 +105,9 @@ declare global {
 
 // Due to the usage of arbitrum stylus contracts the gas limit is increased by 10% to avoid reverts due to out of gas errors
 const GAS_LIMIT_INCREASE_PERCENTAGE = 10;
-const GAS_LIMIT_ADJUSTMENT = ethers.BigNumber.from(100).add(GAS_LIMIT_INCREASE_PERCENTAGE);
+const GAS_LIMIT_ADJUSTMENT = ethers.BigNumber.from(100).add(
+  GAS_LIMIT_INCREASE_PERCENTAGE
+);
 
 // This code defines a LitContracts class that acts as a container for a collection of smart contracts. The class has a constructor that accepts an optional args object with provider and rpc properties. If no provider is specified, the class will create a default provider using the specified rpc URL. If no rpc URL is specified, the class will use a default URL.
 // The class has a number of properties that represent the smart contract instances, such as accessControlConditionsContract, litTokenContract, pkpNftContract, etc. These smart contract instances are created by passing the contract address, ABI, and provider to the ethers.Contract constructor.

--- a/packages/contracts-sdk/src/lib/contracts-sdk.ts
+++ b/packages/contracts-sdk/src/lib/contracts-sdk.ts
@@ -1653,23 +1653,24 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
           }
         );
 
-        if (!param?.gasLimit) {
+        let _gasLimit: BigNumberish | undefined = param?.gasLimit;
+        if (!_gasLimit) {
           const gasEstimation = await this.pkpNftContract.write.provider.estimateGas(tx);
           const adjustedGasLimit = gasEstimation
             .mul(100 + GAS_LIMIT_INCREASE_PERCENTAGE)
             .div(100);
-          tx.gasLimit = adjustedGasLimit;
+          _gasLimit = adjustedGasLimit;
         }
 
         this.log('tx:', tx);
 
-        this.log('...signing tx');
-        const signedTx = await this.signer.signTransaction(tx);
-        this.log('signedTx:', signedTx);
-
-        this.log('sending signed tx...');
-        const sentTx = await this.signer.sendTransaction(
-          signedTx as ethers.providers.TransactionRequest
+        this.log('...signing and sending tx');
+        const sentTx = await this.pkpNftContract.write.mintNext(
+          2,
+          {
+            value: mintCost,
+            gasLimit: _gasLimit,
+          }
         );
 
         this.log('sentTx:', sentTx);

--- a/packages/contracts-sdk/src/lib/contracts-sdk.ts
+++ b/packages/contracts-sdk/src/lib/contracts-sdk.ts
@@ -1079,15 +1079,20 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
     const mintCost = await this.pkpNftContract.read.mintCost();
 
     // -- start minting
-    const tx = await this.callWithGasMargin(this.pkpHelperContract.write, 'mintNextAndAddAuthMethods', [
-      2, // key type
-      [authMethod.authMethodType],
-      [_authMethodId],
-      [_pubkey],
-      [[..._scopes]],
-      true,
-      true,
-    ], { value: mintCost, gasLimit });
+    const tx = await this.callWithGasMargin(
+      this.pkpHelperContract.write,
+      'mintNextAndAddAuthMethods',
+      [
+        2, // key type
+        [authMethod.authMethodType],
+        [_authMethodId],
+        [_pubkey],
+        [[..._scopes]],
+        true,
+        true,
+      ],
+      { value: mintCost, gasLimit }
+    );
     const receipt = await tx.wait();
 
     const events = 'events' in receipt ? receipt.events : receipt.logs;
@@ -1199,11 +1204,19 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
     const _webAuthnPubkey = webAuthnPubkey ?? '0x';
 
     try {
-      const res = await this.callWithGasMargin(this.pkpPermissionsContract.write, 'addPermittedAuthMethod', [pkpTokenId, {
-        authMethodType: authMethodType,
-        id: _authMethodId,
-        userPubkey: _webAuthnPubkey,
-      }, authMethodScopes]);
+      const res = await this.callWithGasMargin(
+        this.pkpPermissionsContract.write,
+        'addPermittedAuthMethod',
+        [
+          pkpTokenId,
+          {
+            authMethodType: authMethodType,
+            id: _authMethodId,
+            userPubkey: _webAuthnPubkey,
+          },
+          authMethodScopes,
+        ]
+      );
 
       const receipt = await res.wait();
 
@@ -1235,7 +1248,11 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
     const scopes = authMethodScopes ?? [];
 
     try {
-      const res = await this.callWithGasMargin(this.pkpPermissionsContract.write, 'addPermittedAction', [pkpTokenId, ipfsIdBytes, scopes]);
+      const res = await this.callWithGasMargin(
+        this.pkpPermissionsContract.write,
+        'addPermittedAction',
+        [pkpTokenId, ipfsIdBytes, scopes]
+      );
 
       const receipt = await res.wait();
 
@@ -1341,7 +1358,12 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
     this.log('Expiration Date (UTC):', expirationDate.toUTCString());
 
     try {
-      const res = await this.callWithGasMargin(this.rateLimitNftContract.write, 'mint', [expiresAt], { value: mintCost, gasLimit });
+      const res = await this.callWithGasMargin(
+        this.rateLimitNftContract.write,
+        'mint',
+        [expiresAt],
+        { value: mintCost, gasLimit }
+      );
 
       const txHash = res.hash;
 
@@ -1602,7 +1624,12 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
         }
 
         this.log('...signing and sending tx');
-        const sentTx = await this.callWithGasMargin(this.pkpNftContract.write, 'mintNext', [2], { value: mintCost, ...param });
+        const sentTx = await this.callWithGasMargin(
+          this.pkpNftContract.write,
+          'mintNext',
+          [2],
+          { value: mintCost, ...param }
+        );
 
         this.log('sentTx:', sentTx);
 
@@ -1661,7 +1688,12 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
             const cost = await this.pkpNftContract.read.mintCost();
             txOpts.value = cost;
           }
-          const tx = await this.callWithGasMargin(this.pkpNftContract.write, 'claimAndMint', [2, derivedKeyId, signatures], txOpts);
+          const tx = await this.callWithGasMargin(
+            this.pkpNftContract.write,
+            'claimAndMint',
+            [2, derivedKeyId, signatures],
+            txOpts
+          );
 
           const txRec = await tx.wait();
 
@@ -1890,7 +1922,11 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
         const ipfsIdBytes = this.utils.getBytesFromMultihash(ipfsId);
         this.log('[addPermittedAction] converted<ipfsIdBytes>:', ipfsIdBytes);
 
-        const tx = await this.callWithGasMargin(this.pkpPermissionsContract.write, 'addPermittedAction', [tokenId, ipfsIdBytes, [1]]);
+        const tx = await this.callWithGasMargin(
+          this.pkpPermissionsContract.write,
+          'addPermittedAction',
+          [tokenId, ipfsIdBytes, [1]]
+        );
 
         this.log('[addPermittedAction] output<tx>:', tx);
 
@@ -1925,7 +1961,11 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
 
         this.log('[addPermittedAddress] input<pkpId>:', pkpId);
 
-        const tx = await this.callWithGasMargin(this.pkpPermissionsContract.write, 'addPermittedAddress', [pkpId, ownerAddress, [1]]);
+        const tx = await this.callWithGasMargin(
+          this.pkpPermissionsContract.write,
+          'addPermittedAddress',
+          [pkpId, ownerAddress, [1]]
+        );
 
         this.log('[addPermittedAddress] output<tx>:', tx);
 
@@ -1960,7 +2000,11 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
         const ipfsHash = this.utils.getBytesFromMultihash(ipfsId);
         this.log('[revokePermittedAction] converted<ipfsHash>:', ipfsHash);
 
-        const tx = await this.callWithGasMargin(this.pkpPermissionsContract.write, 'removePermittedAction', [pkpId, ipfsHash]);
+        const tx = await this.callWithGasMargin(
+          this.pkpPermissionsContract.write,
+          'removePermittedAction',
+          [pkpId, ipfsHash]
+        );
 
         this.log('[revokePermittedAction] output<tx>:', tx);
 
@@ -2188,7 +2232,8 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
           throw new Error('Contract is not available');
         }
 
-        const bigTotal: ethers.BigNumber = await this.rateLimitNftContract.read.totalSupply();
+        const bigTotal: ethers.BigNumber =
+          await this.rateLimitNftContract.read.totalSupply();
         const total = parseInt(bigTotal.toString());
 
         const tokens = await asyncForEachReturn(
@@ -2249,7 +2294,12 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
           throw new Error('Contract is not available');
         }
 
-        const tx = await this.callWithGasMargin(this.rateLimitNftContract.write, 'mint', [timestamp], txOpts);
+        const tx = await this.callWithGasMargin(
+          this.rateLimitNftContract.write,
+          'mint',
+          [timestamp],
+          txOpts
+        );
 
         const res = await tx.wait();
 
@@ -2285,11 +2335,11 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
           throw new Error('Contract is not available');
         }
 
-        const tx = await this.callWithGasMargin(this.rateLimitNftContract.write, 'transferFrom', [
-          fromAddress,
-          toAddress,
-          RLITokenAddress,
-        ]);
+        const tx = await this.callWithGasMargin(
+          this.rateLimitNftContract.write,
+          'transferFrom',
+          [fromAddress, toAddress, RLITokenAddress]
+        );
 
         this.log('tx:', tx);
 
@@ -2349,16 +2399,19 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
         // first get mint cost
         const mintCost = await this.pkpNftContract.read.mintCost();
 
-        const tx = await this.callWithGasMargin(this.pkpHelperContract.write, 'mintNextAndAddAuthMethods', [
-          keyType,
-          permittedAuthMethodTypes,
-          permittedAuthMethodIds as BytesLike[],
-          permittedAuthMethodPubkeys as BytesLike[],
-          permittedAuthMethodScopes,
-          addPkpEthAddressAsPermittedAddress,
-          sendPkpToItself,
-        ],
-        { value: mintCost, gasLimit },
+        const tx = await this.callWithGasMargin(
+          this.pkpHelperContract.write,
+          'mintNextAndAddAuthMethods',
+          [
+            keyType,
+            permittedAuthMethodTypes,
+            permittedAuthMethodIds as BytesLike[],
+            permittedAuthMethodPubkeys as BytesLike[],
+            permittedAuthMethodScopes,
+            addPkpEthAddressAsPermittedAddress,
+            sendPkpToItself,
+          ],
+          { value: mintCost, gasLimit }
         );
         return tx;
       },
@@ -2398,7 +2451,10 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
     percentageIncrease: number = GAS_LIMIT_INCREASE_PERCENTAGE
   ) => {
     if (!overrides.gasLimit) {
-      const txData = await contract.populateTransaction[method](...args, overrides);
+      const txData = await contract.populateTransaction[method](
+        ...args,
+        overrides
+      );
       const gasEstimation = await contract.provider.estimateGas(txData);
       const adjustedGasLimit = gasEstimation
         .mul(100 + percentageIncrease)

--- a/packages/contracts-sdk/src/lib/contracts-sdk.ts
+++ b/packages/contracts-sdk/src/lib/contracts-sdk.ts
@@ -1685,20 +1685,18 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
       claimAndMint: async (
         derivedKeyId: BytesLike,
         signatures: IPubkeyRouter.SignatureStruct[],
-        txOpts: ethers.PayableOverrides & { from?: string }
+        txOpts: ethers.CallOverrides = {}
       ) => {
         try {
-          const overrides = txOpts ?? {};
-
-          if (!overrides.value) {
-            const cost = await this.pkpNftContract.read.mintCost();
-            overrides.value = cost;
-          }
           const tx = await this._callWithAdjustedOverrides(
             this.pkpNftContract.write,
             'claimAndMint',
             [2, derivedKeyId, signatures],
-            overrides
+            {
+              ...txOpts,
+              value:
+                txOpts.value ?? (await this.pkpNftContract.read.mintCost()),
+            }
           );
 
           const txRec = await tx.wait();
@@ -2284,10 +2282,7 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
         txOpts,
         timestamp,
       }: {
-        txOpts: {
-          value: BigNumberish | Promise<BigNumberish>;
-          gasLimit: BigNumberish | Promise<BigNumberish> | undefined;
-        };
+        txOpts: ethers.CallOverrides;
         timestamp: number;
       }) => {
         if (!this.connected) {
@@ -2456,7 +2451,7 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
     contract: T,
     method: K,
     args: Parameters<T['functions'][K]>,
-    overrides: ethers.PayableOverrides & { from?: string } = {},
+    overrides: ethers.CallOverrides = {},
     gasLimitAdjustment: ethers.BigNumber = GAS_LIMIT_ADJUSTMENT
   ): Promise<ethers.BigNumber> => {
     const gasLimit = await contract.estimateGas[method as string](
@@ -2473,7 +2468,7 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
     contract: T,
     method: K,
     args: Parameters<T['functions'][K]>,
-    overrides: ethers.PayableOverrides & { from?: string } = {},
+    overrides: ethers.CallOverrides = {},
     gasLimitAdjustment: ethers.BigNumber = GAS_LIMIT_ADJUSTMENT
   ): Promise<ReturnType<T['functions'][K]>> {
     // Check if the method exists on the contract

--- a/packages/contracts-sdk/src/lib/contracts-sdk.ts
+++ b/packages/contracts-sdk/src/lib/contracts-sdk.ts
@@ -1080,19 +1080,22 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
 
     let _gasLimit: BigNumberish | undefined = gasLimit;
     if (!_gasLimit) {
-      const txData = await this.pkpHelperContract.write.populateTransaction.mintNextAndAddAuthMethods(
-        2, // key type
-        [authMethod.authMethodType],
-        [_authMethodId],
-        [_pubkey],
-        [[..._scopes]],
-        true,
-        true,
-        { value: mintCost }
-      );
+      const txData =
+        await this.pkpHelperContract.write.populateTransaction.mintNextAndAddAuthMethods(
+          2, // key type
+          [authMethod.authMethodType],
+          [_authMethodId],
+          [_pubkey],
+          [[..._scopes]],
+          true,
+          true,
+          { value: mintCost }
+        );
 
-      const gasEstimation = await this.signer.estimateGas(txData);
-      const adjustedGasLimit = gasEstimation.mul(100 + GAS_LIMIT_INCREASE_PERCENTAGE).div(100);
+      const gasEstimation = await this.pkpNftContract.write.provider.estimateGas(txData);
+      const adjustedGasLimit = gasEstimation
+        .mul(100 + GAS_LIMIT_INCREASE_PERCENTAGE)
+        .div(100);
 
       _gasLimit = adjustedGasLimit;
     }
@@ -1643,15 +1646,18 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
         }
 
         this.log('...populating tx');
-        const tx =
-          await this.pkpNftContract.write.populateTransaction.mintNext(2, {
+        const tx = await this.pkpNftContract.write.populateTransaction.mintNext(
+          2,
+          {
             value: mintCost,
-            gasLimit: param?.gasLimit,
-          });
+          }
+        );
 
         if (!param?.gasLimit) {
-          const gasEstimation = await this.signer.estimateGas(tx);
-          const adjustedGasLimit = gasEstimation.mul(100 + GAS_LIMIT_INCREASE_PERCENTAGE).div(100);
+          const gasEstimation = await this.pkpNftContract.write.provider.estimateGas(tx);
+          const adjustedGasLimit = gasEstimation
+            .mul(100 + GAS_LIMIT_INCREASE_PERCENTAGE)
+            .div(100);
           tx.gasLimit = adjustedGasLimit;
         }
 
@@ -2417,18 +2423,21 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
 
         let _gasLimit: BigNumberish | undefined = gasLimit;
         if (!_gasLimit) {
-          const txData = await this.pkpHelperContract.write.populateTransaction.mintNextAndAddAuthMethods(
-            keyType,
-            permittedAuthMethodTypes,
-            permittedAuthMethodIds as BytesLike[],
-            permittedAuthMethodPubkeys as BytesLike[],
-            permittedAuthMethodScopes,
-            addPkpEthAddressAsPermittedAddress,
-            sendPkpToItself,
-            { value: mintCost }
-          );
-          const gasEstimation = await this.signer.estimateGas(txData);
-          const adjustedGasLimit = gasEstimation.mul(100 + GAS_LIMIT_INCREASE_PERCENTAGE).div(100);
+          const txData =
+            await this.pkpHelperContract.write.populateTransaction.mintNextAndAddAuthMethods(
+              keyType,
+              permittedAuthMethodTypes,
+              permittedAuthMethodIds as BytesLike[],
+              permittedAuthMethodPubkeys as BytesLike[],
+              permittedAuthMethodScopes,
+              addPkpEthAddressAsPermittedAddress,
+              sendPkpToItself,
+              { value: mintCost }
+            );
+          const gasEstimation = await this.pkpNftContract.write.provider.estimateGas(txData);
+          const adjustedGasLimit = gasEstimation
+            .mul(100 + GAS_LIMIT_INCREASE_PERCENTAGE)
+            .div(100);
           _gasLimit = adjustedGasLimit;
         }
 

--- a/packages/contracts-sdk/src/lib/contracts-sdk.ts
+++ b/packages/contracts-sdk/src/lib/contracts-sdk.ts
@@ -1091,7 +1091,7 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
           true,
           { value: mintCost }
         );
-      _gasLimit = await this.estimateGasWithMargin(txData);
+      _gasLimit = await this._estimateGasWithMargin(txData);
     }
 
     // -- start minting
@@ -1647,7 +1647,7 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
             await this.pkpNftContract.write.populateTransaction.mintNext(2, {
               value: mintCost,
             });
-          _gasLimit = await this.estimateGasWithMargin(tx);
+          _gasLimit = await this._estimateGasWithMargin(tx);
         }
 
         this.log('...signing and sending tx');
@@ -2418,7 +2418,7 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
               sendPkpToItself,
               { value: mintCost }
             );
-          _gasLimit = await this.estimateGasWithMargin(txData);
+          _gasLimit = await this._estimateGasWithMargin(txData);
         }
 
         const tx = await this.pkpHelperContract.write.mintNextAndAddAuthMethods(
@@ -2464,7 +2464,7 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
     },
   };
 
-  private estimateGasWithMargin = async (
+  private _estimateGasWithMargin = async (
     txData: ethers.PopulatedTransaction,
     porcentualIncrease: number = GAS_LIMIT_INCREASE_PERCENTAGE
   ) => {

--- a/packages/contracts-sdk/src/lib/contracts-sdk.ts
+++ b/packages/contracts-sdk/src/lib/contracts-sdk.ts
@@ -1092,7 +1092,8 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
           { value: mintCost }
         );
 
-      const gasEstimation = await this.pkpNftContract.write.provider.estimateGas(txData);
+      const gasEstimation =
+        await this.pkpNftContract.write.provider.estimateGas(txData);
       const adjustedGasLimit = gasEstimation
         .mul(100 + GAS_LIMIT_INCREASE_PERCENTAGE)
         .div(100);
@@ -1655,7 +1656,8 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
 
         let _gasLimit: BigNumberish | undefined = param?.gasLimit;
         if (!_gasLimit) {
-          const gasEstimation = await this.pkpNftContract.write.provider.estimateGas(tx);
+          const gasEstimation =
+            await this.pkpNftContract.write.provider.estimateGas(tx);
           const adjustedGasLimit = gasEstimation
             .mul(100 + GAS_LIMIT_INCREASE_PERCENTAGE)
             .div(100);
@@ -1665,13 +1667,10 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
         this.log('tx:', tx);
 
         this.log('...signing and sending tx');
-        const sentTx = await this.pkpNftContract.write.mintNext(
-          2,
-          {
-            value: mintCost,
-            gasLimit: _gasLimit,
-          }
-        );
+        const sentTx = await this.pkpNftContract.write.mintNext(2, {
+          value: mintCost,
+          gasLimit: _gasLimit,
+        });
 
         this.log('sentTx:', sentTx);
 
@@ -2435,7 +2434,8 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
               sendPkpToItself,
               { value: mintCost }
             );
-          const gasEstimation = await this.pkpNftContract.write.provider.estimateGas(txData);
+          const gasEstimation =
+            await this.pkpNftContract.write.provider.estimateGas(txData);
           const adjustedGasLimit = gasEstimation
             .mul(100 + GAS_LIMIT_INCREASE_PERCENTAGE)
             .div(100);

--- a/packages/contracts-sdk/src/lib/contracts-sdk.ts
+++ b/packages/contracts-sdk/src/lib/contracts-sdk.ts
@@ -103,7 +103,9 @@ declare global {
   }
 }
 
+// Due to the usage of arbitrum stylus contracts the gas limit is increased by 10% to avoid reverts due to out of gas errors
 const GAS_LIMIT_INCREASE_PERCENTAGE = 10;
+const GAS_LIMIT_ADJUSTMENT = ethers.BigNumber.from(100).add(GAS_LIMIT_INCREASE_PERCENTAGE);
 
 // This code defines a LitContracts class that acts as a container for a collection of smart contracts. The class has a constructor that accepts an optional args object with provider and rpc properties. If no provider is specified, the class will create a default provider using the specified rpc URL. If no rpc URL is specified, the class will use a default URL.
 // The class has a number of properties that represent the smart contract instances, such as accessControlConditionsContract, litTokenContract, pkpNftContract, etc. These smart contract instances are created by passing the contract address, ABI, and provider to the ethers.Contract constructor.
@@ -2450,7 +2452,7 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
     method: string,
     args: unknown[],
     overrides: ethers.PayableOverrides & { from?: string } = {},
-    percentageIncrease: number = GAS_LIMIT_INCREASE_PERCENTAGE
+    gasLimitAdjustment: ethers.BigNumber = GAS_LIMIT_ADJUSTMENT
   ) => {
     const _overrides = overrides;
 
@@ -2460,7 +2462,7 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
         _overrides
       );
       const gasEstimation = await contract.provider.estimateGas(txData);
-      const adjustedGasLimit = gasEstimation.mul(percentageIncrease);
+      const adjustedGasLimit = gasEstimation.mul(gasLimitAdjustment);
       _overrides.gasLimit = adjustedGasLimit;
     }
 


### PR DESCRIPTION
# Description

This PR removes the hardcoded `GAS_LIMIT` constant in contracts sdk used by default when user did not provide one and replaced it with one that increases the limit by certain margin when it is a minting transaction

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Used Ansh demo app that to mint a PKP with contracts-sdk directly (not using relay)
![Screenshot from 2024-07-29 21-09-01](https://github.com/user-attachments/assets/87492c19-6b6a-470e-8bec-dc0fd608c4ce)
 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
