### PR TITLE
feat: add skipFetchSetup to ethers providers constructor

### DIFF
--- a/local-tests/setup/shiva-client.ts
+++ b/local-tests/setup/shiva-client.ts
@@ -92,9 +92,10 @@ export class TestnetClient {
     const networkContext = {
       abi: JSON.parse(contractResolverAbi),
       resolverAddress: contractResolverAddress,
-      provider: new ethers.providers.StaticJsonRpcProvider(
-        `http://${testNetConfig.rpcUrl}`
-      ),
+       provider: new ethers.providers.StaticJsonRpcProvider({
+        url: `http://${testNetConfig.rpcUrl}`,
+        skipFetchSetup: true,
+      }),
       environment: 0, // test deployment uses env value 0 in test common
     };
     return networkContext;

--- a/local-tests/setup/shiva-client.ts
+++ b/local-tests/setup/shiva-client.ts
@@ -92,7 +92,7 @@ export class TestnetClient {
     const networkContext = {
       abi: JSON.parse(contractResolverAbi),
       resolverAddress: contractResolverAddress,
-       provider: new ethers.providers.StaticJsonRpcProvider({
+      provider: new ethers.providers.StaticJsonRpcProvider({
         url: `http://${testNetConfig.rpcUrl}`,
         skipFetchSetup: true,
       }),

--- a/local-tests/setup/tinny-person.ts
+++ b/local-tests/setup/tinny-person.ts
@@ -46,9 +46,10 @@ export class TinnyPerson {
     this.envConfig = envConfig;
 
     this.privateKey = privateKey;
-    this.provider = new ethers.providers.StaticJsonRpcProvider(
-      this.envConfig.rpc
-    );
+    this.provider = new ethers.providers.StaticJsonRpcProvider({
+      url: this.envConfig.rpc,
+      skipFetchSetup: true,
+    });
     this.wallet = new ethers.Wallet(privateKey, this.provider);
   }
 

--- a/packages/contracts-sdk/src/lib/addresses.ts
+++ b/packages/contracts-sdk/src/lib/addresses.ts
@@ -62,9 +62,10 @@ export const derivedAddresses = async ({
         if (cachedPkpJSON[pkpTokenId]) {
           publicKey = cachedPkpJSON[pkpTokenId];
         } else {
-          const provider = new ethers.providers.StaticJsonRpcProvider(
-            defaultRPCUrl
-          );
+          const provider = new ethers.providers.StaticJsonRpcProvider({
+            url: defaultRPCUrl,
+            skipFetchSetup: true,
+          });
 
           const contract = new Contract(
             pkpContractAddress,

--- a/packages/contracts-sdk/src/lib/contracts-sdk.ts
+++ b/packages/contracts-sdk/src/lib/contracts-sdk.ts
@@ -311,7 +311,10 @@ export class LitContracts {
     // ----------------------------------------------
     else if (isNode()) {
       this.log("----- We're in node! -----");
-      this.provider = new ethers.providers.StaticJsonRpcProvider(this.rpc);
+      this.provider = new ethers.providers.StaticJsonRpcProvider({
+        url: this.rpc,
+        skipFetchSetup: true,
+      });
     }
 
     // ======================================
@@ -594,7 +597,10 @@ export class LitContracts {
     if (context && 'provider' in context!) {
       provider = context.provider;
     } else {
-      provider = new ethers.providers.StaticJsonRpcProvider(rpcUrl);
+      provider = new ethers.providers.StaticJsonRpcProvider({
+        url: rpcUrl,
+        skipFetchSetup: true,
+      });
     }
 
     if (!context) {
@@ -1517,7 +1523,10 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
   //   if (isBrowser()) {
   //     provider = new ethers.providers.Web3Provider(window.ethereum, 'any');
   //   } else {
-  //     provider = new ethers.providers.StaticJsonRpcProvider(this.rpc);
+  //     provider = new ethers.providers.StaticJsonRpcProvider({
+  //       url: this.rpc,
+  //       skipFetchSetup: true,
+  //     });
   //   }
   //   const signer = new ethers.Wallet(privateKey, provider);
 
@@ -1530,7 +1539,10 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
   //   if (isBrowser()) {
   //     provider = new ethers.providers.Web3Provider(window.ethereum, 'any');
   //   } else {
-  //     provider = new ethers.providers.StaticJsonRpcProvider(this.rpc);
+  //     provider = new ethers.providers.StaticJsonRpcProvider({
+  //       url: this.rpc,
+  //       skipFetchSetup: true,
+  //     });
   //   }
   //   const signer = new ethers.Wallet(privateKey, provider);
 

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -498,9 +498,10 @@ export class LitCore {
     if (!this.config.contractContext) {
       this.config.contractContext = await LitContracts.getContractAddresses(
         this.config.litNetwork,
-        new ethers.providers.StaticJsonRpcProvider(
-          this.config.rpcUrl || RPC_URL_BY_NETWORK[this.config.litNetwork]
-        )
+        new ethers.providers.StaticJsonRpcProvider({
+          url: this.config.rpcUrl || RPC_URL_BY_NETWORK[this.config.litNetwork],
+          skipFetchSetup: true,
+        })
       );
     } else if (
       !this.config.contractContext.Staking &&

--- a/packages/misc/src/lib/misc.ts
+++ b/packages/misc/src/lib/misc.ts
@@ -635,7 +635,10 @@ export const decimalPlaces = async ({
 }): Promise<number> => {
   const rpcUrl = LIT_CHAINS[chain].rpcUrls[0] as string;
 
-  const web3 = new JsonRpcProvider(rpcUrl);
+  const web3 = new JsonRpcProvider({
+    url: rpcUrl,
+    skipFetchSetup: true,
+  });
 
   const contract = new Contract(contractAddress, (ABI_ERC20 as any).abi, web3);
 

--- a/packages/pkp-ethers/src/lib/pkp-ethers.ts
+++ b/packages/pkp-ethers/src/lib/pkp-ethers.ts
@@ -92,7 +92,10 @@ export class PKPEthersWallet
       );
     }
 
-    this.rpcProvider = new ethers.providers.StaticJsonRpcProvider(rpcUrl);
+    this.rpcProvider = new ethers.providers.StaticJsonRpcProvider({
+      url: rpcUrl,
+      skipFetchSetup: true,
+    });
     this.provider = prop.provider ?? this.rpcProvider;
 
     defineReadOnly(this, '_isSigner', true);
@@ -109,7 +112,10 @@ export class PKPEthersWallet
   };
 
   setRpc = async (rpc: string): Promise<void> => {
-    this.rpcProvider = new ethers.providers.StaticJsonRpcProvider(rpc);
+    this.rpcProvider = new ethers.providers.StaticJsonRpcProvider({
+      url: rpc,
+      skipFetchSetup: true,
+    });
   };
 
   handleRequest = async <T = ETHSignature | ETHTxRes>(


### PR DESCRIPTION
# Description

This PR adds `skipFetchSetup` to `StaticJsonRpcProvider`s instances to avoid no network error in webpack environments such as next.js backend. Explained in #538 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Created a Next.js app that connected to lit network in FE and BE

Backend before:
![Screenshot from 2024-09-23 18-58-03](https://github.com/user-attachments/assets/7178392b-ea81-43b2-9c21-117f56b38452)

Backend after:
![Screenshot from 2024-09-23 21-11-31](https://github.com/user-attachments/assets/20db62cd-a265-4d7a-baa4-e11e1c8994ca)

Note: Frontend was working fine, no changes there

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
