### PR TITLE
fix: wrong encoding - should be `base58` instead of `base64`

### DIFF
--- a/packages/wrapped-keys-lit-actions/src/lib/solana/signTransactionWithSolanaEncryptedKey.js
+++ b/packages/wrapped-keys-lit-actions/src/lib/solana/signTransactionWithSolanaEncryptedKey.js
@@ -6,6 +6,7 @@ const {
 } = require('@solana/web3.js');
 
 const { removeSaltFromDecryptedKey } = require('../utils');
+const { bs58 } = require('bs58');
 
 /**
  *
@@ -80,7 +81,7 @@ const { removeSaltFromDecryptedKey } = require('../utils');
     );
 
     transaction.sign(solanaKeyPair);
-    const signature = transaction.signature.toString('base64');
+    const signature = bs58.encode(transaction.signature);
 
     if (broadcast) {
       const solanaConnection = new Connection(

--- a/packages/wrapped-keys-lit-actions/src/lib/solana/signTransactionWithSolanaEncryptedKey.js
+++ b/packages/wrapped-keys-lit-actions/src/lib/solana/signTransactionWithSolanaEncryptedKey.js
@@ -80,7 +80,7 @@ const { removeSaltFromDecryptedKey } = require('../utils');
     );
 
     transaction.sign(solanaKeyPair);
-    const signature = bs58.encode(transaction.signature);
+    const signature = ethers.utils.base58.encode(transaction.signature);
 
     if (broadcast) {
       const solanaConnection = new Connection(

--- a/packages/wrapped-keys-lit-actions/src/lib/solana/signTransactionWithSolanaEncryptedKey.js
+++ b/packages/wrapped-keys-lit-actions/src/lib/solana/signTransactionWithSolanaEncryptedKey.js
@@ -6,7 +6,6 @@ const {
 } = require('@solana/web3.js');
 
 const { removeSaltFromDecryptedKey } = require('../utils');
-const { bs58 } = require('bs58');
 
 /**
  *


### PR DESCRIPTION
# Description

Fix wrong encoding - it should be `base58` instead of `base64`.

As per @spacesailor24 comment for the following Lit Action:

```js
const transaction = Transaction.from(
  Buffer.from(unsignedTransaction.serializedTransaction, 'base64')
);

transaction.sign(solanaKeyPair);
const signature = transaction.signature.toString('base64');

if (broadcast) {
  const solanaConnection = new Connection(
    clusterApiUrl(unsignedTransaction.chain),
    'confirmed'
  );
  const transactionSignature = await solanaConnection.sendRawTransaction(
    transaction.serialize()
  );

  Lit.Actions.setResponse({ response: transactionSignature });
} else {
  Lit.Actions.setResponse({ response: signature });
}
```

When broadcast is true, transactionSignature will be base58 encoded, but when false, signature is base64 encoded