### PR TITLE
fix: updated sepolia rpc

### DIFF
--- a/packages/constants/src/lib/constants/constants.ts
+++ b/packages/constants/src/lib/constants/constants.ts
@@ -378,7 +378,7 @@ export const LIT_CHAINS: LITChain<LITEVMChain> = {
     name: 'Sepolia Testnet',
     symbol: 'ETH',
     decimals: 18,
-    rpcUrls: ['https://eth-sepolia.g.alchemy.com/v2/demo'],
+    rpcUrls: ['https://ethereum-sepolia-rpc.publicnode.com'],
     blockExplorerUrls: ['https://sepolia.etherscan.io/'],
     type: null,
     vmType: 'EVM',


### PR DESCRIPTION
# Description

Replacement for Sepolia's RPC url with one from https://www.publicnode.com/
Earlier one isn't functional

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Can try to send a transaction,

```
    let rpc = LIT_CHAINS["sepolia"].rpcUrls[0];
    
    const provider = new ethers.providers.JsonRpcProvider(
        rpc
    );
    const signer = new ethers.Wallet(privateKey1, provider);
    
    const unsignedTransaction = {
        to: "0x291B0E3aA139b2bC9Ebd92168575b5c6bAD5236C",
        value: 2,
        gasLimit: "50000",
        gasPrice: (await signer.getGasPrice()).toHexString(),
        nonce: await signer.getTransactionCount(
            signer.getAddress()
        ),
    };

    const tx = await signer.sendTransaction(unsignedTransaction);
    const receipt = tx.wait();
    console.log(tx)
```



# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
