### PR TITLE
chore: remove unused `rateLimitAuthSig` function

### DIFF
--- a/packages/auth-helpers/src/lib/models.ts
+++ b/packages/auth-helpers/src/lib/models.ts
@@ -135,11 +135,6 @@ export interface ISessionCapabilityObject {
    * resource.
    */
   addAllCapabilitiesForResource(litResource: ILitResource): void;
-
-  /**
-   * The AuthSig they insert would own a rate limit nft and can put restrictions on how it * can be used.
-   */
-  addRateLimitAuthSig(authSig: AuthSig): Promise<void>;
 }
 
 export interface ILitResource {

--- a/packages/auth-helpers/src/lib/recap/recap-session-capability-object.spec.ts
+++ b/packages/auth-helpers/src/lib/recap/recap-session-capability-object.spec.ts
@@ -104,38 +104,6 @@ describe('recapSessionCapabilityObject', () => {
     expect(recapSessionCapabilityObject.attenuations).toEqual(att);
   });
 
-  // it('shold be able to add rate limit auth sig', async () => {
-  //   const att = {
-  //     someResource: {
-  //       'lit-ratelimitincrease/1337': [{}],
-  //     },
-  //   };
-
-  //   const recapSessionCapabilityObject = new RecapSessionCapabilityObject(
-  //     att,
-  //     []
-  //   );
-
-  //   const mockAuthSig = {
-  //     sig: '0x137b66529678d1fc58ab5b340ad036082af5b9912f823ba22c2851b8f50990a666ad8f2ab2328e8c94414c0a870163743bde91a5f96e9f967fd45d5e0c17c3911b',
-  //     derivedVia: 'web3.eth.personal.sign',
-  //     signedMessage:
-  //       'localhost wants you to sign in with your Ethereum account:\n0xeF71c2604f17Ec6Fc13409DF24EfdC440D240d37\n\nTESTING TESTING 123\n\nURI: https://localhost/login\nVersion: 1\nChain ID: 1\nNonce: eoeo0dsvyLL2gcHsC\nIssued At: 2023-11-17T15:04:20.324Z\nExpiration Time: 2215-07-14T15:04:20.323Z',
-  //     address: '0xeF71c2604f17Ec6Fc13409DF24EfdC440D240d37',
-  //   };
-
-  //   await recapSessionCapabilityObject.addRateLimitAuthSig(mockAuthSig);
-
-  //   expect(recapSessionCapabilityObject.attenuations).toEqual({
-  //     someResource: {
-  //       'lit-ratelimitincrease/1337': [{}],
-  //     },
-  //   });
-  //   expect(recapSessionCapabilityObject.proofs[0]).toBe(
-  //     'QmQiy7M88uboUkSF68Hv73NWL8dnrbMNZmbstVVi3UVrgM'
-  //   );
-  // });
-
   it('should be able to get proofs', async () => {
     const recapSessionCapabilityObject = new RecapSessionCapabilityObject({}, [
       dummyCID,

--- a/packages/auth-helpers/src/lib/recap/recap-session-capability-object.ts
+++ b/packages/auth-helpers/src/lib/recap/recap-session-capability-object.ts
@@ -22,13 +22,6 @@ export class RecapSessionCapabilityObject implements ISessionCapabilityObject {
     this._inner = new Recap(att, prf);
   }
 
-  /**
-   * @deprecated - to be removed, as it's not used.
-   */
-  async addRateLimitAuthSig(authSig: AuthSig) {
-    throw new Error('Not implemented yet. ');
-  }
-
   static decode(encoded: string): RecapSessionCapabilityObject {
     const recap = Recap.decode_urn(encoded);
     return new this(

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -282,8 +282,7 @@ export class LitNodeClientNodeJs
    */
   static async generateSessionCapabilityObjectWithWildcards(
     litResources: ILitResource[],
-    addAllCapabilities?: boolean,
-    rateLimitAuthSig?: AuthSig
+    addAllCapabilities?: boolean
   ): Promise<ISessionCapabilityObject> {
     const sessionCapabilityObject = new RecapSessionCapabilityObject({}, []);
 
@@ -294,11 +293,6 @@ export class LitNodeClientNodeJs
       for (const litResource of litResources) {
         sessionCapabilityObject.addAllCapabilitiesForResource(litResource);
       }
-    }
-
-    if (rateLimitAuthSig) {
-      throw new Error('Not implemented yet.');
-      // await sessionCapabilityObject.addRateLimitAuthSig(rateLimitAuthSig);
     }
 
     return sessionCapabilityObject;

--- a/packages/types/src/lib/models.ts
+++ b/packages/types/src/lib/models.ts
@@ -128,11 +128,6 @@ export interface ISessionCapabilityObject {
    * resource.
    */
   addAllCapabilitiesForResource(litResource: ILitResource): void;
-
-  /**
-   * The AuthSig they insert would own a rate limit nft and can put restrictions on how it * can be used.
-   */
-  addRateLimitAuthSig(authSig: AuthSig): Promise<void>;
 }
 
 export interface ILitResource {


### PR DESCRIPTION
# Description

addRateLimitAuthSig is not used anywhere in the codebase. It was a leftover from the auth unification project that we forgot to remove.