### PR TITLE
Fix the issue with the epoch propagation delay

### DIFF
--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -890,7 +890,8 @@ export class LitCore {
     if (
       this._epochCache.currentNumber &&
       this._epochCache.startTime &&
-      Date.now() < this._epochCache.startTime + EPOCH_PROPAGATION_DELAY
+      Math.floor(Date.now() / 1000) <
+        this._epochCache.startTime + Math.floor(EPOCH_PROPAGATION_DELAY / 1000)
     ) {
       return this._epochCache.currentNumber - 1;
     }


### PR DESCRIPTION
The issue was just mixing of seconds and milliseconds.  This PR just makes the comparisons all use seconds since that's the highest resolution we get from the chain.  I did test it myself and saw that the new epoch kicked in after 45s.

This replaces https://github.com/LIT-Protocol/js-sdk/pull/595 which has the same fix, but additional debug statements, and also a ton of changed files because i published a test build under the "chris" tag.

To test this, I ran it against datil-test during epoch transition.  I kicked off 300 sigs just before the transition started, and i got 300 successed.  I tried the same thing on v6.4.3 which doesn't have this fix and got about 6 "failed to verify signature" errors.  so i think this finally fixes this problem.  