### PR TITLE
Feat: Return Solana tx sig from Wrapped Keys

### DIFF
--- a/packages/wrapped-keys/src/lib/lit-actions-client/constants.ts
+++ b/packages/wrapped-keys/src/lib/lit-actions-client/constants.ts
@@ -2,12 +2,12 @@ import { LitCidRepository } from './types';
 
 const LIT_ACTION_CID_REPOSITORY: LitCidRepository = Object.freeze({
   signTransaction: Object.freeze({
-    evm: 'QmSsgmy1N1zFZ5yNPCY7QWQZwrYRLuYUJF1VDygJc7L26o',
-    solana: 'QmdkcMmrtqWSQ8VrPr8KwzuzZnAxGJoVDeZP3NKTWCMZCg',
+    evm: 'QmRWGips9G3pHXNa3viGFpAyh1LwzrR35R4xMiG61NuHpS',
+    solana: 'QmTG6CTLxuUnQrKGNtKHyWPUjkftw9KXQMGv4hSwY4UEeA',
   }),
   signMessage: Object.freeze({
-    evm: 'QmWVW51FBH5j3wwaMVy8MR1QyzJgEjuaPh1yqwSGXRCENx',
-    solana: 'QmSPcfFhLofjhNDd5ZdVbhw53zmbR8oV4C2585Bm7C8izH',
+    evm: 'QmNy5bHvgaN2rqo4kMU71jtgSSxDES6HSDgadBV29pfcRu',
+    solana: 'Qma1nRZN5eriT1a7Uffbiek5jsksvWCCqHuE1x1nk9zaAq',
   }),
   generateEncryptedKey: Object.freeze({
     evm: 'QmaoPMSqcze3NW3KSA75ecWSkcmWT1J7kVr8LyJPCKRvHd',

--- a/packages/wrapped-keys/src/lib/lit-actions-client/constants.ts
+++ b/packages/wrapped-keys/src/lib/lit-actions-client/constants.ts
@@ -3,7 +3,7 @@ import { LitCidRepository } from './types';
 const LIT_ACTION_CID_REPOSITORY: LitCidRepository = Object.freeze({
   signTransaction: Object.freeze({
     evm: 'QmRWGips9G3pHXNa3viGFpAyh1LwzrR35R4xMiG61NuHpS',
-    solana: 'QmTG6CTLxuUnQrKGNtKHyWPUjkftw9KXQMGv4hSwY4UEeA',
+    solana: 'QmPZR6FnTPMYpzKxNNHt4xRckDsAoQz76cxkLhJArSoe4w',
   }),
   signMessage: Object.freeze({
     evm: 'QmNy5bHvgaN2rqo4kMU71jtgSSxDES6HSDgadBV29pfcRu',

--- a/packages/wrapped-keys/src/lib/litActions/ethereum/src/signMessageWithEthereumEncryptedKey.js
+++ b/packages/wrapped-keys/src/lib/litActions/ethereum/src/signMessageWithEthereumEncryptedKey.js
@@ -38,7 +38,6 @@ const { removeSaltFromDecryptedKey } = require('../../utils');
   let privateKey;
   try {
     privateKey = removeSaltFromDecryptedKey(decryptedPrivateKey);
-    Lit.Actions.setResponse({ response: privateKey });
   } catch (err) {
     Lit.Actions.setResponse({ response: err.message });
     return;

--- a/packages/wrapped-keys/src/lib/litActions/ethereum/src/signTransactionWithEthereumEncryptedKey.js
+++ b/packages/wrapped-keys/src/lib/litActions/ethereum/src/signTransactionWithEthereumEncryptedKey.js
@@ -66,7 +66,6 @@ const { removeSaltFromDecryptedKey } = require('../../utils');
   let privateKey;
   try {
     privateKey = removeSaltFromDecryptedKey(decryptedPrivateKey);
-    Lit.Actions.setResponse({ response: privateKey });
   } catch (err) {
     Lit.Actions.setResponse({ response: err.message });
     return;

--- a/packages/wrapped-keys/src/lib/litActions/solana/src/signMessageWithSolanaEncryptedKey.js
+++ b/packages/wrapped-keys/src/lib/litActions/solana/src/signMessageWithSolanaEncryptedKey.js
@@ -42,7 +42,6 @@ const { removeSaltFromDecryptedKey } = require('../../utils');
   let privateKey;
   try {
     privateKey = removeSaltFromDecryptedKey(decryptedPrivateKey);
-    Lit.Actions.setResponse({ response: privateKey });
   } catch (err) {
     Lit.Actions.setResponse({ response: err.message });
     return;

--- a/packages/wrapped-keys/src/lib/litActions/solana/src/signTransactionWithSolanaEncryptedKey.js
+++ b/packages/wrapped-keys/src/lib/litActions/solana/src/signTransactionWithSolanaEncryptedKey.js
@@ -87,7 +87,9 @@ const { removeSaltFromDecryptedKey } = require('../../utils');
         clusterApiUrl(unsignedTransaction.chain),
         'confirmed'
       );
-      const transactionSignature = await solanaConnection.sendRawTransaction(transaction.serialize());
+      const transactionSignature = await solanaConnection.sendRawTransaction(
+        transaction.serialize()
+      );
 
       Lit.Actions.setResponse({ response: transactionSignature });
     } else {

--- a/packages/wrapped-keys/src/lib/litActions/solana/src/signTransactionWithSolanaEncryptedKey.js
+++ b/packages/wrapped-keys/src/lib/litActions/solana/src/signTransactionWithSolanaEncryptedKey.js
@@ -65,7 +65,6 @@ const { removeSaltFromDecryptedKey } = require('../../utils');
   let privateKey;
   try {
     privateKey = removeSaltFromDecryptedKey(decryptedPrivateKey);
-    Lit.Actions.setResponse({ response: privateKey });
   } catch (err) {
     Lit.Actions.setResponse({ response: err.message });
     return;

--- a/packages/wrapped-keys/src/lib/litActions/solana/src/signTransactionWithSolanaEncryptedKey.js
+++ b/packages/wrapped-keys/src/lib/litActions/solana/src/signTransactionWithSolanaEncryptedKey.js
@@ -81,14 +81,17 @@ const { removeSaltFromDecryptedKey } = require('../../utils');
 
     transaction.sign(solanaKeyPair);
     const signature = transaction.signature.toString('base64');
-    Lit.Actions.setResponse({ response: signature });
 
     if (broadcast) {
       const solanaConnection = new Connection(
         clusterApiUrl(unsignedTransaction.chain),
         'confirmed'
       );
-      await solanaConnection.sendRawTransaction(transaction.serialize()); // FIXME: Shouldn't this return the tx hash for consistency with the evm action?
+      const transactionSignature = await solanaConnection.sendRawTransaction(transaction.serialize());
+
+      Lit.Actions.setResponse({ response: transactionSignature });
+    } else {
+      Lit.Actions.setResponse({ response: signature });
     }
   } catch (error) {
     Lit.Actions.setResponse({


### PR DESCRIPTION
# Description

Currently Solana Wrapped Keys `signTransactionWithEncryptedKey()` always returns a signed encoded transaction. Which works when the Lit Action isn't broadcasting the tx as the user can broadcast the return value. But in cases where the Lit Action should broadcast the transaction it should return the **transaction signature** which can be used by the user to confirm the transaction status:
```
const status = await solanaConnection.getSignatureStatus(signedTx); // { context: { apiVersion: '2.0.5', slot: 321490377 }, value: { confirmationStatus: 'confirmed', confirmations: 0, err: null, slot: 321490377, status: { Ok: null } } }
const confirmation = await solanaConnection.confirmTransaction(signedTx); // { context: { slot: 321490379 }, value: { err: null } }
```

## Fix

Return transactionSignature which is the result of: `solanaConnection.sendRawTransaction(transaction.serialize());`

## Other changes

Also remove setting the decrypted privateKey from all the Wrapped Keys Lit Actions except `exportPrivateKey`. This warrants updating the Lit Action constants which has been done.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update (We can raise a small docs PR which just tells folks how to confirm the broadcasted tx as in the example above)

# How Has This Been Tested?

Updated the Tinny test `testSignTransactionWithSolanaEncryptedKey` to broadcast a Solana tx. It has been commented out as it requires air dropping SOL on Devnet which is highly rate limited.

# Checklist:

- [ ] **TODO:** I have made corresponding changes to the [documentation](https://linear.app/litprotocol/issue/LIT-3815/wrapped-keys-update-docs-to-confirm-broadcasted-solana-tx)
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Any dependent changes have been merged and published in downstream modules (Pinned Lit Actions on IPFS)
