### PR TITLE
feat: add `GLOBAL_OVERWRITE_IPFS_CODE_BY_NETWORK`

### DIFF
--- a/local-tests/setup/session-sigs/get-lit-action-session-sigs.ts
+++ b/local-tests/setup/session-sigs/get-lit-action-session-sigs.ts
@@ -1,6 +1,9 @@
 import { LitActionResource, LitPKPResource } from '@lit-protocol/auth-helpers';
 import { LitAbility, LitResourceAbilityRequest } from '@lit-protocol/types';
-import { CENTRALISATION_BY_NETWORK, LitNetwork } from '@lit-protocol/constants';
+import {
+  CENTRALISATION_BY_NETWORK,
+  GLOBAL_OVERWRITE_IPFS_CODE_BY_NETWORK,
+} from '@lit-protocol/constants';
 import { TinnyPerson } from '../tinny-person';
 import { TinnyEnvironment } from '../tinny-environment';
 
@@ -142,6 +145,12 @@ export const getInvalidLitActionSessionSigs = async (
       publicKey: alice.authMethodOwnedPkp.publicKey,
       sigName: 'unified-auth-sig',
     },
+    ipfsOptions: {
+      overwriteCode:
+        GLOBAL_OVERWRITE_IPFS_CODE_BY_NETWORK[
+          devEnv.litNodeClient.config.litNetwork
+        ],
+    },
   });
 
   return litActionSessionSigs;
@@ -164,6 +173,12 @@ export const getInvalidLitActionIpfsSessionSigs = async (
     jsParams: {
       publicKey: alice.authMethodOwnedPkp.publicKey,
       sigName: 'unified-auth-sig',
+    },
+    ipfsOptions: {
+      overwriteCode:
+        GLOBAL_OVERWRITE_IPFS_CODE_BY_NETWORK[
+          devEnv.litNodeClient.config.litNetwork
+        ],
     },
   });
 

--- a/local-tests/tests/wrapped-keys/testFailEthereumSignTransactionWrappedKeyInvalidDecryption.ts
+++ b/local-tests/tests/wrapped-keys/testFailEthereumSignTransactionWrappedKeyInvalidDecryption.ts
@@ -8,6 +8,7 @@ import { encryptString } from '@lit-protocol/encryption';
 import { LIT_PREFIX } from 'packages/wrapped-keys/src/lib/constants';
 import { LIT_ACTION_CID_REPOSITORY } from '../../../packages/wrapped-keys/src/lib/lit-actions-client/constants';
 import { getBaseTransactionForNetwork } from './util';
