### PR TITLE
feat: implemented node handshake retry logic over v7 branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "react-router-dom": "6.11.2",
     "ts-jest": "29.1.2",
     "typedoc": "^0.23.10",
-    "typescript": "~4.7.2"
+    "typescript": "5.5.4"
   },
   "workspaces": [
     "packages/*"

--- a/packages/encryption/src/lib/encryption.ts
+++ b/packages/encryption/src/lib/encryption.ts
@@ -128,14 +128,10 @@ export const encryptToJson = async (
  * @returns { Promise<string | Uint8Array> } - The decrypted `string` or file (as a `Uint8Array`) depending on `dataType` property in the parsed JSON provided
  *
  */
-export async function decryptFromJson<T extends DecryptFromJsonProps>(
-  params: T
+export async function decryptFromJson(
+  params: DecryptFromJsonProps
 ): Promise<
-  T extends { parsedJsonData: { dataType: 'file' } }
-    ? ReturnType<typeof decryptToFile>
-    : T extends { parsedJsonData: { dataType: 'string' } }
-    ? ReturnType<typeof decryptToString>
-    : never
+  ReturnType<typeof decryptToFile> | ReturnType<typeof decryptToString>
 > {
   const { sessionSigs, parsedJsonData, litNodeClient } = params;
 
@@ -157,7 +153,6 @@ export async function decryptFromJson<T extends DecryptFromJsonProps>(
       'Invalid params'
     );
 
-  // FIXME: The return type of this function is inferrable based on the value of `params.dataType`
   if (parsedJsonData.dataType === 'string') {
     return decryptToString(
       {

--- a/packages/lit-auth-client/tsconfig.json
+++ b/packages/lit-auth-client/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "module": "commonjs",
-    "moduleResolution": "node16",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -187,13 +187,33 @@ export interface HumanizedAccsProps {
 /** ---------- Key Value Type ---------- */
 export type KV = Record<string, any>;
 
-/** ---------- Lit Node Client ---------- */
+/**
+ * Configuration object for the LitNodeClient.
+ *
+ * @typedef {Object} LitNodeClientConfig
+ * @property {LIT_NETWORKS_KEYS} litNetwork - The key of the Lit network to connect to.
+ * @property {boolean} [alertWhenUnauthorized] - Whether to alert when unauthorized access is detected.
+ * @property {number} [minNodeCount] - Minimum number of nodes to connect to.
+ * @property {boolean} [debug] - Enable or disable debug mode.
+ * @property {number} [connectTimeout] - Timeout for connecting/handshaking with all nodes in milliseconds.
+ * @property {number} [nodeConnectionTimeout] - Timeout for connection requests made to each node in milliseconds (default is 7500ms).
+ * @property {number} [nodeRequestTimeout] - Timeout for each request made to a node in milliseconds.
+ * @property {boolean} [retryNodeHandshake] - Whether to retry handshaking with a particular node if it failed, retrying until connectTimeout is reached.
+ * @property {boolean} [checkNodeAttestation] - Whether to check for node attestation.
+ * @property {LitContractContext | LitContractResolverContext} [contractContext] - Contract context for interaction.
+ * @property {StorageProvider} [storageProvider] - Storage provider for session or local storage.
+ * @property {(authSigParams: AuthCallbackParams) => Promise<AuthSig>} [defaultAuthCallback] - Default callback for handling authentication signatures.
+ * @property {string} [rpcUrl] - URL for the RPC endpoint.
+ */
 export interface LitNodeClientConfig {
   litNetwork: LIT_NETWORKS_KEYS;
   alertWhenUnauthorized?: boolean;
   minNodeCount?: number;
   debug?: boolean;
   connectTimeout?: number;
+  nodeConnectTimeout?: number;
+  nodeRequestTimeout?: number;
+  retryNodeHandshake?: boolean;
   checkNodeAttestation?: boolean;
   contractContext?: LitContractContext | LitContractResolverContext;
   storageProvider?: StorageProvider;
@@ -645,10 +665,20 @@ export interface ExecuteJsNoSigningResponse extends ExecuteJsResponseBase {
 
 export interface LitNodePromise {}
 
+/**
+ * Represents a command to be sent to a node.
+ *
+ * @typedef {Object} SendNodeCommand
+ * @property {string} url - The URL to which the command is sent.
+ * @property {any} data - The data to be sent with the command.
+ * @property {string} requestId - The unique identifier for the request.
+ * @property {number} [timeout] - Timeout for this request, in milliseconds. Overrides the config's nodeRequestTimeout.
+ */
 export interface SendNodeCommand {
   url: string;
   data: any;
   requestId: string;
+  timeout?: number;
 }
 export interface SigShare {
   sigType:

--- a/yarn.lock
+++ b/yarn.lock
@@ -22879,15 +22879,15 @@ typeforce@^1.11.3:
   resolved "https://registry.yarnpkg.com/typeforce/-/typeforce-1.18.0.tgz#d7416a2c5845e085034d70fcc5b6cc4a90edbfdc"
   integrity sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==
 
+typescript@5.5.4:
+  version "5.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.4.tgz#d9852d6c82bad2d2eda4fd74a5762a8f5909e9ba"
+  integrity sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==
+
 "typescript@^3 || ^4":
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
-
-typescript@~4.7.2:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 typescript@~5.3.2:
   version "5.3.3"


### PR DESCRIPTION
# Description

This PR:
- updates the "connected to X of Y nodes, with a minimum of Z" as that was misleading when X>=Z
- adds retry logic to each node handshake request on certain scenarios (with a flag to [de]activate it, and retries until handshake timeout is reached). Defaults to `true`
- adds a per node HANDSHAKE timeout, configurable. (apart from full handshake timeout). This one overrides the request timeout if present. Defaults to `7500`ms.
- adds per node REQUEST timeout (applies also to handshake if present and handshake one is not), configurable. Defaults to `35000`ms (because LitActions have a 30s timeout, plus some network lag)
- reports correctly why the handshake failed using new VErrors

With default configs, the handshake process will attempt to connect to each node, the ones that don't succeed before 7500ms will be cancelled and retried in loop until they all succeed or handshake timeout is reached
When retry is set to false, the first failing node will fail the whole process (can be changed for naga allowing X=>Z handshakes)

![Screenshot from 2024-09-02 21-30-39](https://github.com/user-attachments/assets/27f8edd2-d66c-4acd-966b-ec039025eb51)

Bonus of this PR:
Updates TS to 5.4 in order to use `AbortSignal.timeout` and not have to wait until #622 and then need a followup

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Manually tested several configs with a demo script and playing around with configs

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
