### PR TITLE
divide by 100 after multiplying by 110 to get a 10% increase

### DIFF
--- a/packages/contracts-sdk/src/lib/contracts-sdk.ts
+++ b/packages/contracts-sdk/src/lib/contracts-sdk.ts
@@ -2452,7 +2452,10 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
       ...args,
       overrides
     );
-    return gasLimit.mul(gasLimitAdjustment);
+    // BigNumber uses integer math, so for example, to get a 10% increase,
+    // we multiply it by 110 to get 10% more gas and then divide
+    // by 100 to get the final gas limit
+    return gasLimit.mul(gasLimitAdjustment).div(100);
   };
 
   private async _callWithAdjustedOverrides<

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -893,7 +893,7 @@ export class LitCore {
       Math.floor(Date.now() / 1000) <
         this._epochCache.startTime +
           Math.floor(EPOCH_PROPAGATION_DELAY / 1000) &&
-      this._epochCache.currentNumber > 2
+      this._epochCache.currentNumber >= 3
     ) {
       return this._epochCache.currentNumber - 1;
     }

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -891,7 +891,9 @@ export class LitCore {
       this._epochCache.currentNumber &&
       this._epochCache.startTime &&
       Math.floor(Date.now() / 1000) <
-        this._epochCache.startTime + Math.floor(EPOCH_PROPAGATION_DELAY / 1000)
+        this._epochCache.startTime +
+          Math.floor(EPOCH_PROPAGATION_DELAY / 1000) &&
+      this._epochCache.currentNumber > 2
     ) {
       return this._epochCache.currentNumber - 1;
     }


### PR DESCRIPTION
The https://github.com/LIT-Protocol/js-sdk/pull/567 PR seems to have a bug in it that multiplies the gas limit by 110 instead of increasing it by 10%.  This is fixed by adding a division by 100 after the multiplication, which results in a 10% increase

Edit: this PR also adds a fix to the epoch delay, to make it work with the tests.  It works fine on live networks, but in the tests, when we try to use epoch 2, the delay hasn't passed yet, so we try to use epoch 1.  but epoch 1 is the first epoch and has no peers in it.  so the signing process fails in the tests.  the nodes go "i don't know about that peer".  so i put in a fix to only apply the delay if epochNumber >= 3.