### PR TITLE
dev: Add id fetching to logger api and expose in lit core

### DIFF
--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -224,6 +224,10 @@ export class LitCore {
     return globalThis.logManager.getLogsForId(id);
   };
 
+  getRequestIds = (): Set<string> => {
+    return globalThis.logManager.LoggerIds;
+  };
+
   /**
    * Retrieves the validator data including staking contract, epoch, minNodeCount, and bootstrapUrls.
    * @returns An object containing the validator data.

--- a/packages/logger/src/lib/logger.spec.ts
+++ b/packages/logger/src/lib/logger.spec.ts
@@ -101,4 +101,16 @@ describe('logger', () => {
 
     expect(lm.getLogsForId('foo6').length).toEqual(count);
   });
+
+  it('should retain logger keys and return from LogManager', () => {
+    const count = 10;
+    for (let i = 0; i < count; i++) {
+      const logger = lm.get('' + i, 'foo7');
+      logger.setLevel(LogLevel.DEBUG);
+      logger.debug(i + '');
+    }
+
+    expect(lm.getLogsForId('foo7').length).toEqual(count);
+    expect(lm.LoggerIds.size).toEqual(1);
+  });
 });

--- a/packages/logger/src/lib/logger.ts
+++ b/packages/logger/src/lib/logger.ts
@@ -411,6 +411,17 @@ export class LogManager {
     }
   }
 
+  get LoggerIds(): string[] {
+    const keys: string[] = [];
+    for (const category of this._loggers.entries()) {
+      for (const child of category[1].Children) {
+        keys.push(child[0]);
+      }
+    }
+
+    return keys;
+  }
+
   // if a logger is given an id it will persist logs under its logger instance
   public get(category: string, id?: string): Logger {
     let instance = this._loggers.get(category);


### PR DESCRIPTION
# Description

Adds functionality to fetch logs based on `requestId` such that logs from an active sdk connection can be looked up and returned. Logs are currently stored in memory but can be stored in `local storage` as well with some minor updates to tail deletion of logs as new logs are added.


Below is an example of querying logs

```js
  let ids = devEnv.litNodeClient.getRequestIds();
  console.log('request ids', ids);
  console.log(ids[1]);
  const logs = devEnv.litNodeClient.getLogsForRequestId(ids[1]);
  console.log(logs);
```

example output: 

```ascii
[
  '[Lit-JS-SDK v6.4.10]\x1B[36m[DEBUG]\x1B[0m [core] [id: 6e232dc7de4e] sendCommandToNode with url https://173.208.0.151:443/web/execute/v1 and data {\n' +
    '  "code": "KGFzeW5jICgpID0+IHsKICAgICAgY29uc3Qgc2lnU2hhcmUgPSBhd2FpdCBMaXRBY3Rpb25zLnNpZ25FY2RzYSh7CiAgICAgICAgdG9TaWduOiBkYXRhVG9TaWduLAogICAgICAgIHB1YmxpY0tleSwKICAgICAgICBzaWdOYW1lOiAic2lnIiwKICAgICAgfSk7CiAgICB9KSgpOw==",\n' +
    '  "jsParams": {\n' +
    '    "dataToSign": [\n' +
    '      125,\n' +
    '      135,\n' +
    '      197,\n' +
    '      234,\n' +
    '      117,\n' +
    '      247,\n' +
    '      55,\n' +
    '      139,\n' +
    '      183,\n' +
    '      1,\n' +
    '      228,\n' +
    '      4,\n' +
    '      197,\n' +
    '      6,\n' +
    '      57,\n' +
    '      22,\n' +
    '      26,\n' +
    '      243,\n' +
    '      239,\n' +
    '      246,\n' +
    '      98,\n' +
    '      147,\n' +
    '      233,\n' +
    '      243,\n' +
    '      117,\n' +
    '      181,\n' +
    '      241,\n' +
    '      126,\n' +
    '      181,\n' +
    '      4,\n' +
    '      118,\n' +
    '      244\n' +
    '    ],\n' +
    '    "publicKey": "0450ecc0e552c28998598d505e9453ce62ec84f06c2bfbb6a2704a6daa1e23435293c339e6d63637f6381a30f4ba9ae0d05149066733a599b06c2ba1f95be487e7"\n' +
    '  },\n' +
    '  "authSig": {\n' +
    '    "sig": "59d97f25075c3eab2f7dbbaea978f3f998a5295aa71cca66a7417ba54877052d8253e5e127643c030c0dc955e9e986e9853f94c63ff6dea0df74d2c07814480b",\n' +
    '    "derivedVia": "litSessionSignViaNacl",\n' +
    `    "signedMessage": "{\\"sessionKey\\":\\"249baa0a80c2b48588b072a98723047029abf25a3917b04d413851bce277d349\\",\\"resourceAbilityRequests\\":[{\\"resource\\":{\\"resource\\":\\"*\\",\\"resourcePrefix\\":\\"lit-pkp\\"},\\"ability\\":\\"pkp-signing\\"},{\\"resource\\":{\\"resource\\":\\"*\\",\\"resourcePrefix\\":\\"lit-litaction\\"},\\"ability\\":\\"lit-action-execution\\"}],\\"capabilities\\":[{\\"sig\\":\\"0xbecbcbb3f70d6c4aa40124eb27095cc043dd5cccfabbe0a75397586e3069f77a22d34a0dd1755a1e4518eb8073d3812462a82d2b41a542429d8a8b513636e21b1b\\",\\"derivedVia\\":\\"web3.eth.personal.sign\\",\\"signedMessage\\":\\"localhost wants you to sign in with your Ethereum account:\\\\n0x70997970C51812dc3A010C7d01b50e0d17dc79C8\\\\n\\\\nThis is a test statement.  You can put anything you want here. I further authorize the stated URI to perform the following actions on my behalf: (1) 'Auth': 'Auth' for 'lit-ratelimitincrease://23789'.\\\\n\\\\nURI: lit:capability:delegation\\\\nVersion: 1\\\\nChain ID: 1\\\\nNonce: 0x97cee5dde740e6cd3e8ca84c8780c78d3e476678fdac457df6303bec4f850717\\\\nIssued At: 2024-09-05T16:05:03.319Z\\\\nExpiration Time: 2024-09-12T16:05:03.314Z\\\\nResources:\\\\n- urn:recap:eyJhdHQiOnsibGl0LXJhdGVsaW1pdGluY3JlYXNlOi8vMjM3ODkiOnsiQXV0aC9BdXRoIjpbeyJuZnRfaWQiOlsiMjM3ODkiXSwidXNlcyI6IjIwMCJ9XX19LCJwcmYiOltdfQ\\",\\"address\\":\\"0x70997970C51812dc3A010C7d01b50e0d17dc79C8\\"},{\\"sig\\":\\"0x149b6a8b0f9cfc1bfbdf65628a86f2777c37a8b6b433ee446df100b5a5bef8bc1ea7e61e58d974309c04dffad21fa0de844fccabe7865ab46b4d5a4aa8f035ab1c\\",\\"derivedVia\\":\\"web3.eth.personal.sign\\",\\"signedMessage\\":\\"localhost wants you to sign in with your Ethereum account:\\\\n0x90F79bf6EB2c4f870365E785982E1f101E93b906\\\\n\\\\nThis is a test statement.  You can put anything you want here. I further authorize the stated URI to perform the following actions on my behalf: (1) 'Threshold': 'Execution' for 'lit-litaction://*'. (2) 'Threshold': 'Signing' for 'lit-pkp://*'.\\\\n\\\\nURI: lit:session:249baa0a80c2b48588b072a98723047029abf25a3917b04d413851bce277d349\\\\nVersion: 1\\\\nChain ID: 1\\\\nNonce: 0x97cee5dde740e6cd3e8ca84c8780c78d3e476678fdac457df6303bec4f850717\\\\nIssued At: 2024-09-05T16:05:05.575Z\\\\nExpiration Time: 2024-09-06T16:05:05.288Z\\\\nResources:\\\\n- urn:recap:eyJhdHQiOnsibGl0LWxpdGFjdGlvbjovLyoiOnsiVGhyZXNob2xkL0V4ZWN1dGlvbiI6W3t9XX0sImxpdC1wa3A6Ly8qIjp7IlRocmVzaG9sZC9TaWduaW5nIjpbe31dfX0sInByZiI6W119\\",\\"address\\":\\"0x90F79bf6EB2c4f870365E785982E1f101E93b906\\"}],\\"issuedAt\\":\\"2024-09-05T16:05:05.635Z\\",\\"expiration\\":\\"2024-09-06T16:05:05.288Z\\",\\"nodeAddress\\":\\"https://173.208.0.151:443\\"}",\n` +
    '    "address": "249baa0a80c2b48588b072a98723047029abf25a3917b04d413851bce277d349",\n' +
    '    "algo": "ed25519"\n' +
    '  },\n' +
    '  "epoch": 1594\n' +
    '}',
  '[Lit-JS-SDK v6.4.10]\x1B[36m[DEBUG]\x1B[0m [core] [id: 6e232dc7de4e] sendCommandToNode with url https://207.244.66.41:443/web/execute/v1 and data {\n' +
    '  "code": "KGFzeW5jICgpID0+IHsKICAgICAgY29uc3Qgc2lnU2hhcmUgPSBhd2FpdCBMaXRBY3Rpb25zLnNpZ25FY2RzYSh7CiAgICAgICAgdG9TaWduOiBkYXRhVG9TaWduLAogICAgICAgIHB1YmxpY0tleSwKICAgICAgICBzaWdOYW1lOiAic2lnIiwKICAgICAgfSk7CiAgICB9KSgpOw==",\n' +
    '  "jsParams": {\n' +
    '    "dataToSign": [\n' +
    '      125,\n' +
    '      135,\n' +
    '      197,\n' +
    '      234,\n' +
    '      117,\n' +
    '      247,\n' +
    '      55,\n' +
    '      139,\n' +
    '      183,\n' +
    '      1,\n' +
    '      228,\n' +
    '      4,\n' +
    '      197,\n' +
    '      6,\n' +
    '      57,\n' +
    '      22,\n' +
    '      26,\n' +
    '      243,\n' +
    '      239,\n' +
    '      246,\n' +
    '      98,\n' +
    '      147,\n' +
    '      233,\n' +
    '      243,\n' +
    '      117,\n' +
    '      181,\n' +
    '      241,\n' +
    '      126,\n' +
    '      181,\n' +
    '      4,\n' +
    '      118,\n' +
    '      244\n' +
    '    ],\n' +
    '    "publicKey": "0450ecc0e552c28998598d505e9453ce62ec84f06c2bfbb6a2704a6daa1e23435293c339e6d63637f6381a30f4ba9ae0d05149066733a599b06c2ba1f95be487e7"\n' +
    '  },\n' +
    '  "authSig": {\n' +
    '    "sig": "0114b18a2a39e707b2c20144bfce39a9ab3d488a632c4f8826660f8c8ee3bbcf16ab7a4a98673c3a84a5ebddf8af255d3eb766495af4bae43c37fa15ecac4806",\n' +
    '    "derivedVia": "litSessionSignViaNacl",\n' +
    `    "signedMessage": "{\\"sessionKey\\":\\"249baa0a80c2b48588b072a98723047029abf25a3917b04d413851bce277d349\\",\\"resourceAbilityRequests\\":[{\\"resource\\":{\\"resource\\":\\"*\\",\\"resourcePrefix\\":\\"lit-pkp\\"},\\"ability\\":\\"pkp-signing\\"},{\\"resource\\":{\\"resource\\":\\"*\\",\\"resourcePrefix\\":\\"lit-litaction\\"},\\"ability\\":\\"lit-action-execution\\"}],\\"capabilities\\":[{\\"sig\\":\\"0xbecbcbb3f70d6c4aa40124eb27095cc043dd5cccfabbe0a75397586e3069f77a22d34a0dd1755a1e4518eb8073d3812462a82d2b41a542429d8a8b513636e21b1b\\",\\"derivedVia\\":\\"web3.eth.personal.sign\\",\\"signedMessage\\":\\"localhost wants you to sign in with your Ethereum account:\\\\n0x70997970C51812dc3A010C7d01b50e0d17dc79C8\\\\n\\\\nThis is a test statement.  You can put anything you want here. I further authorize the stated URI to perform the following actions on my behalf: (1) 'Auth': 'Auth' for 'lit-ratelimitincrease://23789'.\\\\n\\\\nURI: lit:capability:delegation\\\\nVersion: 1\\\\nChain ID: 1\\\\nNonce: 0x97cee5dde740e6cd3e8ca84c8780c78d3e476678fdac457df6303bec4f850717\\\\nIssued At: 2024-09-05T16:05:03.319Z\\\\nExpiration Time: 2024-09-12T16:05:03.314Z\\\\nResources:\\\\n- urn:recap:eyJhdHQiOnsibGl0LXJhdGVsaW1pdGluY3JlYXNlOi8vMjM3ODkiOnsiQXV0aC9BdXRoIjpbeyJuZnRfaWQiOlsiMjM3ODkiXSwidXNlcyI6IjIwMCJ9XX19LCJwcmYiOltdfQ\\",\\"address\\":\\"0x70997970C51812dc3A010C7d01b50e0d17dc79C8\\"},{\\"sig\\":\\"0x149b6a8b0f9cfc1bfbdf65628a86f2777c37a8b6b433ee446df100b5a5bef8bc1ea7e61e58d974309c04dffad21fa0de844fccabe7865ab46b4d5a4aa8f035ab1c\\",\\"derivedVia\\":\\"web3.eth.personal.sign\\",\\"signedMessage\\":\\"localhost wants you to sign in with your Ethereum account:\\\\n0x90F79bf6EB2c4f870365E785982E1f101E93b906\\\\n\\\\nThis is a test statement.  You can put anything you want here. I further authorize the stated URI to perform the following actions on my behalf: (1) 'Threshold': 'Execution' for 'lit-litaction://*'. (2) 'Threshold': 'Signing' for 'lit-pkp://*'.\\\\n\\\\nURI: lit:session:249baa0a80c2b48588b072a98723047029abf25a3917b04d413851bce277d349\\\\nVersion: 1\\\\nChain ID: 1\\\\nNonce: 0x97cee5dde740e6cd3e8ca84c8780c78d3e476678fdac457df6303bec4f850717\\\\nIssued At: 2024-09-05T16:05:05.575Z\\\\nExpiration Time: 2024-09-06T16:05:05.288Z\\\\nResources:\\\\n- urn:recap:eyJhdHQiOnsibGl0LWxpdGFjdGlvbjovLyoiOnsiVGhyZXNob2xkL0V4ZWN1dGlvbiI6W3t9XX0sImxpdC1wa3A6Ly8qIjp7IlRocmVzaG9sZC9TaWduaW5nIjpbe31dfX0sInByZiI6W119\\",\\"address\\":\\"0x90F79bf6EB2c4f870365E785982E1f101E93b906\\"}],\\"issuedAt\\":\\"2024-09-05T16:05:05.635Z\\",\\"expiration\\":\\"2024-09-06T16:05:05.288Z\\",\\"nodeAddress\\":\\"https://207.244.66.41:443\\"}",\n` +
    '    "address": "249baa0a80c2b48588b072a98723047029abf25a3917b04d413851bce277d349",\n' +
    '    "algo": "ed25519"\n' +
    '  },\n' +
    '  "epoch": 1594\n' +
    '}',
  '[Lit-JS-SDK v6.4.10]\x1B[36m[DEBUG]\x1B[0m [core] [id: 6e232dc7de4e] sendCommandToNode with url https://207.244.90.225:443/web/execute/v1 and data {\n' +
    '  "code": "KGFzeW5jICgpID0+IHsKICAgICAgY29uc3Qgc2lnU2hhcmUgPSBhd2FpdCBMaXRBY3Rpb25zLnNpZ25FY2RzYSh7CiAgICAgICAgdG9TaWduOiBkYXRhVG9TaWduLAogICAgICAgIHB1YmxpY0tleSwKICAgICAgICBzaWdOYW1lOiAic2lnIiwKICAgICAgfSk7CiAgICB9KSgpOw==",\n' +
    '  "jsParams": {\n' +
    '    "dataToSign": [\n' +
    '      125,\n' +
    '      135,\n' +
    '      197,\n' +
    '      234,\n' +
    '      117,\n' +
    '      247,\n' +
    '      55,\n' +
    '      139,\n' +
    '      183,\n' +
    '      1,\n' +
    '      228,\n' +
    '      4,\n' +
    '      197,\n' +
    '      6,\n' +
    '      57,\n' +
    '      22,\n' +
    '      26,\n' +
    '      243,\n' +
    '      239,\n' +
    '      246,\n' +
    '      98,\n' +
    '      147,\n' +
    '      233,\n' +
    '      243,\n' +
    '      117,\n' +
    '      181,\n' +
    '      241,\n' +
    '      126,\n' +
    '      181,\n' +
    '      4,\n' +
    '      118,\n' +
    '      244\n' +
    '    ],\n' +
    '    "publicKey": "0450ecc0e552c28998598d505e9453ce62ec84f06c2bfbb6a2704a6daa1e23435293c339e6d63637f6381a30f4ba9ae0d05149066733a599b06c2ba1f95be487e7"\n' +
    '  },\n' +
    '  "authSig": {\n' +
    '    "sig": "b79819879f2e1eb32d95298727cdacc919f39d006afcf3e95625c4dba5a3bc7fbd9685d65033438a7deecb446310ab82f48add2ca47bfd0b4ca4b8600fe99b08",\n' +
    '    "derivedVia": "litSessionSignViaNacl",\n' +
    `    "signedMessage": "{\\"sessionKey\\":\\"249baa0a80c2b48588b072a98723047029abf25a3917b04d413851bce277d349\\",\\"resourceAbilityRequests\\":[{\\"resource\\":{\\"resource\\":\\"*\\",\\"resourcePrefix\\":\\"lit-pkp\\"},\\"ability\\":\\"pkp-signing\\"},{\\"resource\\":{\\"resource\\":\\"*\\",\\"resourcePrefix\\":\\"lit-litaction\\"},\\"ability\\":\\"lit-action-execution\\"}],\\"capabilities\\":[{\\"sig\\":\\"0xbecbcbb3f70d6c4aa40124eb27095cc043dd5cccfabbe0a75397586e3069f77a22d34a0dd1755a1e4518eb8073d3812462a82d2b41a542429d8a8b513636e21b1b\\",\\"derivedVia\\":\\"web3.eth.personal.sign\\",\\"signedMessage\\":\\"localhost wants you to sign in with your Ethereum account:\\\\n0x70997970C51812dc3A010C7d01b50e0d17dc79C8\\\\n\\\\nThis is a test statement.  You can put anything you want here. I further authorize the stated URI to perform the following actions on my behalf: (1) 'Auth': 'Auth' for 'lit-ratelimitincrease://23789'.\\\\n\\\\nURI: lit:capability:delegation\\\\nVersion: 1\\\\nChain ID: 1\\\\nNonce: 0x97cee5dde740e6cd3e8ca84c8780c78d3e476678fdac457df6303bec4f850717\\\\nIssued At: 2024-09-05T16:05:03.319Z\\\\nExpiration Time: 2024-09-12T16:05:03.314Z\\\\nResources:\\\\n- urn:recap:eyJhdHQiOnsibGl0LXJhdGVsaW1pdGluY3JlYXNlOi8vMjM3ODkiOnsiQXV0aC9BdXRoIjpbeyJuZnRfaWQiOlsiMjM3ODkiXSwidXNlcyI6IjIwMCJ9XX19LCJwcmYiOltdfQ\\",\\"address\\":\\"0x70997970C51812dc3A010C7d01b50e0d17dc79C8\\"},{\\"sig\\":\\"0x149b6a8b0f9cfc1bfbdf65628a86f2777c37a8b6b433ee446df100b5a5bef8bc1ea7e61e58d974309c04dffad21fa0de844fccabe7865ab46b4d5a4aa8f035ab1c\\",\\"derivedVia\\":\\"web3.eth.personal.sign\\",\\"signedMessage\\":\\"localhost wants you to sign in with your Ethereum account:\\\\n0x90F79bf6EB2c4f870365E785982E1f101E93b906\\\\n\\\\nThis is a test statement.  You can put anything you want here. I further authorize the stated URI to perform the following actions on my behalf: (1) 'Threshold': 'Execution' for 'lit-litaction://*'. (2) 'Threshold': 'Signing' for 'lit-pkp://*'.\\\\n\\\\nURI: lit:session:249baa0a80c2b48588b072a98723047029abf25a3917b04d413851bce277d349\\\\nVersion: 1\\\\nChain ID: 1\\\\nNonce: 0x97cee5dde740e6cd3e8ca84c8780c78d3e476678fdac457df6303bec4f850717\\\\nIssued At: 2024-09-05T16:05:05.575Z\\\\nExpiration Time: 2024-09-06T16:05:05.288Z\\\\nResources:\\\\n- urn:recap:eyJhdHQiOnsibGl0LWxpdGFjdGlvbjovLyoiOnsiVGhyZXNob2xkL0V4ZWN1dGlvbiI6W3t9XX0sImxpdC1wa3A6Ly8qIjp7IlRocmVzaG9sZC9TaWduaW5nIjpbe31dfX0sInByZiI6W119\\",\\"address\\":\\"0x90F79bf6EB2c4f870365E785982E1f101E93b906\\"}],\\"issuedAt\\":\\"2024-09-05T16:05:05.635Z\\",\\"expiration\\":\\"2024-09-06T16:05:05.288Z\\",\\"nodeAddress\\":\\"https://207.244.90.225:443\\"}",\n` +
    '    "address": "249baa0a80c2b48588b072a98723047029abf25a3917b04d413851bce277d349",\n' +
    '    "algo": "ed25519"\n' +
    '  },\n' +
    '  "epoch": 1594\n' +
    '}',
  '[Lit-JS-SDK v6.4.10]\x1B[36m[DEBUG]\x1B[0m [core] [id: 6e232dc7de4e] sendCommandToNode with url https://23.82.129.77:443/web/execute/v1 and data {\n' +
    '  "code": "KGFzeW5jICgpID0+IHsKICAgICAgY29uc3Qgc2lnU2hhcmUgPSBhd2FpdCBMaXRBY3Rpb25zLnNpZ25FY2RzYSh7CiAgICAgICAgdG9TaWduOiBkYXRhVG9TaWduLAogICAgICAgIHB1YmxpY0tleSwKICAgICAgICBzaWdOYW1lOiAic2lnIiwKICAgICAgfSk7CiAgICB9KSgpOw==",\n' +
    '  "jsParams": {\n' +
    '    "dataToSign": [\n' +
    '      125,\n' +
    '      135,\n' +
    '      197,\n' +
    '      234,\n' +
    '      117,\n' +
    '      247,\n' +
    '      55,\n' +
    '      139,\n' +
    '      183,\n' +
    '      1,\n' +
    '      228,\n' +
    '      4,\n' +
    '      197,\n' +
    '      6,\n' +
    '      57,\n' +
    '      22,\n' +
    '      26,\n' +
    '      243,\n' +
    '      239,\n' +
    '      246,\n' +
    '      98,\n' +
    '      147,\n' +
    '      233,\n' +
    '      243,\n' +
    '      117,\n' +
    '      181,\n' +
    '      241,\n' +
    '      126,\n' +
    '      181,\n' +
    '      4,\n' +
    '      118,\n' +
    '      244\n' +
    '    ],\n' +
    '    "publicKey": "0450ecc0e552c28998598d505e9453ce62ec84f06c2bfbb6a2704a6daa1e23435293c339e6d63637f6381a30f4ba9ae0d05149066733a599b06c2ba1f95be487e7"\n' +
    '  },\n' +
    '  "authSig": {\n' +
    '    "sig": "52347ec573c0f128862713589b98969636c48f52b08fa401e311fcc0083bb604078bc02a987fdd67750fb800c324847772023379b883af565768bce821d34d04",\n' +
    '    "derivedVia": "litSessionSignViaNacl",\n' +
    `    "signedMessage": "{\\"sessionKey\\":\\"249baa0a80c2b48588b072a98723047029abf25a3917b04d413851bce277d349\\",\\"resourceAbilityRequests\\":[{\\"resource\\":{\\"resource\\":\\"*\\",\\"resourcePrefix\\":\\"lit-pkp\\"},\\"ability\\":\\"pkp-signing\\"},{\\"resource\\":{\\"resource\\":\\"*\\",\\"resourcePrefix\\":\\"lit-litaction\\"},\\"ability\\":\\"lit-action-execution\\"}],\\"capabilities\\":[{\\"sig\\":\\"0xbecbcbb3f70d6c4aa40124eb27095cc043dd5cccfabbe0a75397586e3069f77a22d34a0dd1755a1e4518eb8073d3812462a82d2b41a542429d8a8b513636e21b1b\\",\\"derivedVia\\":\\"web3.eth.personal.sign\\",\\"signedMessage\\":\\"localhost wants you to sign in with your Ethereum account:\\\\n0x70997970C51812dc3A010C7d01b50e0d17dc79C8\\\\n\\\\nThis is a test statement.  You can put anything you want here. I further authorize the stated URI to perform the following actions on my behalf: (1) 'Auth': 'Auth' for 'lit-ratelimitincrease://23789'.\\\\n\\\\nURI: lit:capability:delegation\\\\nVersion: 1\\\\nChain ID: 1\\\\nNonce: 0x97cee5dde740e6cd3e8ca84c8780c78d3e476678fdac457df6303bec4f850717\\\\nIssued At: 2024-09-05T16:05:03.319Z\\\\nExpiration Time: 2024-09-12T16:05:03.314Z\\\\nResources:\\\\n- urn:recap:eyJhdHQiOnsibGl0LXJhdGVsaW1pdGluY3JlYXNlOi8vMjM3ODkiOnsiQXV0aC9BdXRoIjpbeyJuZnRfaWQiOlsiMjM3ODkiXSwidXNlcyI6IjIwMCJ9XX19LCJwcmYiOltdfQ\\",\\"address\\":\\"0x70997970C51812dc3A010C7d01b50e0d17dc79C8\\"},{\\"sig\\":\\"0x149b6a8b0f9cfc1bfbdf65628a86f2777c37a8b6b433ee446df100b5a5bef8bc1ea7e61e58d974309c04dffad21fa0de844fccabe7865ab46b4d5a4aa8f035ab1c\\",\\"derivedVia\\":\\"web3.eth.personal.sign\\",\\"signedMessage\\":\\"localhost wants you to sign in with your Ethereum account:\\\\n0x90F79bf6EB2c4f870365E785982E1f101E93b906\\\\n\\\\nThis is a test statement.  You can put anything you want here. I further authorize the stated URI to perform the following actions on my behalf: (1) 'Threshold': 'Execution' for 'lit-litaction://*'. (2) 'Threshold': 'Signing' for 'lit-pkp://*'.\\\\n\\\\nURI: lit:session:249baa0a80c2b48588b072a98723047029abf25a3917b04d413851bce277d349\\\\nVersion: 1\\\\nChain ID: 1\\\\nNonce: 0x97cee5dde740e6cd3e8ca84c8780c78d3e476678fdac457df6303bec4f850717\\\\nIssued At: 2024-09-05T16:05:05.575Z\\\\nExpiration Time: 2024-09-06T16:05:05.288Z\\\\nResources:\\\\n- urn:recap:eyJhdHQiOnsibGl0LWxpdGFjdGlvbjovLyoiOnsiVGhyZXNob2xkL0V4ZWN1dGlvbiI6W3t9XX0sImxpdC1wa3A6Ly8qIjp7IlRocmVzaG9sZC9TaWduaW5nIjpbe31dfX0sInByZiI6W119\\",\\"address\\":\\"0x90F79bf6EB2c4f870365E785982E1f101E93b906\\"}],\\"issuedAt\\":\\"2024-09-05T16:05:05.635Z\\",\\"expiration\\":\\"2024-09-06T16:05:05.288Z\\",\\"nodeAddress\\":\\"https://23.82.129.77:443\\"}",\n` +
    '    "address": "249baa0a80c2b48588b072a98723047029abf25a3917b04d413851bce277d349",\n' +
    '    "algo": "ed25519"\n' +
    '  },\n' +
    '  "epoch": 1594\n' +
    '}',
  '[Lit-JS-SDK v6.4.10]\x1B[36m[DEBUG]\x1B[0m [core] [id: 6e232dc7de4e] sendCommandToNode with url https://199.115.115.103:443/web/execute/v1 and data {\n' +
    '  "code": "KGFzeW5jICgpID0+IHsKICAgICAgY29uc3Qgc2lnU2hhcmUgPSBhd2FpdCBMaXRBY3Rpb25zLnNpZ25FY2RzYSh7CiAgICAgICAgdG9TaWduOiBkYXRhVG9TaWduLAogICAgICAgIHB1YmxpY0tleSwKICAgICAgICBzaWdOYW1lOiAic2lnIiwKICAgICAgfSk7CiAgICB9KSgpOw==",\n' +
    '  "jsParams": {\n' +
    '    "dataToSign": [\n' +
    '      125,\n' +
    '      135,\n' +
    '      197,\n' +
    '      234,\n' +
    '      117,\n' +
    '      247,\n' +
    '      55,\n' +
    '      139,\n' +
    '      183,\n' +
    '      1,\n' +
    '      228,\n' +
    '      4,\n' +
    '      197,\n' +
    '      6,\n' +
    '      57,\n' +
    '      22,\n' +
    '      26,\n' +
    '      243,\n' +
    '      239,\n' +
    '      246,\n' +
    '      98,\n' +
    '      147,\n' +
    '      233,\n' +
    '      243,\n' +
    '      117,\n' +
    '      181,\n' +
    '      241,\n' +
    '      126,\n' +
    '      181,\n' +
    '      4,\n' +
    '      118,\n' +
    '      244\n' +
    '    ],\n' +
    '    "publicKey": "0450ecc0e552c28998598d505e9453ce62ec84f06c2bfbb6a2704a6daa1e23435293c339e6d63637f6381a30f4ba9ae0d05149066733a599b06c2ba1f95be487e7"\n' +
    '  },\n' +
    '  "authSig": {\n' +
    '    "sig": "f2f23778175961e04da00ac972cff2ecefa9d8b49a6c5c8ccf1a8a8c5af10e66acd5830b1aa5dc0c7cf4cf304e7ae1b952ef40a64f429c58b9fa4ffe77b7e701",\n' +
    '    "derivedVia": "litSessionSignViaNacl",\n' +
    `    "signedMessage": "{\\"sessionKey\\":\\"249baa0a80c2b48588b072a98723047029abf25a3917b04d413851bce277d349\\",\\"resourceAbilityRequests\\":[{\\"resource\\":{\\"resource\\":\\"*\\",\\"resourcePrefix\\":\\"lit-pkp\\"},\\"ability\\":\\"pkp-signing\\"},{\\"resource\\":{\\"resource\\":\\"*\\",\\"resourcePrefix\\":\\"lit-litaction\\"},\\"ability\\":\\"lit-action-execution\\"}],\\"capabilities\\":[{\\"sig\\":\\"0xbecbcbb3f70d6c4aa40124eb27095cc043dd5cccfabbe0a75397586e3069f77a22d34a0dd1755a1e4518eb8073d3812462a82d2b41a542429d8a8b513636e21b1b\\",\\"derivedVia\\":\\"web3.eth.personal.sign\\",\\"signedMessage\\":\\"localhost wants you to sign in with your Ethereum account:\\\\n0x70997970C51812dc3A010C7d01b50e0d17dc79C8\\\\n\\\\nThis is a test statement.  You can put anything you want here. I further authorize the stated URI to perform the following actions on my behalf: (1) 'Auth': 'Auth' for 'lit-ratelimitincrease://23789'.\\\\n\\\\nURI: lit:capability:delegation\\\\nVersion: 1\\\\nChain ID: 1\\\\nNonce: 0x97cee5dde740e6cd3e8ca84c8780c78d3e476678fdac457df6303bec4f850717\\\\nIssued At: 2024-09-05T16:05:03.319Z\\\\nExpiration Time: 2024-09-12T16:05:03.314Z\\\\nResources:\\\\n- urn:recap:eyJhdHQiOnsibGl0LXJhdGVsaW1pdGluY3JlYXNlOi8vMjM3ODkiOnsiQXV0aC9BdXRoIjpbeyJuZnRfaWQiOlsiMjM3ODkiXSwidXNlcyI6IjIwMCJ9XX19LCJwcmYiOltdfQ\\",\\"address\\":\\"0x70997970C51812dc3A010C7d01b50e0d17dc79C8\\"},{\\"sig\\":\\"0x149b6a8b0f9cfc1bfbdf65628a86f2777c37a8b6b433ee446df100b5a5bef8bc1ea7e61e58d974309c04dffad21fa0de844fccabe7865ab46b4d5a4aa8f035ab1c\\",\\"derivedVia\\":\\"web3.eth.personal.sign\\",\\"signedMessage\\":\\"localhost wants you to sign in with your Ethereum account:\\\\n0x90F79bf6EB2c4f870365E785982E1f101E93b906\\\\n\\\\nThis is a test statement.  You can put anything you want here. I further authorize the stated URI to perform the following actions on my behalf: (1) 'Threshold': 'Execution' for 'lit-litaction://*'. (2) 'Threshold': 'Signing' for 'lit-pkp://*'.\\\\n\\\\nURI: lit:session:249baa0a80c2b48588b072a98723047029abf25a3917b04d413851bce277d349\\\\nVersion: 1\\\\nChain ID: 1\\\\nNonce: 0x97cee5dde740e6cd3e8ca84c8780c78d3e476678fdac457df6303bec4f850717\\\\nIssued At: 2024-09-05T16:05:05.575Z\\\\nExpiration Time: 2024-09-06T16:05:05.288Z\\\\nResources:\\\\n- urn:recap:eyJhdHQiOnsibGl0LWxpdGFjdGlvbjovLyoiOnsiVGhyZXNob2xkL0V4ZWN1dGlvbiI6W3t9XX0sImxpdC1wa3A6Ly8qIjp7IlRocmVzaG9sZC9TaWduaW5nIjpbe31dfX0sInByZiI6W119\\",\\"address\\":\\"0x90F79bf6EB2c4f870365E785982E1f101E93b906\\"}],\\"issuedAt\\":\\"2024-09-05T16:05:05.635Z\\",\\"expiration\\":\\"2024-09-06T16:05:05.288Z\\",\\"nodeAddress\\":\\"https://199.115.115.103:443\\"}",\n` +
    '    "address": "249baa0a80c2b48588b072a98723047029abf25a3917b04d413851bce277d349",\n' +
    '    "algo": "ed25519"\n' +
    '  },\n' +
    '  "epoch": 1594\n' +
    '}',
  '[Lit-JS-SDK v6.4.10]\x1B[36m[DEBUG]\x1B[0m [core] [id: 6e232dc7de4e] sendCommandToNode with url https://104.245.147.218:443/web/execute/v1 and data {\n' +
    '  "code": "KGFzeW5jICgpID0+IHsKICAgICAgY29uc3Qgc2lnU2hhcmUgPSBhd2FpdCBMaXRBY3Rpb25zLnNpZ25FY2RzYSh7CiAgICAgICAgdG9TaWduOiBkYXRhVG9TaWduLAogICAgICAgIHB1YmxpY0tleSwKICAgICAgICBzaWdOYW1lOiAic2lnIiwKICAgICAgfSk7CiAgICB9KSgpOw==",\n' +
    '  "jsParams": {\n' +
    '    "dataToSign": [\n' +
    '      125,\n' +
    '      135,\n' +
    '      197,\n' +
    '      234,\n' +
    '      117,\n' +
    '      247,\n' +
    '      55,\n' +
    '      139,\n' +
    '      183,\n' +
    '      1,\n' +
    '      228,\n' +
    '      4,\n' +
    '      197,\n' +
    '      6,\n' +
    '      57,\n' +
    '      22,\n' +
    '      26,\n' +
    '      243,\n' +
    '      239,\n' +
    '      246,\n' +
    '      98,\n' +
    '      147,\n' +
    '      233,\n' +
    '      243,\n' +
    '      117,\n' +
    '      181,\n' +
    '      241,\n' +
    '      126,\n' +
    '      181,\n' +
    '      4,\n' +
    '      118,\n' +
    '      244\n' +
    '    ],\n' +
    '    "publicKey": "0450ecc0e552c28998598d505e9453ce62ec84f06c2bfbb6a2704a6daa1e23435293c339e6d63637f6381a30f4ba9ae0d05149066733a599b06c2ba1f95be487e7"\n' +
    '  },\n' +
    '  "authSig": {\n' +
    '    "sig": "9d3cf6190cc3e70770e8ab998a0224818468aee4b75e3e531ea1e26a0e4d5d3701698edc2474d42c666471cea773756eff721c1ae35e16322dc90d7182ca3002",\n' +
    '    "derivedVia": "litSessionSignViaNacl",\n' +
    `    "signedMessage": "{\\"sessionKey\\":\\"249baa0a80c2b48588b072a98723047029abf25a3917b04d413851bce277d349\\",\\"resourceAbilityRequests\\":[{\\"resource\\":{\\"resource\\":\\"*\\",\\"resourcePrefix\\":\\"lit-pkp\\"},\\"ability\\":\\"pkp-signing\\"},{\\"resource\\":{\\"resource\\":\\"*\\",\\"resourcePrefix\\":\\"lit-litaction\\"},\\"ability\\":\\"lit-action-execution\\"}],\\"capabilities\\":[{\\"sig\\":\\"0xbecbcbb3f70d6c4aa40124eb27095cc043dd5cccfabbe0a75397586e3069f77a22d34a0dd1755a1e4518eb8073d3812462a82d2b41a542429d8a8b513636e21b1b\\",\\"derivedVia\\":\\"web3.eth.personal.sign\\",\\"signedMessage\\":\\"localhost wants you to sign in with your Ethereum account:\\\\n0x70997970C51812dc3A010C7d01b50e0d17dc79C8\\\\n\\\\nThis is a test statement.  You can put anything you want here. I further authorize the stated URI to perform the following actions on my behalf: (1) 'Auth': 'Auth' for 'lit-ratelimitincrease://23789'.\\\\n\\\\nURI: lit:capability:delegation\\\\nVersion: 1\\\\nChain ID: 1\\\\nNonce: 0x97cee5dde740e6cd3e8ca84c8780c78d3e476678fdac457df6303bec4f850717\\\\nIssued At: 2024-09-05T16:05:03.319Z\\\\nExpiration Time: 2024-09-12T16:05:03.314Z\\\\nResources:\\\\n- urn:recap:eyJhdHQiOnsibGl0LXJhdGVsaW1pdGluY3JlYXNlOi8vMjM3ODkiOnsiQXV0aC9BdXRoIjpbeyJuZnRfaWQiOlsiMjM3ODkiXSwidXNlcyI6IjIwMCJ9XX19LCJwcmYiOltdfQ\\",\\"address\\":\\"0x70997970C51812dc3A010C7d01b50e0d17dc79C8\\"},{\\"sig\\":\\"0x149b6a8b0f9cfc1bfbdf65628a86f2777c37a8b6b433ee446df100b5a5bef8bc1ea7e61e58d974309c04dffad21fa0de844fccabe7865ab46b4d5a4aa8f035ab1c\\",\\"derivedVia\\":\\"web3.eth.personal.sign\\",\\"signedMessage\\":\\"localhost wants you to sign in with your Ethereum account:\\\\n0x90F79bf6EB2c4f870365E785982E1f101E93b906\\\\n\\\\nThis is a test statement.  You can put anything you want here. I further authorize the stated URI to perform the following actions on my behalf: (1) 'Threshold': 'Execution' for 'lit-litaction://*'. (2) 'Threshold': 'Signing' for 'lit-pkp://*'.\\\\n\\\\nURI: lit:session:249baa0a80c2b48588b072a98723047029abf25a3917b04d413851bce277d349\\\\nVersion: 1\\\\nChain ID: 1\\\\nNonce: 0x97cee5dde740e6cd3e8ca84c8780c78d3e476678fdac457df6303bec4f850717\\\\nIssued At: 2024-09-05T16:05:05.575Z\\\\nExpiration Time: 2024-09-06T16:05:05.288Z\\\\nResources:\\\\n- urn:recap:eyJhdHQiOnsibGl0LWxpdGFjdGlvbjovLyoiOnsiVGhyZXNob2xkL0V4ZWN1dGlvbiI6W3t9XX0sImxpdC1wa3A6Ly8qIjp7IlRocmVzaG9sZC9TaWduaW5nIjpbe31dfX0sInByZiI6W119\\",\\"address\\":\\"0x90F79bf6EB2c4f870365E785982E1f101E93b906\\"}],\\"issuedAt\\":\\"2024-09-05T16:05:05.635Z\\",\\"expiration\\":\\"2024-09-06T16:05:05.288Z\\",\\"nodeAddress\\":\\"https://104.245.147.218:443\\"}",\n` +
    '    "address": "249baa0a80c2b48588b072a98723047029abf25a3917b04d413851bce277d349",\n' +
    '    "algo": "ed25519"\n' +
    '  },\n' +
    '  "epoch": 1594\n' +
    '}',
  '[Lit-JS-SDK v6.4.10]\x1B[36m[DEBUG]\x1B[0m [core] [id: 6e232dc7de4e] sendCommandToNode with url https://178.162.172.88:443/web/execute/v1 and data {\n' +
    '  "code": "KGFzeW5jICgpID0+IHsKICAgICAgY29uc3Qgc2lnU2hhcmUgPSBhd2FpdCBMaXRBY3Rpb25zLnNpZ25FY2RzYSh7CiAgICAgICAgdG9TaWduOiBkYXRhVG9TaWduLAogICAgICAgIHB1YmxpY0tleSwKICAgICAgICBzaWdOYW1lOiAic2lnIiwKICAgICAgfSk7CiAgICB9KSgpOw==",\n' +
    '  "jsParams": {\n' +
    '    "dataToSign": [\n' +
    '      125,\n' +
    '      135,\n' +
    '      197,\n' +
    '      234,\n' +
    '      117,\n' +
    '      247,\n' +
    '      55,\n' +
    '      139,\n' +
    '      183,\n' +
    '      1,\n' +
    '      228,\n' +
    '      4,\n' +
    '      197,\n' +
    '      6,\n' +
    '      57,\n' +
    '      22,\n' +
    '      26,\n' +
    '      243,\n' +
    '      239,\n' +
    '      246,\n' +
    '      98,\n' +
    '      147,\n' +
    '      233,\n' +
    '      243,\n' +
    '      117,\n' +
    '      181,\n' +
    '      241,\n' +
    '      126,\n' +
    '      181,\n' +
    '      4,\n' +
    '      118,\n' +
    '      244\n' +
    '    ],\n' +
    '    "publicKey": "0450ecc0e552c28998598d505e9453ce62ec84f06c2bfbb6a2704a6daa1e23435293c339e6d63637f6381a30f4ba9ae0d05149066733a599b06c2ba1f95be487e7"\n' +
    '  },\n' +
    '  "authSig": {\n' +
    '    "sig": "056db9d73882ac5c082a2b3a31c0f292b4f4c3262f78c5c8ee4eb1d1f806dce32a2d0daae75b9a789fbcec0b8ca410358b8b86456908f68168c1da85283bfb04",\n' +
    '    "derivedVia": "litSessionSignViaNacl",\n' +
    `    "signedMessage": "{\\"sessionKey\\":\\"249baa0a80c2b48588b072a98723047029abf25a3917b04d413851bce277d349\\",\\"resourceAbilityRequests\\":[{\\"resource\\":{\\"resource\\":\\"*\\",\\"resourcePrefix\\":\\"lit-pkp\\"},\\"ability\\":\\"pkp-signing\\"},{\\"resource\\":{\\"resource\\":\\"*\\",\\"resourcePrefix\\":\\"lit-litaction\\"},\\"ability\\":\\"lit-action-execution\\"}],\\"capabilities\\":[{\\"sig\\":\\"0xbecbcbb3f70d6c4aa40124eb27095cc043dd5cccfabbe0a75397586e3069f77a22d34a0dd1755a1e4518eb8073d3812462a82d2b41a542429d8a8b513636e21b1b\\",\\"derivedVia\\":\\"web3.eth.personal.sign\\",\\"signedMessage\\":\\"localhost wants you to sign in with your Ethereum account:\\\\n0x70997970C51812dc3A010C7d01b50e0d17dc79C8\\\\n\\\\nThis is a test statement.  You can put anything you want here. I further authorize the stated URI to perform the following actions on my behalf: (1) 'Auth': 'Auth' for 'lit-ratelimitincrease://23789'.\\\\n\\\\nURI: lit:capability:delegation\\\\nVersion: 1\\\\nChain ID: 1\\\\nNonce: 0x97cee5dde740e6cd3e8ca84c8780c78d3e476678fdac457df6303bec4f850717\\\\nIssued At: 2024-09-05T16:05:03.319Z\\\\nExpiration Time: 2024-09-12T16:05:03.314Z\\\\nResources:\\\\n- urn:recap:eyJhdHQiOnsibGl0LXJhdGVsaW1pdGluY3JlYXNlOi8vMjM3ODkiOnsiQXV0aC9BdXRoIjpbeyJuZnRfaWQiOlsiMjM3ODkiXSwidXNlcyI6IjIwMCJ9XX19LCJwcmYiOltdfQ\\",\\"address\\":\\"0x70997970C51812dc3A010C7d01b50e0d17dc79C8\\"},{\\"sig\\":\\"0x149b6a8b0f9cfc1bfbdf65628a86f2777c37a8b6b433ee446df100b5a5bef8bc1ea7e61e58d974309c04dffad21fa0de844fccabe7865ab46b4d5a4aa8f035ab1c\\",\\"derivedVia\\":\\"web3.eth.personal.sign\\",\\"signedMessage\\":\\"localhost wants you to sign in with your Ethereum account:\\\\n0x90F79bf6EB2c4f870365E785982E1f101E93b906\\\\n\\\\nThis is a test statement.  You can put anything you want here. I further authorize the stated URI to perform the following actions on my behalf: (1) 'Threshold': 'Execution' for 'lit-litaction://*'. (2) 'Threshold': 'Signing' for 'lit-pkp://*'.\\\\n\\\\nURI: lit:session:249baa0a80c2b48588b072a98723047029abf25a3917b04d413851bce277d349\\\\nVersion: 1\\\\nChain ID: 1\\\\nNonce: 0x97cee5dde740e6cd3e8ca84c8780c78d3e476678fdac457df6303bec4f850717\\\\nIssued At: 2024-09-05T16:05:05.575Z\\\\nExpiration Time: 2024-09-06T16:05:05.288Z\\\\nResources:\\\\n- urn:recap:eyJhdHQiOnsibGl0LWxpdGFjdGlvbjovLyoiOnsiVGhyZXNob2xkL0V4ZWN1dGlvbiI6W3t9XX0sImxpdC1wa3A6Ly8qIjp7IlRocmVzaG9sZC9TaWduaW5nIjpbe31dfX0sInByZiI6W119\\",\\"address\\":\\"0x90F79bf6EB2c4f870365E785982E1f101E93b906\\"}],\\"issuedAt\\":\\"2024-09-05T16:05:05.635Z\\",\\"expiration\\":\\"2024-09-06T16:05:05.288Z\\",\\"nodeAddress\\":\\"https://178.162.172.88:443\\"}",\n` +
    '    "address": "249baa0a80c2b48588b072a98723047029abf25a3917b04d413851bce277d349",\n' +
    '    "algo": "ed25519"\n' +
    '  },\n' +
    '  "epoch": 1594\n' +
    '}',
  '[Lit-JS-SDK v6.4.10]\x1B[36m[DEBUG]\x1B[0m [core] [id: 6e232dc7de4e] executeJs responseData from node :  [\n' +
    '  {\n' +
    '    "success": true,\n' +
    '    "signedData": {\n' +
    '      "sig": {\n' +
    '        "sigType": "K256",\n' +
    '        "dataSigned": "fail",\n' +
    '        "signatureShare": "",\n' +
    '        "shareIndex": 0,\n' +
    '        "bigR": "",\n' +
    '        "publicKey": "",\n' +
    '        "sigName": "sig"\n' +
    '      }\n' +
    '    },\n' +
    '    "decryptedData": {},\n' +
    '    "claimData": {},\n' +
    '    "response": "",\n' +
    '    "logs": ""\n' +
    '  },\n' +
    '  {\n' +
    '    "success": true,\n' +
    '    "signedData": {\n' +
    '      "sig": {\n' +
    '        "sigType": "K256",\n' +
    '        "dataSigned": "fail",\n' +
    '        "signatureShare": "",\n' +
    '        "shareIndex": 0,\n' +
    '        "bigR": "",\n' +
    '        "publicKey": "",\n' +
    '        "sigName": "sig"\n' +
    '      }\n' +
    '    },\n' +
    '    "decryptedData": {},\n' +
    '    "claimData": {},\n' +
    '    "response": "",\n' +
    '    "logs": ""\n' +
    '  },\n' +
    '  {\n' +
    '    "success": true,\n' +
    '    "signedData": {\n' +
    '      "sig": {\n' +
    '        "sigType": "K256",\n' +
    '        "dataSigned": "fail",\n' +
    '        "signatureShare": "",\n' +
    '        "shareIndex": 0,\n' +
    '        "bigR": "",\n' +
    '        "publicKey": "",\n' +
    '        "sigName": "sig"\n' +
    '      }\n' +
    '    },\n' +
    '    "decryptedData": {},\n' +
    '    "claimData": {},\n' +
    '    "response": "",\n' +
    '    "logs": ""\n' +
    '  },\n' +
    '  {\n' +
    '    "success": true,\n' +
    '    "signedData": {\n' +
    '      "sig": {\n' +
    '        "sigType": "K256",\n' +
    '        "dataSigned": "\\"7D87C5EA75F7378BB701E404C50639161AF3EFF66293E9F375B5F17EB50476F4\\"",\n' +
    '        "signatureShare": "\\"504157934EFD1F85F65B06F3C4ABCCF1E94059704B7146C91702977B4576864D\\"",\n' +
    '        "shareIndex": 0,\n' +
    '        "bigR": "\\"02FF5C623A2A4B6E8613B8C96CABB422FF5EDC429276191BC9C7128957AB543E80\\"",\n' +
    '        "publicKey": "\\"0450ECC0E552C28998598D505E9453CE62EC84F06C2BFBB6A2704A6DAA1E23435293C339E6D63637F6381A30F4BA9AE0D05149066733A599B06C2BA1F95BE487E7\\"",\n' +
    '        "sigName": "sig"\n' +
    '      }\n' +
    '    },\n' +
    '    "decryptedData": {},\n' +
    '    "claimData": {},\n' +
    '    "response": "",\n' +
    '    "logs": ""\n' +
    '  },\n' +
    '  {\n' +
    '    "success": true,\n' +
    '    "signedData": {\n' +
    '      "sig": {\n' +
    '        "sigType": "K256",\n' +
    '        "dataSigned": "\\"7D87C5EA75F7378BB701E404C50639161AF3EFF66293E9F375B5F17EB50476F4\\"",\n' +
    '        "signatureShare": "\\"789C6CFE63AE1CE419B1BBA78E5E3F54E7F4CCC859AE84CE32113C202F56A026\\"",\n' +
    '        "shareIndex": 0,\n' +
    '        "bigR": "\\"02FF5C623A2A4B6E8613B8C96CABB422FF5EDC429276191BC9C7128957AB543E80\\"",\n' +
    '        "publicKey": "\\"0450ECC0E552C28998598D505E9453CE62EC84F06C2BFBB6A2704A6DAA1E23435293C339E6D63637F6381A30F4BA9AE0D05149066733A599B06C2BA1F95BE487E7\\"",\n' +
    '        "sigName": "sig"\n' +
    '      }\n' +
    '    },\n' +
    '    "decryptedData": {},\n' +
    '    "claimData": {},\n' +
    '    "response": "",\n' +
    '    "logs": ""\n' +
    '  },\n' +
    '  {\n' +
    '    "success": true,\n' +
    '    "signedData": {\n' +
    '      "sig": {\n' +
    '        "sigType": "K256",\n' +
    '        "dataSigned": "\\"7D87C5EA75F7378BB701E404C50639161AF3EFF66293E9F375B5F17EB50476F4\\"",\n' +
    '        "signatureShare": "\\"682452B8BB1CBF447F51765AE4A344A4F6172FE26443C1241F2823EE14388C47\\"",\n' +
    '        "shareIndex": 0,\n' +
    '        "bigR": "\\"02FF5C623A2A4B6E8613B8C96CABB422FF5EDC429276191BC9C7128957AB543E80\\"",\n' +
    '        "publicKey": "\\"0450ECC0E552C28998598D505E9453CE62EC84F06C2BFBB6A2704A6DAA1E23435293C339E6D63637F6381A30F4BA9AE0D05149066733A599B06C2BA1F95BE487E7\\"",\n' +
    '        "sigName": "sig"\n' +
    '      }\n' +
    '    },\n' +
    '    "decryptedData": {},\n' +
    '    "claimData": {},\n' +
    '    "response": "",\n' +
    '    "logs": ""\n' +
    '  },\n' +
    '  {\n' +
    '    "success": true,\n' +
    '    "signedData": {\n' +
    '      "sig": {\n' +
    '        "sigType": "K256",\n' +
    '        "dataSigned": "\\"7D87C5EA75F7378BB701E404C50639161AF3EFF66293E9F375B5F17EB50476F4\\"",\n' +
    '        "signatureShare": "\\"A2161D02D181C17F3442E7727631C100F9AD511EB75A057B071226D56C79F890\\"",\n' +
    '        "shareIndex": 0,\n' +
    '        "bigR": "\\"02FF5C623A2A4B6E8613B8C96CABB422FF5EDC429276191BC9C7128957AB543E80\\"",\n' +
    '        "publicKey": "\\"0450ECC0E552C28998598D505E9453CE62EC84F06C2BFBB6A2704A6DAA1E23435293C339E6D63637F6381A30F4BA9AE0D05149066733A599B06C2BA1F95BE487E7\\"",\n' +
    '        "sigName": "sig"\n' +
    '      }\n' +
    '    },\n' +
    '    "decryptedData": {},\n' +
    '    "claimData": {},\n' +
    '    "response": "",\n' +
    '    "logs": ""\n' +
    '  }\n' +
    ']',
  '[Lit-JS-SDK v6.4.10]\x1B[36m[DEBUG]\x1B[0m [core] [id: 6e232dc7de4e] signatures shares to combine:  [\n' +
    '  {},\n' +
    '  {},\n' +
    '  {},\n' +
    '  {\n' +
    '    "sig": {\n' +
    '      "sigType": "K256",\n' +
    '      "signatureShare": "504157934EFD1F85F65B06F3C4ABCCF1E94059704B7146C91702977B4576864D",\n' +
    '      "shareIndex": 0,\n' +
    '      "bigR": "02FF5C623A2A4B6E8613B8C96CABB422FF5EDC429276191BC9C7128957AB543E80",\n' +
    '      "publicKey": "0450ECC0E552C28998598D505E9453CE62EC84F06C2BFBB6A2704A6DAA1E23435293C339E6D63637F6381A30F4BA9AE0D05149066733A599B06C2BA1F95BE487E7",\n' +
    '      "dataSigned": "7D87C5EA75F7378BB701E404C50639161AF3EFF66293E9F375B5F17EB50476F4",\n' +
    '      "sigName": "sig"\n' +
    '    }\n' +
    '  },\n' +
    '  {\n' +
    '    "sig": {\n' +
    '      "sigType": "K256",\n' +
    '      "signatureShare": "789C6CFE63AE1CE419B1BBA78E5E3F54E7F4CCC859AE84CE32113C202F56A026",\n' +
    '      "shareIndex": 0,\n' +
    '      "bigR": "02FF5C623A2A4B6E8613B8C96CABB422FF5EDC429276191BC9C7128957AB543E80",\n' +
    '      "publicKey": "0450ECC0E552C28998598D505E9453CE62EC84F06C2BFBB6A2704A6DAA1E23435293C339E6D63637F6381A30F4BA9AE0D05149066733A599B06C2BA1F95BE487E7",\n' +
    '      "dataSigned": "7D87C5EA75F7378BB701E404C50639161AF3EFF66293E9F375B5F17EB50476F4",\n' +
    '      "sigName": "sig"\n' +
    '    }\n' +
    '  },\n' +
    '  {\n' +
    '    "sig": {\n' +
    '      "sigType": "K256",\n' +
    '      "signatureShare": "682452B8BB1CBF447F51765AE4A344A4F6172FE26443C1241F2823EE14388C47",\n' +
    '      "shareIndex": 0,\n' +
    '      "bigR": "02FF5C623A2A4B6E8613B8C96CABB422FF5EDC429276191BC9C7128957AB543E80",\n' +
    '      "publicKey": "0450ECC0E552C28998598D505E9453CE62EC84F06C2BFBB6A2704A6DAA1E23435293C339E6D63637F6381A30F4BA9AE0D05149066733A599B06C2BA1F95BE487E7",\n' +
    '      "dataSigned": "7D87C5EA75F7378BB701E404C50639161AF3EFF66293E9F375B5F17EB50476F4",\n' +
    '      "sigName": "sig"\n' +
    '    }\n' +
    '  },\n' +
    '  {\n' +
    '    "sig": {\n' +
    '      "sigType": "K256",\n' +
    '      "signatureShare": "A2161D02D181C17F3442E7727631C100F9AD511EB75A057B071226D56C79F890",\n' +
    '      "shareIndex": 0,\n' +
    '      "bigR": "02FF5C623A2A4B6E8613B8C96CABB422FF5EDC429276191BC9C7128957AB543E80",\n' +
    '      "publicKey": "0450ECC0E552C28998598D505E9453CE62EC84F06C2BFBB6A2704A6DAA1E23435293C339E6D63637F6381A30F4BA9AE0D05149066733A599B06C2BA1F95BE487E7",\n' +
    '      "dataSigned": "7D87C5EA75F7378BB701E404C50639161AF3EFF66293E9F375B5F17EB50476F4",\n' +
    '      "sigName": "sig"\n' +
    '    }\n' +
    '  }\n' +
    ']',
  '[Lit-JS-SDK v6.4.10]\x1B[36m[DEBUG]\x1B[0m [core] [id: 6e232dc7de4e] invalid field signatureShare in signature share: sig, continuing with share processing',
  '[Lit-JS-SDK v6.4.10]\x1B[36m[DEBUG]\x1B[0m [core] [id: 6e232dc7de4e] starting signature combine for sig name: sig [\n' +
    '  {\n' +
    '    "sigType": "K256",\n' +
    '    "signatureShare": "504157934EFD1F85F65B06F3C4ABCCF1E94059704B7146C91702977B4576864D",\n' +
    '    "shareIndex": 0,\n' +
    '    "bigR": "02FF5C623A2A4B6E8613B8C96CABB422FF5EDC429276191BC9C7128957AB543E80",\n' +
    '    "publicKey": "0450ECC0E552C28998598D505E9453CE62EC84F06C2BFBB6A2704A6DAA1E23435293C339E6D63637F6381A30F4BA9AE0D05149066733A599B06C2BA1F95BE487E7",\n' +
    '    "dataSigned": "7D87C5EA75F7378BB701E404C50639161AF3EFF66293E9F375B5F17EB50476F4",\n' +
    '    "sigName": "sig"\n' +
    '  },\n' +
    '  {\n' +
    '    "sigType": "K256",\n' +
    '    "signatureShare": "789C6CFE63AE1CE419B1BBA78E5E3F54E7F4CCC859AE84CE32113C202F56A026",\n' +
    '    "shareIndex": 0,\n' +
    '    "bigR": "02FF5C623A2A4B6E8613B8C96CABB422FF5EDC429276191BC9C7128957AB543E80",\n' +
    '    "publicKey": "0450ECC0E552C28998598D505E9453CE62EC84F06C2BFBB6A2704A6DAA1E23435293C339E6D63637F6381A30F4BA9AE0D05149066733A599B06C2BA1F95BE487E7",\n' +
    '    "dataSigned": "7D87C5EA75F7378BB701E404C50639161AF3EFF66293E9F375B5F17EB50476F4",\n' +
    '    "sigName": "sig"\n' +
    '  },\n' +
    '  {\n' +
    '    "sigType": "K256",\n' +
    '    "signatureShare": "682452B8BB1CBF447F51765AE4A344A4F6172FE26443C1241F2823EE14388C47",\n' +
    '    "shareIndex": 0,\n' +
    '    "bigR": "02FF5C623A2A4B6E8613B8C96CABB422FF5EDC429276191BC9C7128957AB543E80",\n' +
    '    "publicKey": "0450ECC0E552C28998598D505E9453CE62EC84F06C2BFBB6A2704A6DAA1E23435293C339E6D63637F6381A30F4BA9AE0D05149066733A599B06C2BA1F95BE487E7",\n' +
    '    "dataSigned": "7D87C5EA75F7378BB701E404C50639161AF3EFF66293E9F375B5F17EB50476F4",\n' +
    '    "sigName": "sig"\n' +
    '  },\n' +
    '  {\n' +
    '    "sigType": "K256",\n' +
    '    "signatureShare": "A2161D02D181C17F3442E7727631C100F9AD511EB75A057B071226D56C79F890",\n' +
    '    "shareIndex": 0,\n' +
    '    "bigR": "02FF5C623A2A4B6E8613B8C96CABB422FF5EDC429276191BC9C7128957AB543E80",\n' +
    '    "publicKey": "0450ECC0E552C28998598D505E9453CE62EC84F06C2BFBB6A2704A6DAA1E23435293C339E6D63637F6381A30F4BA9AE0D05149066733A599B06C2BA1F95BE487E7",\n' +
    '    "dataSigned": "7D87C5EA75F7378BB701E404C50639161AF3EFF66293E9F375B5F17EB50476F4",\n' +
    '    "sigName": "sig"\n' +
    '  }\n' +
    ']',
  '[Lit-JS-SDK v6.4.10]\x1B[36m[DEBUG]\x1B[0m [core] [id: 6e232dc7de4e] number of shares for sig: 7',
  '[Lit-JS-SDK v6.4.10]\x1B[36m[DEBUG]\x1B[0m [core] [id: 6e232dc7de4e] validated length for signature: sig 4',
  '[Lit-JS-SDK v6.4.10]\x1B[36m[DEBUG]\x1B[0m [core] [id: 6e232dc7de4e] minimum required shares for threshold: 4'
]
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
