### PR TITLE
fix: add support for different os types for the sed shell script command

### DIFF
--- a/packages/wrapped-keys/build-bc.sh
+++ b/packages/wrapped-keys/build-bc.sh
@@ -8,4 +8,27 @@ set -e
 cp -r ../../dist/packages/wrapped-keys ../../dist/packages/wrapped-keys-bc
 yarn bundle
 cp -r ../wrapped-keys/src/lib/generated/litActions ../../dist/packages/wrapped-keys-bc/src/lib/generated
-sed -i 's/wrapped-keys/wrapped-keys-bc/' ../../dist/packages/wrapped-keys-bc/package.json
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  # Linux
+  sed -i 's/wrapped-keys/wrapped-keys-bc/' ../../dist/packages/wrapped-keys-bc/package.json
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  # Mac OSX
+  sed -i '' 's/wrapped-keys/wrapped-keys-bc/' ../../dist/packages/wrapped-keys-bc/package.json
+elif [[ "$OSTYPE" == "cygwin" ]]; then
+  # POSIX compatibility layer and Linux environment emulation for Windows
+  sed -i 's/wrapped-keys/wrapped-keys-bc/' ../../dist/packages/wrapped-keys-bc/package.json
+elif [[ "$OSTYPE" == "msys" ]]; then
+  # Lightweight shell and GNU utilities compiled for Windows (part of MinGW)
+  sed -i 's/wrapped-keys/wrapped-keys-bc/' ../../dist/packages/wrapped-keys-bc/package.json
+elif [[ "$OSTYPE" == "win32" ]]; then
+  # I'm not sure this can happen.
+  echo "win32 detected, sed might not be supported in this environment."
+elif [[ "$OSTYPE" == "freebsd"* ]]; then
+  # FreeBSD
+  echo "FreeBSD detected, sed -i might not be supported."
+else
+  # Unknown OS
+  echo "Unknown operating system: $OSTYPE. sed -i might not be supported."
+fi
+´

--- a/packages/wrapped-keys/build-bc.sh
+++ b/packages/wrapped-keys/build-bc.sh
@@ -31,4 +31,3 @@ else
   # Unknown OS
   echo "Unknown operating system: $OSTYPE. sed -i might not be supported."
 fi
-´


### PR DESCRIPTION
Add support for different OS type when executing `sed` command in a shell script. Previously it was only working on Linux (GNU sed), but we need it to work on macOs as well (BSD sed)