### PR TITLE
Feature/lit 3767 fix could only connect to 8 of 6 required nodes from 9 all nodes

### DIFF
--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -639,13 +639,11 @@ export class LitCore {
     await Promise.race([
       new Promise((_resolve, reject) => {
         timeoutHandle = setTimeout(() => {
-          const msg = `Error: Could not connect to enough nodes after timeout of ${
+          const msg = `Error: Could not connect to all required nodes after timeout of ${
             this.config.connectTimeout
-          }ms.  Could only connect to ${Object.keys(serverKeys).length} of ${
-            this.config.minNodeCount
-          } required nodes, from ${
+          }ms. Could only connect to ${Object.keys(serverKeys).length} of ${
             this.config.bootstrapUrls.length
-          } possible nodes.  Please check your network connection and try again.  Note that you can control this timeout with the connectTimeout config option which takes milliseconds.`;
+          } required nodes. Please check your network connection and try again. Note that you can control this timeout with the connectTimeout config option which takes milliseconds.`;
 
           try {
             // TODO: Kludge, replace with standard error construction

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -986,7 +986,11 @@ export class LitCore {
       const abortController = new AbortController();
       req.signal = abortController.signal;
       abortTimeout = setTimeout(() => {
-        abortController.abort(new Error(`Request to node timed out based on config. Timeout: ${requestTimeout}`));
+        abortController.abort(
+          new Error(
+            `Request to node timed out based on config. Timeout: ${requestTimeout}`
+          )
+        );
       }, requestTimeout);
     }
 

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -977,17 +977,17 @@ export class LitCore {
     };
 
     let abortTimeout: ReturnType<typeof setTimeout>;
-    if (timeout || this.config.nodeRequestTimeout) {
+    const requestTimeout = timeout || this.config.nodeRequestTimeout;
+    if (requestTimeout) {
       // TODO: Use AbortSignal.timeout once we update to TS >=4.9.5. It considers request active time instead of elapsed time
       // Example:
-      // const abortSignal = AbortSignal.timeout(timeout || this.config.nodeRequestTimeout);
+      // const abortSignal = AbortSignal.timeout(requestTimeout);
       // req.signal = abortSignal;
       const abortController = new AbortController();
       req.signal = abortController.signal;
-      abortTimeout = setTimeout(
-        () => abortController.abort('Request to node timed out'),
-        timeout || this.config.nodeRequestTimeout
-      );
+      abortTimeout = setTimeout(() => {
+        abortController.abort(new Error(`Request to node timed out based on config. Timeout: ${requestTimeout}`));
+      }, requestTimeout);
     }
 
     const sendRequestPromise = sendRequest(url, req, requestId);

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -979,7 +979,9 @@ export class LitCore {
     let abortTimeout: ReturnType<typeof setTimeout>;
     if (timeout || this.config.nodeRequestTimeout) {
       // TODO: Use AbortSignal.timeout once we update to TS >=4.9.5. It considers request active time instead of elapsed time
-      // AbortSignal.timeout(timout || this.config.nodeRequestTimeout)
+      // Example:
+      // const abortSignal = AbortSignal.timeout(timeout || this.config.nodeRequestTimeout);
+      // req.signal = abortSignal;
       const abortController = new AbortController();
       req.signal = abortController.signal;
       abortTimeout = setTimeout(

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -60,7 +60,6 @@ import {
   NodeClientErrorV0,
   NodeClientErrorV1,
   NodeCommandServerKeysResponse,
-  NodeErrorV3,
   RejectedNodePromises,
   SendNodeCommand,
   SessionSigsMap,
@@ -978,7 +977,10 @@ export class LitCore {
       // AbortSignal.timeout(this.config.nodeRequestTimeout)
       const abortController = new AbortController();
       req.signal = abortController.signal;
-      abortTimeout = setTimeout(() => abortController.abort("Request to node timed out"), this.config.nodeRequestTimeout);
+      abortTimeout = setTimeout(
+        () => abortController.abort('Request to node timed out'),
+        this.config.nodeRequestTimeout
+      );
     }
 
     const sendRequestPromise = sendRequest(url, req, requestId);

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -193,7 +193,11 @@ export interface LitNodeClientConfig {
   alertWhenUnauthorized?: boolean;
   minNodeCount?: number;
   debug?: boolean;
+  // Timeout for connecting/handshaking with all nodes
   connectTimeout?: number;
+  // Timeout for each request made to a node
+  nodeRequestTimeout?: number;
+  // Whether to retry handshaking a particular node if it failed, will retry until connectTimeout is reached
   retryNodeHandshake?: boolean;
   checkNodeAttestation?: boolean;
   contractContext?: LitContractContext | LitContractResolverContext;

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -195,6 +195,8 @@ export interface LitNodeClientConfig {
   debug?: boolean;
   // Timeout for connecting/handshaking with all nodes
   connectTimeout?: number;
+  // Timeout for connection request made to each node. If not provided, the default value is 7500ms
+  nodeConnectionTimeout?: number;
   // Timeout for each request made to a node
   nodeRequestTimeout?: number;
   // Whether to retry handshaking a particular node if it failed, will retry until connectTimeout is reached
@@ -646,6 +648,8 @@ export interface SendNodeCommand {
   url: string;
   data: any;
   requestId: string;
+  // Timeout for this request. Overrides the config's nodeRequestTimeout
+  timeout?: number;
 }
 export interface SigShare {
   sigType:

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -187,19 +187,32 @@ export interface HumanizedAccsProps {
 /** ---------- Key Value Type ---------- */
 export type KV = Record<string, any>;
 
-/** ---------- Lit Node Client ---------- */
+/**
+ * Configuration object for the LitNodeClient.
+ *
+ * @typedef {Object} LitNodeClientConfig
+ * @property {LIT_NETWORKS_KEYS} litNetwork - The key of the Lit network to connect to.
+ * @property {boolean} [alertWhenUnauthorized] - Whether to alert when unauthorized access is detected.
+ * @property {number} [minNodeCount] - Minimum number of nodes to connect to.
+ * @property {boolean} [debug] - Enable or disable debug mode.
+ * @property {number} [connectTimeout] - Timeout for connecting/handshaking with all nodes in milliseconds.
+ * @property {number} [nodeConnectionTimeout] - Timeout for connection requests made to each node in milliseconds (default is 7500ms).
+ * @property {number} [nodeRequestTimeout] - Timeout for each request made to a node in milliseconds.
+ * @property {boolean} [retryNodeHandshake] - Whether to retry handshaking with a particular node if it failed, retrying until connectTimeout is reached.
+ * @property {boolean} [checkNodeAttestation] - Whether to check for node attestation.
+ * @property {LitContractContext | LitContractResolverContext} [contractContext] - Contract context for interaction.
+ * @property {StorageProvider} [storageProvider] - Storage provider for session or local storage.
+ * @property {(authSigParams: AuthCallbackParams) => Promise<AuthSig>} [defaultAuthCallback] - Default callback for handling authentication signatures.
+ * @property {string} [rpcUrl] - URL for the RPC endpoint.
+ */
 export interface LitNodeClientConfig {
   litNetwork: LIT_NETWORKS_KEYS;
   alertWhenUnauthorized?: boolean;
   minNodeCount?: number;
   debug?: boolean;
-  // Timeout for connecting/handshaking with all nodes
   connectTimeout?: number;
-  // Timeout for connection request made to each node. If not provided, the default value is 7500ms
   nodeConnectionTimeout?: number;
-  // Timeout for each request made to a node
   nodeRequestTimeout?: number;
-  // Whether to retry handshaking a particular node if it failed, will retry until connectTimeout is reached
   retryNodeHandshake?: boolean;
   checkNodeAttestation?: boolean;
   contractContext?: LitContractContext | LitContractResolverContext;
@@ -644,11 +657,19 @@ export interface ExecuteJsNoSigningResponse extends ExecuteJsResponseBase {
 
 export interface LitNodePromise {}
 
+/**
+ * Represents a command to be sent to a node.
+ *
+ * @typedef {Object} SendNodeCommand
+ * @property {string} url - The URL to which the command is sent.
+ * @property {any} data - The data to be sent with the command.
+ * @property {string} requestId - The unique identifier for the request.
+ * @property {number} [timeout] - Timeout for this request, in milliseconds. Overrides the config's nodeRequestTimeout.
+ */
 export interface SendNodeCommand {
   url: string;
   data: any;
   requestId: string;
-  // Timeout for this request. Overrides the config's nodeRequestTimeout
   timeout?: number;
 }
 export interface SigShare {

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -194,6 +194,7 @@ export interface LitNodeClientConfig {
   minNodeCount?: number;
   debug?: boolean;
   connectTimeout?: number;
+  retryNodeHandshake?: boolean;
   checkNodeAttestation?: boolean;
   contractContext?: LitContractContext | LitContractResolverContext;
   storageProvider?: StorageProvider;


### PR DESCRIPTION
# Description

This PR:
- updates the "connected to X of Y nodes, with a minimum of Z" as that was misleading when X>=Z
- adds retry logic to each node handshake request (with a flag to [de]activate it, and retries until handshake timeout is reached). Defaults to `true`
- adds a per node HANDSHAKE timeout, configurable. (apart from full handshake timeout). This one overrides the request timeout if present. Defaults to `7500`ms.
- adds per node REQUEST timeout (applies also to handshake if present and handshake one is not), configurable. Defaults to `35000`ms (because LitActions have a 30s timeout, plus some network lag)

With default configs, the handshake process will attempt to connect to each node, the ones that don't succeed before 7500ms will be cancelled and retried in loop until they all succeed or handshake timeout is reached
When retry is set to false, the first failing node will fail the whole process (can be changed for naga allowing X=>Z handshakes)

![Screenshot from 2024-08-14 19-15-36](https://github.com/user-attachments/assets/fa38840d-6273-45a9-b32d-8a7f37212b20)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually tested several configs with a demo app

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
