### PR TITLE
fix: missing SEV check for Datil

### DIFF
--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -116,6 +116,7 @@ const NETWORKS_REQUIRING_SEV: string[] = [
   LitNetwork.Habanero,
   LitNetwork.Manzano,
   LitNetwork.DatilTest,
+  LitNetwork.Datil,
 ];
 
 export class LitCore {


### PR DESCRIPTION
Adding Datil to `NETWORKS_REQUIRING_SEV`