### PR TITLE
Fix request params sent to nodes

### DIFF
--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -929,6 +929,12 @@ export class LitCore {
     // FIXME: Replace <any> usage with explicit, strongly typed handlers
     data = { ...data, epoch: this.currentEpochNumber };
 
+    // If there is a `sessionSigs' object in the params remove before sending the request;
+    // this line has been added as a catch all to prevent unnitended ata
+    if (data.sessionSigs) {
+      delete data.sessionSigs;
+    }
+
     logWithRequestId(
       requestId,
       `sendCommandToNode with url ${url} and data`,

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -930,7 +930,7 @@ export class LitCore {
     data = { ...data, epoch: this.currentEpochNumber };
 
     // If there is a `sessionSigs' object in the params remove before sending the request;
-    // this line has been added as a catch all to prevent sending with the request 
+    // this line has been added as a catch all to prevent sending with the request
     if (data.sessionSigs) {
       delete data.sessionSigs;
     }

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -930,7 +930,7 @@ export class LitCore {
     data = { ...data, epoch: this.currentEpochNumber };
 
     // If there is a `sessionSigs' object in the params remove before sending the request;
-    // this line has been added as a catch all to prevent unnitended ata
+    // this line has been added as a catch all to prevent sending with the request 
     if (data.sessionSigs) {
       delete data.sessionSigs;
     }


### PR DESCRIPTION
Fixes an issue where we send the `sessionSigs` map to all nodes when performing network operations where we should only be sending a single value as the `authSig` from this mapping.


This fix is a stop gap as we need a `ParamsValidator` which will perform the following operations
- Check that all properties required for a network operation are defined
    - If all required properties are not found throw an exception
-  Perform basic type assertion that required properties are of the correct type
- Check for properties which are not relevant for a given network operation and remove them