+import { GLOBAL_OVERWRITE_IPFS_CODE_BY_NETWORK } from '@lit-protocol/constants';
 
 /**
  * Test Commands:
@@ -57,7 +58,10 @@ export const testFailEthereumSignTransactionWrappedKeyInvalidDecryption =
             accessControlConditions: [decryptionAccessControlCondition],
           },
           ipfsOptions: {
-            overwriteCode: true,
+            overwriteCode:
+              GLOBAL_OVERWRITE_IPFS_CODE_BY_NETWORK[
+                devEnv.litNodeClient.config.litNetwork
+              ],
           },
         });
       } catch (e: any) {

--- a/packages/constants/src/lib/constants/constants.ts
+++ b/packages/constants/src/lib/constants/constants.ts
@@ -1019,4 +1019,7 @@ export const RELAY_URL_DATIL_TEST = 'https://datil-test-relayer.getlit.dev';
 export const LIT_ACTION_IPFS_HASH =
   'QmUjX8MW6StQ7NKNdaS6g4RMkvN5hcgtKmEi8Mca6oX4t3';
 
-export const FALLBACK_IPFS_GATEWAY = 'https://flk-ipfs.io/ipfs/';
+export const FALLBACK_IPFS_GATEWAYS = [
+  'https://flk-ipfs.io/ipfs/',
+  'https://litprotocol.mypinata.cloud/ipfs/',
+];

--- a/packages/constants/src/lib/constants/constants.ts
+++ b/packages/constants/src/lib/constants/constants.ts
@@ -1019,4 +1019,4 @@ export const RELAY_URL_DATIL_TEST = 'https://datil-test-relayer.getlit.dev';
 export const LIT_ACTION_IPFS_HASH =
   'QmUjX8MW6StQ7NKNdaS6g4RMkvN5hcgtKmEi8Mca6oX4t3';
 
-export const FALLBACK_IPFS_GATEWAY = 'https://litprotocol.mypinata.cloud/ipfs/';
+export const FALLBACK_IPFS_GATEWAY = 'https://flk-ipfs.io/ipfs/';

--- a/packages/constants/src/lib/constants/mappers.ts
+++ b/packages/constants/src/lib/constants/mappers.ts
@@ -51,7 +51,7 @@ export const GLOBAL_OVERWRITE_IPFS_CODE_BY_NETWORK: {
   habanero: false,
   'datil-dev': false,
   'datil-test': false,
-  datil: true,
+  datil: true, // <-- this is the only one that is true. To be re-evaluated in the future.
   custom: false,
   localhost: false,
 };

--- a/packages/constants/src/lib/constants/mappers.ts
+++ b/packages/constants/src/lib/constants/mappers.ts
@@ -42,3 +42,16 @@ export const GENERAL_WORKER_URL_BY_NETWORK: {
   custom: 'https://apis.getlit.dev/cayenne/contracts',
   localhost: 'https://apis.getlit.dev/cayenne/contracts',
 };
+
+export const GLOBAL_OVERWRITE_IPFS_CODE_BY_NETWORK: {
+  [key in LIT_NETWORK_VALUES]: boolean;
+} = {
+  cayenne: false,
+  manzano: false,
+  habanero: false,
+  'datil-dev': false,
+  'datil-test': false,
+  datil: true,
+  custom: false,
+  localhost: false,
+};

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -2216,7 +2216,6 @@ export class LitNodeClientNodeJs
         // Check if IPFS options are provided and if the code should be fetched from IPFS and overwrite the current code.
         // This will fetch the code from the specified IPFS gateway using the provided ipfsId,
         // and update the params with the fetched code, removing the ipfsId afterward.
-
         const overwriteCode =
           params.ipfsOptions?.overwriteCode ||
           GLOBAL_OVERWRITE_IPFS_CODE_BY_NETWORK[this.config.litNetwork];

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -965,8 +965,10 @@ export class LitNodeClientNodeJs
    * @returns The base64-encoded fallback IPFS code.
    * @throws An error if the code retrieval fails.
    */
