### PR TITLE
LIT-3896 - Better error logs & request id tracking and submission for wrapped-keys service client

### DIFF
--- a/packages/wrapped-keys/src/lib/api/sign-message-with-encrypted-key.ts
+++ b/packages/wrapped-keys/src/lib/api/sign-message-with-encrypted-key.ts
@@ -25,8 +25,6 @@ export async function signMessageWithEncryptedKey(
     litNetwork: litNodeClient.config.litNetwork,
   });
 
-  console.log('fetched metadata', storedKeyMetadata);
-
   const allowPkpAddressToDecrypt = getPkpAccessControlCondition(
     storedKeyMetadata.pkpAddress
   );

--- a/packages/wrapped-keys/src/lib/service-client/client.ts
+++ b/packages/wrapped-keys/src/lib/service-client/client.ts
@@ -19,20 +19,18 @@ export async function listPrivateKeyMetadata(
 ): Promise<StoredKeyMetadata[]> {
   const { litNetwork, sessionSig } = params;
 
+  const requestId = generateRequestId();
   const { baseUrl, initParams } = getBaseRequestParams({
     litNetwork,
     sessionSig,
     method: 'GET',
+    requestId,
   });
 
   const pkpAddress = getPkpAddressFromSessionSig(sessionSig);
 
-  const requestId = generateRequestId();
-  const url = new URL(`${baseUrl}/${pkpAddress}`);
-  url.searchParams.set('requestId', requestId);
-
   return makeRequest<StoredKeyMetadata[]>({
-    url: url.toString(),
+    url: `${baseUrl}/${pkpAddress}`,
     init: initParams,
     requestId,
   });
@@ -49,19 +47,17 @@ export async function fetchPrivateKey(
 ): Promise<StoredKeyData> {
   const { litNetwork, sessionSig, id } = params;
 
+  const requestId = generateRequestId();
   const { baseUrl, initParams } = getBaseRequestParams({
     litNetwork,
     sessionSig,
     method: 'GET',
+    requestId,
   });
   const pkpAddress = getPkpAddressFromSessionSig(sessionSig);
 
-  const requestId = generateRequestId();
-
-  const url = new URL(`${baseUrl}/${pkpAddress}/${id}`);
-  url.searchParams.set('requestId', requestId);
   return makeRequest<StoredKeyData>({
-    url: url.toString(),
+    url: `${baseUrl}/${pkpAddress}/${id}`,
     init: initParams,
     requestId,
   });
@@ -77,18 +73,19 @@ export async function storePrivateKey(
 ): Promise<StoreEncryptedKeyResult> {
   const { litNetwork, sessionSig, storedKeyMetadata } = params;
 
+  const requestId = generateRequestId();
   const { baseUrl, initParams } = getBaseRequestParams({
     litNetwork,
     sessionSig,
     method: 'POST',
+    requestId,
   });
-  const requestId = generateRequestId();
 
   const { pkpAddress, id } = await makeRequest<StoreEncryptedKeyResult>({
     url: baseUrl,
     init: {
       ...initParams,
-      body: JSON.stringify({ ...storedKeyMetadata, requestId }),
+      body: JSON.stringify(storedKeyMetadata),
     },
     requestId,
   });

--- a/packages/wrapped-keys/src/lib/service-client/types.ts
+++ b/packages/wrapped-keys/src/lib/service-client/types.ts
@@ -34,4 +34,5 @@ export interface BaseRequestParams {
   sessionSig: AuthSig;
   method: 'GET' | 'POST';
   litNetwork: LIT_NETWORKS_KEYS;
+  requestId: string;
 }

--- a/packages/wrapped-keys/src/lib/service-client/utils.ts
+++ b/packages/wrapped-keys/src/lib/service-client/utils.ts
@@ -104,12 +104,18 @@ async function getResponseJson<T>(response: Response): Promise<T | string> {
   }
 }
 
+export function generateRequestId(): string {
+  return Math.random().toString(16).slice(2);
+}
+
 export async function makeRequest<T>({
   url,
   init,
+  requestId,
 }: {
   url: string;
   init: RequestInit;
+  requestId: string;
 }) {
   try {
     const response = await fetch(url, { ...init });
@@ -127,16 +133,11 @@ export async function makeRequest<T>({
 
     return result;
   } catch (e: unknown) {
-    let cause = '';
-    // @ts-expect-error - Yes, it's unknown, but we know the property is there.
-    if ('cause' in e) {
-      // @ts-expect-error - Yes, it's unknown, but we know the property is there; fetch throws TypeError with `cause`
-      cause = e.cause;
-    }
     throw new Error(
-      `Failed to make request for wrapped key: ${(e as Error).message}${
-        cause ? ' - ' + cause : ''
-      }`
+      `Request(${requestId}) for wrapped key failed. Error: ${
+        (e as Error).message
+        // @ts-expect-error Unknown, but `cause` is on `TypeError: fetch failed` errors
+      }${e.cause ? ' - ' + e.cause : ''}`
     );
   }
 }

--- a/packages/wrapped-keys/src/lib/service-client/utils.ts
+++ b/packages/wrapped-keys/src/lib/service-client/utils.ts
@@ -57,6 +57,7 @@ export function getBaseRequestParams(requestParams: BaseRequestParams): {
     initParams: {
       method,
       headers: {
+        'x-correlation-id': requestParams.requestId,
         'Content-Type': 'application/json',
         'Lit-Network': litNetwork,
         Authorization: composeAuthHeader(sessionSig), // As Base64 string to avoid escaping issues

--- a/packages/wrapped-keys/src/lib/service-client/utils.ts
+++ b/packages/wrapped-keys/src/lib/service-client/utils.ts
@@ -111,7 +111,6 @@ export async function makeRequest<T>({
   url: string;
   init: RequestInit;
 }) {
-  console.log('Fetching from URL', url);
   const response = await fetch(url, { ...init });
 
   if (!response.ok) {
@@ -119,10 +118,7 @@ export async function makeRequest<T>({
     throw new Error(`Failed to make request for wrapped key: ${errorMessage}`);
   }
 
-  /**
-   *
-   */
-  const result = await getResponseJson<T>(response);
+    const result = await getResponseJson<T>(response);
 
   if (typeof result === 'string') {
     throw new Error(`Unexpected response from wrapped key service: ${result}`);


### PR DESCRIPTION
# Description

- Updated logging logic in wrapped-keys so that we now log HTTP error codes for failed requests, and `error.cause` when it is defined.
- `error.cause` should give us insights into the _reason_ why a `fetch failed` error is thrown; previously all we saw in logs was the string `fetch failed`, because fetch puts the really useful info in a `cause` property on the error
- Added requestId generation and logging to the wrapped-keys service client.  Error logs now include our _internal_ request id, and we send that request ID to the API backend in the `x-correlation-id` header, which provides integration with cloudwatch and `pino-lambda` (for service logs) -- It was just an added benefit that it was also the simplest way (identical logic for GET and POST routes)

Example output from `testFailImportWrappedKeysWithSamePrivateKey` test:
![image](https://github.com/user-attachments/assets/292c6ec5-fec4-4dd8-a761-7f6d8be766a5)

## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran local-tests against `datil-test` instances of the lambda functions; verified functionality is working as expected

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