-
-  async _getFallbackIpfsCode(gatewayUrl: string | undefined, ipfsId: string) {
+  private async _getFallbackIpfsCode(
+    gatewayUrl: string | undefined,
+    ipfsId: string
+  ) {
     const allGateways = gatewayUrl
       ? [gatewayUrl, ...FALLBACK_IPFS_GATEWAYS]
       : FALLBACK_IPFS_GATEWAYS;

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -1909,6 +1909,8 @@ export interface GetPkpSessionSigs
    * sending it to the node
    */
   authMethods?: AuthMethod[];
+
+  ipfsOptions?: IpfsOptions;
 }
 
 /**
@@ -1926,7 +1928,9 @@ export type GetLitActionSessionSigs = CommonGetSessionSigsProps &
     | (Pick<Required<LitActionSdkParams>, 'litActionIpfsId'> & {
         litActionCode?: never;
       })
-  );
+  ) & {
+    ipfsOptions?: IpfsOptions;
+  };
 
 export interface SessionKeyCache {
   value: SessionKeyPair;

--- a/packages/wrapped-keys/src/lib/lit-actions-client/export-private-key.ts
+++ b/packages/wrapped-keys/src/lib/lit-actions-client/export-private-key.ts
@@ -2,6 +2,7 @@ import { AccessControlConditions } from '@lit-protocol/types';
 
 import { postLitActionValidation } from './utils';
 import { ExportPrivateKeyParams, StoredKeyData } from '../types';
+import { GLOBAL_OVERWRITE_IPFS_CODE_BY_NETWORK } from '@lit-protocol/constants';
 
 interface SignMessageWithLitActionParams extends ExportPrivateKeyParams {
   accessControlConditions: AccessControlConditions;
@@ -36,7 +37,8 @@ export async function exportPrivateKeyWithLitAction(
       accessControlConditions,
     },
     ipfsOptions: {
-      overwriteCode: true,
+      overwriteCode:
+        GLOBAL_OVERWRITE_IPFS_CODE_BY_NETWORK[litNodeClient.config.litNetwork],
     },
   });
 

--- a/packages/wrapped-keys/src/lib/lit-actions-client/generate-key.ts
+++ b/packages/wrapped-keys/src/lib/lit-actions-client/generate-key.ts
@@ -1,6 +1,7 @@
 import { AccessControlConditions } from '@lit-protocol/types';
 import { postLitActionValidation } from './utils';
 import { GeneratePrivateKeyParams } from '../types';
+import { GLOBAL_OVERWRITE_IPFS_CODE_BY_NETWORK } from '@lit-protocol/constants';
 
 interface GeneratePrivateKeyLitActionParams extends GeneratePrivateKeyParams {
   pkpAddress: string;
@@ -29,7 +30,8 @@ export async function generateKeyWithLitAction({
       accessControlConditions,
     },
     ipfsOptions: {
-      overwriteCode: true,
+      overwriteCode:
+        GLOBAL_OVERWRITE_IPFS_CODE_BY_NETWORK[litNodeClient.config.litNetwork],
     },
   });
 

--- a/packages/wrapped-keys/src/lib/lit-actions-client/sign-message.ts
+++ b/packages/wrapped-keys/src/lib/lit-actions-client/sign-message.ts
@@ -2,6 +2,7 @@ import { AccessControlConditions } from '@lit-protocol/types';
 
 import { postLitActionValidation } from './utils';
 import { SignMessageWithEncryptedKeyParams, StoredKeyData } from '../types';
+import { GLOBAL_OVERWRITE_IPFS_CODE_BY_NETWORK } from '@lit-protocol/constants';
 
 interface SignMessageWithLitActionParams
   extends SignMessageWithEncryptedKeyParams {
@@ -34,7 +35,8 @@ export async function signMessageWithLitAction(
       accessControlConditions,
     },
     ipfsOptions: {
-      overwriteCode: true,
+      overwriteCode:
+        GLOBAL_OVERWRITE_IPFS_CODE_BY_NETWORK[litNodeClient.config.litNetwork],
     },
   });
   return postLitActionValidation(result);

--- a/packages/wrapped-keys/src/lib/lit-actions-client/sign-transaction.ts
+++ b/packages/wrapped-keys/src/lib/lit-actions-client/sign-transaction.ts
@@ -10,6 +10,7 @@ import {
   SerializedTransaction,
   StoredKeyData,
 } from '../types';
+import { GLOBAL_OVERWRITE_IPFS_CODE_BY_NETWORK } from '@lit-protocol/constants';
 
 interface SignTransactionWithLitActionParams {
   litNodeClient: ILitNodeClient;
@@ -42,7 +43,8 @@ export async function signTransactionWithLitAction({
       accessControlConditions,
     },
     ipfsOptions: {
-      overwriteCode: true,
+      overwriteCode:
+        GLOBAL_OVERWRITE_IPFS_CODE_BY_NETWORK[litNodeClient.config.litNetwork],
     },
   });
 


### PR DESCRIPTION
# Description

By default, we will always fetch the IPFS content for the datil mainnet network. Other network can specify to overwrite by passing it the `ipfsOptions` param to the `executeJs`, `getPkpSessionSigs` and `getLitActionSessionSigs` functions.

This is where we change the [default](https://github.com/LIT-Protocol/js-sdk/pull/609/files#diff-f0af9d412918612361cd43d65265f31c219f32b98baaafe4f3eb98c9aea221f9R54).

Also added `FALLBACK_IPFS_GATEWAYS` for fallback gateways, here's the speed test from the UK

<img width="584" alt="image" src="https://github.com/user-attachments/assets/06e026f7-a219-4d31-a1c2-ae543de421e4">
