### PR TITLE
feat: remove support for cayenne, habanero and manzano

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,6 @@
 #Tinny ENV Vars
 MAX_ATTEMPTS=1
-NETWORK=cayenne
+NETWORK=datil-dev
 DEBUG=true
 WAIT_FOR_KEY_INTERVAL=3000
 LIT_OFFICAL_RPC=https://chain-rpc.litprotocol.com/http

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ yarn test:local
 
 ## Create a new react demo app using the Lit JS SDK
 
-```js
+```sh
 yarn tools --create --react contracts-sdk --demo
 ```
 
@@ -164,13 +164,13 @@ yarn delete:package <package-name>
 
 ## Building
 
-```jsx
+```sh
 yarn build
 ```
 
 ### Building target package
 
-```jsx
+```sh
 yarn nx run <project-name>:build
 ```
 
@@ -226,18 +226,9 @@ You must have at least nodejs v18 to do this.
 
 5. Update the docs with `yarn gen:docs --push`
 
-6. Finally, publish with the `@cayenne` tag: `yarn publish:cayenne`
+6. Finally, publish with `yarn publish:packages`
 
 7. Commit these changes "Published version X.X.X"
-
-### Publishing to Serrano / Jalapno
-
-```sh
-git checkout serrano
-yarn bump
-yarn build
-yarn node ./tools/scripts/pub.mjs --tag serrano-jalapeno
-```
 
 ## Testing
 
@@ -251,7 +242,7 @@ yarn test:local
 
 ### Unit Tests
 
-```jsx
+```sh
 yarn test:unit
 ```
 

--- a/local-tests/README.md
+++ b/local-tests/README.md
@@ -19,12 +19,12 @@ The `testName` specified in the filter **must be the same as the function name**
 // run all tests on local chain
 DEBUG=true NETWORK=custom yarn test:local
 
-// run filtered tests on manzano
-DEBUG=true NETWORK=manzano yarn test:local --filter=testExample
-DEBUG=true NETWORK=manzano yarn test:local --filter=testExample,testBundleSpeed
+// run filtered tests on datil-test
+DEBUG=true NETWORK=datil-test yarn test:local --filter=testExample
+DEBUG=true NETWORK=datil-test yarn test:local --filter=testExample,testBundleSpeed
 
 // run filtered tests by keyword
-DEBUG=true NETWORK=manzano yarn test:local --filter=Encrypt
+DEBUG=true NETWORK=datil-test yarn test:local --filter=Encrypt
 
 // eg.
 yarn test:local --filter=testExample,testBundleSpeed
@@ -41,7 +41,7 @@ Below is the API documentation for the `ProcessEnvs` interface, detailing the co
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `MAX_ATTEMPTS`           | Each test is executed in a loop with a maximum number of attempts specified by `devEnv.processEnvs.MAX_ATTEMPTS`.                                                                                               |
 | `TEST_TIMEOUT`           | The maximum number of milliseconds to wait for a test to complete.                                                                                                                                              |
-| `NETWORK`                | The network to use for testing, which can be one of the following: `LIT_NETWORK.Custom`, `LIT_NETWORK.Manzano`, or `LIT_NETWORK.Cayenne`.                                                                       |
+| `NETWORK`                | The network to use for testing, which can be one of the following: `LIT_NETWORK.Custom`, `LIT_NETWORK.DatilDev`, or `LIT_NETWORK.Datil`.                                                                        |
 | `DEBUG`                  | Specifies whether to enable debug mode.                                                                                                                                                                         |
 | `REQUEST_PER_KILOSECOND` | To execute a transaction with Lit, you must reserve capacity on the network using Capacity Credits. These allow a set number of requests over a period (default 2 days).                                        |
 | `WAIT_FOR_KEY_INTERVAL`  | Wait time in milliseconds if no private keys are available.                                                                                                                                                     |
@@ -76,8 +76,8 @@ In the test function, a `devEnv` variable will automatically be added as the fir
 export const testExample = async (devEnv: TinnyEnvironment) => {
 
   // ========== Enviorment ==========
-  // This test will be skipped if we are testing on the Cayenne network
-  devEnv.setUnavailable(LIT_NETWORK.Cayenne);
+  // This test will be skipped if we are testing on the DatilDev network
+  devEnv.setUnavailable(LIT_NETWORK.DatilDev);
 
   // Using litNodeClient
   const res = await devEnv.litNodeClient.executeJs({...});
@@ -137,6 +137,7 @@ export const testBundleSpeed = async (devEnv: TinnyEnvironment) => {
 
   console.log(a, b, c, d, e);
 };
-----------------
-Build time: 77ms
+// ----------------
+// Build time: 77ms
+// ----------------
 ```

--- a/local-tests/README.md
+++ b/local-tests/README.md
@@ -126,7 +126,6 @@ The `TinnyPerson` class encapsulates various functionalities to manage wallet op
 # esbuild benchmark
 
 ```ts
-
 // test-bundle-speed.ts
 export const testBundleSpeed = async (devEnv: TinnyEnvironment) => {
   const a = await import('@lit-protocol/lit-node-client');

--- a/local-tests/setup/tinny-config.ts
+++ b/local-tests/setup/tinny-config.ts
@@ -19,8 +19,6 @@ export interface ProcessEnvs {
   /**
    * The network to use for testing. This can be one of the following:
    * - `LIT_NETWORK.Custom`
-   * - `LIT_NETWORK.Manzano`
-   * - `LIT_NETWORK.Cayenne`
    * - `LIT_NETWORK.DatilDev`
    */
   NETWORK: LIT_NETWORK_VALUES;

--- a/local-tests/setup/tinny-environment.ts
+++ b/local-tests/setup/tinny-environment.ts
@@ -223,7 +223,7 @@ export class TinnyEnvironment {
    *
    * The LitNodeClient is configured differently based on the network:
    * - Custom: Uses custom settings for local testing, with node attestation disabled.
-   * - Manzano (or other specified testnets): Configures for specific network environments with node attestation enabled.
+   * - DatilTest (or other specified testnets): Configures for specific network environments with node attestation enabled.
    *
    * Logs the process and exits if the client is not ready after attempting to connect.
    */

--- a/local-tests/tests/test-example.ts
+++ b/local-tests/tests/test-example.ts
@@ -6,8 +6,8 @@ import { LIT_NETWORK } from '@lit-protocol/constants';
 import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 export const testExample = async (devEnv: TinnyEnvironment) => {
-  // Note: This test will be skipped if we are testing on the Cayenne network
-  devEnv.setUnavailable(LIT_NETWORK.Cayenne);
+  // Note: This test will be skipped if we are testing on the DatilDev network
+  devEnv.setUnavailable(LIT_NETWORK.DatilDev);
 
   const alice = await devEnv.createRandomPerson();
 

--- a/local-tests/tests/testCosmosAuthSigToEncryptDecryptString.ts
+++ b/local-tests/tests/testCosmosAuthSigToEncryptDecryptString.ts
@@ -6,8 +6,8 @@ import { encryptString, decryptToString } from '@lit-protocol/encryption';
 
 /**
  * Test Commands:
- * ❌ NETWORK=cayenne yarn test:local --filter=testCosmosAuthSigToEncryptDecryptString
- * ❌ NETWORK=manzano yarn test:local --filter=testCosmosAuthSigToEncryptDecryptString
+ * ❌ NETWORK=datil-dev yarn test:local --filter=testCosmosAuthSigToEncryptDecryptString
+ * ❌ NETWORK=datil-test yarn test:local --filter=testCosmosAuthSigToEncryptDecryptString
  * ❌ NETWORK=custom yarn test:local --filter=testCosmosAuthSigToEncryptDecryptString
  * ❌ NETWORK=datil-dev yarn test:local --filter=testCosmosAuthSigToEncryptDecryptString
  */
@@ -16,9 +16,7 @@ export const testCosmosAuthSigToEncryptDecryptString = async (
 ) => {
   console.log('❌❌ THIS IS A KNOWN FAILING TEST, PLEASE IGNORE FOR NOW. ❌❌');
 
-  devEnv.setUnavailable(LIT_NETWORK.Cayenne);
   devEnv.setUnavailable(LIT_NETWORK.Custom);
-  devEnv.setUnavailable(LIT_NETWORK.Manzano);
   devEnv.setUnavailable(LIT_NETWORK.DatilDev);
 
   const accs = AccessControlConditions.getCosmosBasicAccessControlConditions({

--- a/local-tests/tests/testDelegatingCapacityCreditsNFTToAnotherPkpToExecuteJs.ts
+++ b/local-tests/tests/testDelegatingCapacityCreditsNFTToAnotherPkpToExecuteJs.ts
@@ -13,8 +13,7 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
  *
  *
  * ## Test Commands:
- * - ❌ Not supported in Cayenne
- * - ✅ NETWORK=manzano yarn test:local --filter=testDelegatingCapacityCreditsNFTToAnotherPkpToExecuteJs
+ * - ✅ NETWORK=datil-test yarn test:local --filter=testDelegatingCapacityCreditsNFTToAnotherPkpToExecuteJs
  * - ✅ NETWORK=custom yarn test:local --filter=testDelegatingCapacityCreditsNFTToAnotherPkpToExecuteJs
  */
 export const testDelegatingCapacityCreditsNFTToAnotherPkpToExecuteJs = async (

--- a/local-tests/tests/testDelegatingCapacityCreditsNFTToAnotherWalletToExecuteJs.ts
+++ b/local-tests/tests/testDelegatingCapacityCreditsNFTToAnotherWalletToExecuteJs.ts
@@ -11,8 +11,7 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
  *
  *
  * ## Test Commands:
- * - ❌ Not supported in Cayenne, but session sigs would still work
- * - ✅ NETWORK=manzano yarn test:local --filter=testDelegatingCapacityCreditsNFTToAnotherWalletToExecuteJs
+ * - ✅ NETWORK=datil-test yarn test:local --filter=testDelegatingCapacityCreditsNFTToAnotherWalletToExecuteJs
  * - ✅ NETWORK=custom yarn test:local --filter=testDelegatingCapacityCreditsNFTToAnotherWalletToExecuteJs
  */
 export const testDelegatingCapacityCreditsNFTToAnotherWalletToExecuteJs =

--- a/local-tests/tests/testDelegatingCapacityCreditsNFTToAnotherWalletToPkpSign.ts
+++ b/local-tests/tests/testDelegatingCapacityCreditsNFTToAnotherWalletToPkpSign.ts
@@ -11,8 +11,7 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
  *
  *
  * ## Test Commands:
- * - ❌ Not supported in Cayenne, but session sigs would still work
- * - ✅ NETWORK=manzano yarn test:local --filter=testDelegatingCapacityCreditsNFTToAnotherWalletToPkpSign
+ * - ✅ NETWORK=datil-test yarn test:local --filter=testDelegatingCapacityCreditsNFTToAnotherWalletToPkpSign
  * - ✅ NETWORK=custom yarn test:local --filter=testDelegatingCapacityCreditsNFTToAnotherWalletToPkpSign
  */
 export const testDelegatingCapacityCreditsNFTToAnotherWalletToPkpSign = async (

--- a/local-tests/tests/testEthAuthSigToEncryptDecryptString.ts
+++ b/local-tests/tests/testEthAuthSigToEncryptDecryptString.ts
@@ -6,8 +6,8 @@ import { encryptString, decryptToString } from '@lit-protocol/encryption';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testEthAuthSigToEncryptDecryptString
- * ✅ NETWORK=manzano yarn test:local --filter=testEthAuthSigToEncryptDecryptString
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testEthAuthSigToEncryptDecryptString
+ * ✅ NETWORK=datil-test yarn test:local --filter=testEthAuthSigToEncryptDecryptString
  * ✅ NETWORK=custom yarn test:local --filter=testEthAuthSigToEncryptDecryptString
  */
 export const testEthAuthSigToEncryptDecryptString = async (

--- a/local-tests/tests/testExecuteJsBroadcastAndCollect.ts
+++ b/local-tests/tests/testExecuteJsBroadcastAndCollect.ts
@@ -5,17 +5,13 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptString
- * ❌ NOT AVAILABLE IN MANZANO
- * ✅ NETWORK=custom yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptString
  * ✅ NETWORK=datil-dev yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptString
+ * ✅ NETWORK=custom yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptString
  *
  */
 export const testExecuteJsBroadcastAndCollect = async (
   devEnv: TinnyEnvironment
 ) => {
-  devEnv.setUnavailable(LIT_NETWORK.Manzano);
-
   const alice = await devEnv.createRandomPerson();
   // set access control conditions for encrypting and decrypting
   const accs = AccessControlConditions.getEmvBasicAccessControlConditions({

--- a/local-tests/tests/testExecuteJsDecryptAndCombine.ts
+++ b/local-tests/tests/testExecuteJsDecryptAndCombine.ts
@@ -8,17 +8,13 @@ import { encryptString } from '@lit-protocol/encryption';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptString
- * ❌ NOT AVAILABLE IN MANZANO
- * ✅ NETWORK=custom yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptString
  * ✅ NETWORK=datil-dev yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptString
+ * ✅ NETWORK=custom yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptString
  *
  */
 export const testExecutJsDecryptAndCombine = async (
   devEnv: TinnyEnvironment
 ) => {
-  devEnv.setUnavailable(LIT_NETWORK.Manzano);
-
   const alice = await devEnv.createRandomPerson();
   // set access control conditions for encrypting and decrypting
   const accs = AccessControlConditions.getEmvBasicAccessControlConditions({

--- a/local-tests/tests/testExecuteJsSignAndCombineEcdsa.ts
+++ b/local-tests/tests/testExecuteJsSignAndCombineEcdsa.ts
@@ -11,8 +11,7 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
  *
  *
  * ## Test Commands:
- * - ❌ Not supported in Cayenne, but session sigs would still work
- * - ✅ NETWORK=manzano yarn test:local --filter=testUseCapacityDelegationAuthSigWithUnspecifiedCapacityTokenIdToExecuteJs
+ * - ✅ NETWORK=datil-test yarn test:local --filter=testUseCapacityDelegationAuthSigWithUnspecifiedCapacityTokenIdToExecuteJs
  * - ✅ NETWORK=custom yarn test:local --filter=testUseCapacityDelegationAuthSigWithUnspecifiedCapacityTokenIdToExecuteJs
  */
 export const testExecuteJsSignAndCombineEcdsa = async (

--- a/local-tests/tests/testPkpEthersWithEoaSessionSigsToEthSign.ts
+++ b/local-tests/tests/testPkpEthersWithEoaSessionSigsToEthSign.ts
@@ -5,8 +5,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSign
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSign
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSign
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSign
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSign
  */
 export const testPkpEthersWithEoaSessionSigsToEthSign = async (

--- a/local-tests/tests/testPkpEthersWithEoaSessionSigsToEthSignTransaction.ts
+++ b/local-tests/tests/testPkpEthersWithEoaSessionSigsToEthSignTransaction.ts
@@ -5,8 +5,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSignTransaction
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSignTransaction
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSignTransaction
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSignTransaction
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSignTransaction
  */
 export const testPkpEthersWithEoaSessionSigsToEthSignTransaction = async (

--- a/local-tests/tests/testPkpEthersWithEoaSessionSigsToEthSignTypedData.ts
+++ b/local-tests/tests/testPkpEthersWithEoaSessionSigsToEthSignTypedData.ts
@@ -5,8 +5,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSignTypedData
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSignTypedData
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSignTypedData
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSignTypedData
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSignTypedData
  */
 export const testPkpEthersWithEoaSessionSigsToEthSignTypedData = async (

--- a/local-tests/tests/testPkpEthersWithEoaSessionSigsToEthSignTypedDataUtil.ts
+++ b/local-tests/tests/testPkpEthersWithEoaSessionSigsToEthSignTypedDataUtil.ts
@@ -9,8 +9,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSignTypedDataUtil
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSignTypedDataUtil
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSignTypedDataUtil
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSignTypedDataUtil
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSignTypedDataUtil
  */
 export const testPkpEthersWithEoaSessionSigsToEthSignTypedDataUtil = async (

--- a/local-tests/tests/testPkpEthersWithEoaSessionSigsToEthSignTypedDataV1.ts
+++ b/local-tests/tests/testPkpEthersWithEoaSessionSigsToEthSignTypedDataV1.ts
@@ -9,8 +9,8 @@ import {
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSignTypedDataV1
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSignTypedDataV1
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSignTypedDataV1
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSignTypedDataV1
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSignTypedDataV1
  */
 export const testPkpEthersWithEoaSessionSigsToEthSignTypedDataV1 = async (

--- a/local-tests/tests/testPkpEthersWithEoaSessionSigsToEthSignTypedDataV3.ts
+++ b/local-tests/tests/testPkpEthersWithEoaSessionSigsToEthSignTypedDataV3.ts
@@ -9,8 +9,8 @@ import {
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSignTypedDataV3
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSignTypedDataV3
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSignTypedDataV3
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSignTypedDataV3
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSignTypedDataV3
  */
 export const testPkpEthersWithEoaSessionSigsToEthSignTypedDataV3 = async (

--- a/local-tests/tests/testPkpEthersWithEoaSessionSigsToEthSignTypedDataV4.ts
+++ b/local-tests/tests/testPkpEthersWithEoaSessionSigsToEthSignTypedDataV4.ts
@@ -9,8 +9,8 @@ import {
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSignTypedDataV4
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSignTypedDataV4
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSignTypedDataV4
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSignTypedDataV4
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithEoaSessionSigsToEthSignTypedDataV4
  */
 export const testPkpEthersWithEoaSessionSigsToEthSignTypedDataV4 = async (

--- a/local-tests/tests/testPkpEthersWithEoaSessionSigsToPersonalSign.ts
+++ b/local-tests/tests/testPkpEthersWithEoaSessionSigsToPersonalSign.ts
@@ -5,8 +5,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithEoaSessionSigsToPersonalSign
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithEoaSessionSigsToPersonalSign
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithEoaSessionSigsToPersonalSign
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithEoaSessionSigsToPersonalSign
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithEoaSessionSigsToPersonalSign
  */
 export const testPkpEthersWithEoaSessionSigsToPersonalSign = async (

--- a/local-tests/tests/testPkpEthersWithEoaSessionSigsToSendTx.ts
+++ b/local-tests/tests/testPkpEthersWithEoaSessionSigsToSendTx.ts
@@ -5,8 +5,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithEoaSessionSigsToSendTx
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithEoaSessionSigsToSendTx
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithEoaSessionSigsToSendTx
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithEoaSessionSigsToSendTx
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithEoaSessionSigsToSendTx
  */
 export const testPkpEthersWithEoaSessionSigsToSendTx = async (

--- a/local-tests/tests/testPkpEthersWithEoaSessionSigsToSignMessage.ts
+++ b/local-tests/tests/testPkpEthersWithEoaSessionSigsToSignMessage.ts
@@ -5,8 +5,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithEoaSessionSigsToSignMessage
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithEoaSessionSigsToSignMessage
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithEoaSessionSigsToSignMessage
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithEoaSessionSigsToSignMessage
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithEoaSessionSigsToSignMessage
  */
 export const testPkpEthersWithEoaSessionSigsToSignMessage = async (

--- a/local-tests/tests/testPkpEthersWithEoaSessionSigsToSignWithAuthContext.ts
+++ b/local-tests/tests/testPkpEthersWithEoaSessionSigsToSignWithAuthContext.ts
@@ -11,8 +11,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithEoaSessionSigsToSignWithAuthContext
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithEoaSessionSigsToSignWithAuthContext
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithEoaSessionSigsToSignWithAuthContext
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithEoaSessionSigsToSignWithAuthContext
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithEoaSessionSigsToSignWithAuthContext
  */
 export const testPkpEthersWithEoaSessionSigsToSignWithAuthContext = async (

--- a/local-tests/tests/testPkpEthersWithLitActionSessionSigsToEthSign.ts
+++ b/local-tests/tests/testPkpEthersWithLitActionSessionSigsToEthSign.ts
@@ -5,8 +5,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSign
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSign
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSign
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSign
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSign
  */
 export const testPkpEthersWithLitActionSessionSigsToEthSign = async (

--- a/local-tests/tests/testPkpEthersWithLitActionSessionSigsToEthSignTransaction.ts
+++ b/local-tests/tests/testPkpEthersWithLitActionSessionSigsToEthSignTransaction.ts
@@ -5,8 +5,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSignTransaction
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSignTransaction
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSignTransaction
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSignTransaction
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSignTransaction
  */
 export const testPkpEthersWithLitActionSessionSigsToEthSignTransaction = async (

--- a/local-tests/tests/testPkpEthersWithLitActionSessionSigsToEthSignTypedData.ts
+++ b/local-tests/tests/testPkpEthersWithLitActionSessionSigsToEthSignTypedData.ts
@@ -5,8 +5,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSignTypedData
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSignTypedData
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSignTypedData
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSignTypedData
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSignTypedData
  */
 export const testPkpEthersWithLitActionSessionSigsToEthSignTypedData = async (

--- a/local-tests/tests/testPkpEthersWithLitActionSessionSigsToEthSignTypedDataUtil.ts
+++ b/local-tests/tests/testPkpEthersWithLitActionSessionSigsToEthSignTypedDataUtil.ts
@@ -5,8 +5,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSignTypedDataUtil
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSignTypedDataUtil
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSignTypedDataUtil
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSignTypedDataUtil
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSignTypedDataUtil
  */
 export const testPkpEthersWithLitActionSessionSigsToEthSignTypedDataUtil =

--- a/local-tests/tests/testPkpEthersWithLitActionSessionSigsToEthSignTypedDataV1.ts
+++ b/local-tests/tests/testPkpEthersWithLitActionSessionSigsToEthSignTypedDataV1.ts
@@ -9,8 +9,8 @@ import { getLitActionSessionSigs } from 'local-tests/setup/session-sigs/get-lit-
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSignTypedDataV1
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSignTypedDataV1
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSignTypedDataV1
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSignTypedDataV1
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSignTypedDataV1
  */
 export const testPkpEthersWithLitActionSessionSigsToEthSignTypedDataV1 = async (

--- a/local-tests/tests/testPkpEthersWithLitActionSessionSigsToEthSignTypedDataV3.ts
+++ b/local-tests/tests/testPkpEthersWithLitActionSessionSigsToEthSignTypedDataV3.ts
@@ -8,8 +8,8 @@ import { getLitActionSessionSigs } from 'local-tests/setup/session-sigs/get-lit-
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSignTypedDataV3
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSignTypedDataV3
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSignTypedDataV3
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSignTypedDataV3
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSignTypedDataV3
  */
 export const testPkpEthersWithLitActionSessionSigsToEthSignTypedDataV3 = async (

--- a/local-tests/tests/testPkpEthersWithLitActionSessionSigsToEthSignTypedDataV4.ts
+++ b/local-tests/tests/testPkpEthersWithLitActionSessionSigsToEthSignTypedDataV4.ts
@@ -9,8 +9,8 @@ import { getLitActionSessionSigs } from 'local-tests/setup/session-sigs/get-lit-
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSignTypedDataV4
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSignTypedDataV4
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSignTypedDataV4
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSignTypedDataV4
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToEthSignTypedDataV4
  */
 export const testPkpEthersWithLitActionSessionSigsToEthSignTypedDataV4 = async (

--- a/local-tests/tests/testPkpEthersWithLitActionSessionSigsToPersonalSign.ts
+++ b/local-tests/tests/testPkpEthersWithLitActionSessionSigsToPersonalSign.ts
@@ -5,8 +5,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToPersonalSign
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToPersonalSign
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToPersonalSign
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToPersonalSign
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToPersonalSign
  */
 export const testPkpEthersWithLitActionSessionSigsToPersonalSign = async (

--- a/local-tests/tests/testPkpEthersWithLitActionSessionSigsToSendTx.ts
+++ b/local-tests/tests/testPkpEthersWithLitActionSessionSigsToSendTx.ts
@@ -5,8 +5,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToSendTx
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToSendTx
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToSendTx
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToSendTx
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToSendTx
  */
 export const testPkpEthersWithLitActionSessionSigsToSendTx = async (

--- a/local-tests/tests/testPkpEthersWithLitActionSessionSigsToSignMessage.ts
+++ b/local-tests/tests/testPkpEthersWithLitActionSessionSigsToSignMessage.ts
@@ -4,8 +4,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToSignMessage
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToSignMessage
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToSignMessage
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToSignMessage
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithLitActionSessionSigsToSignMessage
  */
 export const testPkpEthersWithLitActionSessionSigsToSignMessage = async (

--- a/local-tests/tests/testPkpEthersWithPkpSessionSigsToEthSign.ts
+++ b/local-tests/tests/testPkpEthersWithPkpSessionSigsToEthSign.ts
@@ -5,8 +5,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSign
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSign
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSign
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSign
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSign
  */
 export const testPkpEthersWithPkpSessionSigsToEthSign = async (

--- a/local-tests/tests/testPkpEthersWithPkpSessionSigsToEthSignTransaction.ts
+++ b/local-tests/tests/testPkpEthersWithPkpSessionSigsToEthSignTransaction.ts
@@ -5,8 +5,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSignTransaction
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSignTransaction
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSignTransaction
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSignTransaction
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSignTransaction
  */
 export const testPkpEthersWithPkpSessionSigsToEthSignTransaction = async (

--- a/local-tests/tests/testPkpEthersWithPkpSessionSigsToEthSignTypedData.ts
+++ b/local-tests/tests/testPkpEthersWithPkpSessionSigsToEthSignTypedData.ts
@@ -5,8 +5,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSignTypedData
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSignTypedData
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSignTypedData
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSignTypedData
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSignTypedData
  */
 export const testPkpEthersWithPkpSessionSigsToEthSignTypedData = async (

--- a/local-tests/tests/testPkpEthersWithPkpSessionSigsToEthSignTypedDataUtil.ts
+++ b/local-tests/tests/testPkpEthersWithPkpSessionSigsToEthSignTypedDataUtil.ts
@@ -5,8 +5,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSignTypedDataUtil
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSignTypedDataUtil
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSignTypedDataUtil
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSignTypedDataUtil
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSignTypedDataUtil
  */
 export const testPkpEthersWithPkpSessionSigsToEthSignTypedDataUtil = async (

--- a/local-tests/tests/testPkpEthersWithPkpSessionSigsToEthSignTypedDataV1.ts
+++ b/local-tests/tests/testPkpEthersWithPkpSessionSigsToEthSignTypedDataV1.ts
@@ -9,8 +9,8 @@ import { getPkpSessionSigs } from 'local-tests/setup/session-sigs/get-pkp-sessio
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSignTypedDataV1
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSignTypedDataV1
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSignTypedDataV1
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSignTypedDataV1
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSignTypedDataV1
  */
 export const testPkpEthersWithPkpSessionSigsToEthSignTypedDataV1 = async (

--- a/local-tests/tests/testPkpEthersWithPkpSessionSigsToEthSignTypedDataV3.ts
+++ b/local-tests/tests/testPkpEthersWithPkpSessionSigsToEthSignTypedDataV3.ts
@@ -8,8 +8,8 @@ import { getPkpSessionSigs } from 'local-tests/setup/session-sigs/get-pkp-sessio
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSignTypedDataV3
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSignTypedDataV3
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSignTypedDataV3
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSignTypedDataV3
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSignTypedDataV3
  */
 export const testPkpEthersWithPkpSessionSigsToEthSignTypedDataV3 = async (

--- a/local-tests/tests/testPkpEthersWithPkpSessionSigsToEthSignTypedDataV4.ts
+++ b/local-tests/tests/testPkpEthersWithPkpSessionSigsToEthSignTypedDataV4.ts
@@ -9,8 +9,8 @@ import { getPkpSessionSigs } from 'local-tests/setup/session-sigs/get-pkp-sessio
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSignTypedDataV4
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSignTypedDataV4
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSignTypedDataV4
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSignTypedDataV4
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithPkpSessionSigsToEthSignTypedDataV4
  */
 export const testPkpEthersWithPkpSessionSigsToEthSignTypedDataV4 = async (

--- a/local-tests/tests/testPkpEthersWithPkpSessionSigsToPersonalSign.ts
+++ b/local-tests/tests/testPkpEthersWithPkpSessionSigsToPersonalSign.ts
@@ -5,8 +5,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithPkpSessionSigsToPersonalSign
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithPkpSessionSigsToPersonalSign
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithPkpSessionSigsToPersonalSign
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithPkpSessionSigsToPersonalSign
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithPkpSessionSigsToPersonalSign
  */
 export const testPkpEthersWithPkpSessionSigsToPersonalSign = async (

--- a/local-tests/tests/testPkpEthersWithPkpSessionSigsToSendTx.ts
+++ b/local-tests/tests/testPkpEthersWithPkpSessionSigsToSendTx.ts
@@ -5,8 +5,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithPkpSessionSigsToSendTx
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithPkpSessionSigsToSendTx
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithPkpSessionSigsToSendTx
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithPkpSessionSigsToSendTx
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithPkpSessionSigsToSendTx
  */
 export const testPkpEthersWithPkpSessionSigsToSendTx = async (

--- a/local-tests/tests/testPkpEthersWithPkpSessionSigsToSignMessage.ts
+++ b/local-tests/tests/testPkpEthersWithPkpSessionSigsToSignMessage.ts
@@ -4,8 +4,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testPkpEthersWithPkpSessionSigsToSignMessage
- * ✅ NETWORK=manzano yarn test:local --filter=testPkpEthersWithPkpSessionSigsToSignMessage
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpEthersWithPkpSessionSigsToSignMessage
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpEthersWithPkpSessionSigsToSignMessage
  * ✅ NETWORK=custom yarn test:local --filter=testPkpEthersWithPkpSessionSigsToSignMessage
  */
 export const testPkpEthersWithPkpSessionSigsToSignMessage = async (

--- a/local-tests/tests/testRelayer.ts
+++ b/local-tests/tests/testRelayer.ts
@@ -5,8 +5,8 @@ import { EthWalletProvider, LitRelay } from '@lit-protocol/lit-auth-client';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testRelayer
- * ✅ NETWORK=manzano yarn test:local --filter=testRelayer
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testRelayer
+ * ✅ NETWORK=datil-test yarn test:local --filter=testRelayer
  * ✅ NETWORK=custom yarn test:local --filter=testRelayer
  * ✅ NETWORK=datil-dev yarn test:local --filter=testRelayer
  */

--- a/local-tests/tests/testSolAuthSigToEncryptDecryptString.ts
+++ b/local-tests/tests/testSolAuthSigToEncryptDecryptString.ts
@@ -5,8 +5,8 @@ import { encryptString, decryptToString } from '@lit-protocol/encryption';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testSolAuthSigToEncryptDecryptString
- * ✅ NETWORK=manzano yarn test:local --filter=testSolAuthSigToEncryptDecryptString
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testSolAuthSigToEncryptDecryptString
+ * ✅ NETWORK=datil-test yarn test:local --filter=testSolAuthSigToEncryptDecryptString
  * ✅ NETWORK=custom yarn test:local --filter=testSolAuthSigToEncryptDecryptString
  */
 export const testSolAuthSigToEncryptDecryptString = async (

--- a/local-tests/tests/testUseCapacityDelegationAuthSigWithUnspecifiedCapacityTokenIdToExecuteJs.ts
+++ b/local-tests/tests/testUseCapacityDelegationAuthSigWithUnspecifiedCapacityTokenIdToExecuteJs.ts
@@ -11,8 +11,7 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
  *
  *
  * ## Test Commands:
- * - ❌ Not supported in Cayenne, but session sigs would still work
- * - ✅ NETWORK=manzano yarn test:local --filter=testUseCapacityDelegationAuthSigWithUnspecifiedCapacityTokenIdToExecuteJs
+ * - ✅ NETWORK=datil-test yarn test:local --filter=testUseCapacityDelegationAuthSigWithUnspecifiedCapacityTokenIdToExecuteJs
  * - ✅ NETWORK=custom yarn test:local --filter=testUseCapacityDelegationAuthSigWithUnspecifiedCapacityTokenIdToExecuteJs
  */
 export const testUseCapacityDelegationAuthSigWithUnspecifiedCapacityTokenIdToExecuteJs =

--- a/local-tests/tests/testUseCapacityDelegationAuthSigWithUnspecifiedCapacityTokenIdToPkpSign.ts
+++ b/local-tests/tests/testUseCapacityDelegationAuthSigWithUnspecifiedCapacityTokenIdToPkpSign.ts
@@ -11,8 +11,7 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
  *
  *
  * ## Test Commands:
- * - ❌ Not supported in Cayenne, but session sigs would still work
- * - ✅ NETWORK=manzano yarn test:local --filter=testUseCapacityDelegationAuthSigWithUnspecifiedCapacityTokenIdToPkpSign
+ * - ✅ NETWORK=datil-test yarn test:local --filter=testUseCapacityDelegationAuthSigWithUnspecifiedCapacityTokenIdToPkpSign
  * - ✅ NETWORK=custom yarn test:local --filter=testUseCapacityDelegationAuthSigWithUnspecifiedCapacityTokenIdToPkpSign
  */
 export const testUseCapacityDelegationAuthSigWithUnspecifiedCapacityTokenIdToPkpSign =

--- a/local-tests/tests/testUseCapacityDelegationAuthSigWithUnspecifiedDelegateesToExecuteJs.ts
+++ b/local-tests/tests/testUseCapacityDelegationAuthSigWithUnspecifiedDelegateesToExecuteJs.ts
@@ -11,8 +11,7 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
  *
  *
  * ## Test Commands:
- * - ❌ Not supported in Cayenne, but session sigs would still work
- * - ✅ NETWORK=manzano yarn test:local --filter=testUseCapacityDelegationAuthSigWithUnspecifiedDelegateesToExecuteJs
+ * - ✅ NETWORK=datil-test yarn test:local --filter=testUseCapacityDelegationAuthSigWithUnspecifiedDelegateesToExecuteJs
  * - ✅ NETWORK=custom yarn test:local --filter=testUseCapacityDelegationAuthSigWithUnspecifiedDelegateesToExecuteJs
  */
 

--- a/local-tests/tests/testUseCapacityDelegationAuthSigWithUnspecifiedDelegateesToPkpSign.ts
+++ b/local-tests/tests/testUseCapacityDelegationAuthSigWithUnspecifiedDelegateesToPkpSign.ts
@@ -11,8 +11,7 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
  *
  *
  * ## Test Commands:
- * - ❌ Not supported in Cayenne, but session sigs would still work
- * - ✅ NETWORK=manzano yarn test:local --filter=testUseCapacityDelegationAuthSigWithUnspecifiedDelegateesToPkpSign
+ * - ✅ NETWORK=datil-test yarn test:local --filter=testUseCapacityDelegationAuthSigWithUnspecifiedDelegateesToPkpSign
  * - ✅ NETWORK=custom yarn test:local --filter=testUseCapacityDelegationAuthSigWithUnspecifiedDelegateesToPkpSign
  */
 

--- a/local-tests/tests/testUseCustomAuthSessionSigsToPkpSignExecuteJs.ts
+++ b/local-tests/tests/testUseCustomAuthSessionSigsToPkpSignExecuteJs.ts
@@ -9,8 +9,7 @@ import { stringToIpfsHash } from 'local-tests/setup/tinny-utils';
 
 /**
  * Test Commands:
- * NETWORK=cayenne yarn test:local --filter=testUseCustomAuthSessionSigsToPkpSignExecuteJs
- * NOT AVAILABLE IN HABANERO
+ * NETWORK=datil-dev yarn test:local --filter=testUseCustomAuthSessionSigsToPkpSignExecuteJs
  * NETWORK=custom yarn test:local --filter=testUseCustomAuthSessionSigsToPkpSignExecuteJs
  */
 export const testUseCustomAuthSessionSigsToPkpSignExecuteJs = async (

--- a/local-tests/tests/testUseEoaSessionSigsToEncryptDecryptFile.ts
+++ b/local-tests/tests/testUseEoaSessionSigsToEncryptDecryptFile.ts
@@ -9,8 +9,8 @@ import { encryptString, decryptToFile } from '@lit-protocol/encryption';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUseEoaSessionSigsToEncryptDecryptFile
- * ✅ NETWORK=manzano yarn test:local --filter=testUseEoaSessionSigsToEncryptDecryptFile
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUseEoaSessionSigsToEncryptDecryptFile
+ * ✅ NETWORK=datil-test yarn test:local --filter=testUseEoaSessionSigsToEncryptDecryptFile
  * ✅ NETWORK=custom yarn test:local --filter=testUseEoaSessionSigsToEncryptDecryptFile
  */
 export const testUseEoaSessionSigsToEncryptDecryptFile = async (

--- a/local-tests/tests/testUseEoaSessionSigsToEncryptDecryptString.ts
+++ b/local-tests/tests/testUseEoaSessionSigsToEncryptDecryptString.ts
@@ -9,8 +9,8 @@ import { encryptString, decryptToString } from '@lit-protocol/encryption';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUseEoaSessionSigsToEncryptDecryptString
- * ✅ NETWORK=manzano yarn test:local --filter=testUseEoaSessionSigsToEncryptDecryptString
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUseEoaSessionSigsToEncryptDecryptString
+ * ✅ NETWORK=datil-test yarn test:local --filter=testUseEoaSessionSigsToEncryptDecryptString
  * ✅ NETWORK=custom yarn test:local --filter=testUseEoaSessionSigsToEncryptDecryptString
  */
 export const testUseEoaSessionSigsToEncryptDecryptString = async (

--- a/local-tests/tests/testUseEoaSessionSigsToEncryptDecryptUint8Array.ts
+++ b/local-tests/tests/testUseEoaSessionSigsToEncryptDecryptUint8Array.ts
@@ -16,8 +16,8 @@ import { log } from '@lit-protocol/misc';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUseEoaSessionSigsToEncryptDecryptUint8Array
- * ✅ NETWORK=manzano yarn test:local --filter=testUseEoaSessionSigsToEncryptDecryptUint8Array
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUseEoaSessionSigsToEncryptDecryptUint8Array
+ * ✅ NETWORK=datil-test yarn test:local --filter=testUseEoaSessionSigsToEncryptDecryptUint8Array
  * ✅ NETWORK=custom yarn test:local --filter=testUseEoaSessionSigsToEncryptDecryptUint8Array
  */
 export const testUseEoaSessionSigsToEncryptDecryptUint8Array = async (

--- a/local-tests/tests/testUseEoaSessionSigsToExecuteJsClaimKeys.ts
+++ b/local-tests/tests/testUseEoaSessionSigsToExecuteJsClaimKeys.ts
@@ -21,8 +21,8 @@ import { log } from '@lit-protocol/misc';
  * - Note: The key claiming process involves multiple nodes within the Lit network verifying the sessionSigs and collaboratively signing the claim, which results in the generation of a new key pair if successful.
  *
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUseEoaSessionSigsToExecuteJsClaimKeys
- * ✅ NETWORK=manzano yarn test:local --filter=testUseEoaSessionSigsToExecuteJsClaimKeys
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUseEoaSessionSigsToExecuteJsClaimKeys
+ * ✅ NETWORK=datil-test yarn test:local --filter=testUseEoaSessionSigsToExecuteJsClaimKeys
  * ✅ NETWORK=custom yarn test:local --filter=testUseEoaSessionSigsToExecuteJsClaimKeys
  */
 export const testUseEoaSessionSigsToExecuteJsClaimKeys = async (

--- a/local-tests/tests/testUseEoaSessionSigsToExecuteJsClaimMultipleKeys.ts
+++ b/local-tests/tests/testUseEoaSessionSigsToExecuteJsClaimMultipleKeys.ts
@@ -11,8 +11,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
  * - Then: The claim operation should successfully return signatures, derived key IDs, and validate the existence and structure of claimed results.
  * *
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUseEoaSessionSigsToExecuteJsClaimMultipleKeys
- * ✅ NETWORK=manzano yarn test:local --filter=testUseEoaSessionSigsToExecuteJsClaimMultipleKeys
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUseEoaSessionSigsToExecuteJsClaimMultipleKeys
+ * ✅ NETWORK=datil-test yarn test:local --filter=testUseEoaSessionSigsToExecuteJsClaimMultipleKeys
  * ✅ NETWORK=custom yarn test:local --filter=testUseEoaSessionSigsToExecuteJsClaimMultipleKeys
  */
 export const testUseEoaSessionSigsToExecuteJsClaimMultipleKeys = async (

--- a/local-tests/tests/testUseEoaSessionSigsToExecuteJsConsoleLog.ts
+++ b/local-tests/tests/testUseEoaSessionSigsToExecuteJsConsoleLog.ts
@@ -3,8 +3,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUseEoaSessionSigsToExecuteJsConsoleLog
- * ✅ NETWORK=manzano yarn test:local --filter=testUseEoaSessionSigsToExecuteJsConsoleLog
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUseEoaSessionSigsToExecuteJsConsoleLog
+ * ✅ NETWORK=datil-test yarn test:local --filter=testUseEoaSessionSigsToExecuteJsConsoleLog
  * ✅ NETWORK=custom yarn test:local --filter=testUseEoaSessionSigsToExecuteJsConsoleLog
  */
 export const testUseEoaSessionSigsToExecuteJsConsoleLog = async (

--- a/local-tests/tests/testUseEoaSessionSigsToExecuteJsJsonResponse.ts
+++ b/local-tests/tests/testUseEoaSessionSigsToExecuteJsJsonResponse.ts
@@ -3,8 +3,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUseEoaSessionSigsToExecuteJsJsonResponse
- * ✅ NETWORK=manzano yarn test:local --filter=testUseEoaSessionSigsToExecuteJsJsonResponse
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUseEoaSessionSigsToExecuteJsJsonResponse
+ * ✅ NETWORK=datil-test yarn test:local --filter=testUseEoaSessionSigsToExecuteJsJsonResponse
  * ✅ NETWORK=custom yarn test:local --filter=testUseEoaSessionSigsToExecuteJsJsonResponse
  */
 export const testUseEoaSessionSigsToExecuteJsJsonResponse = async (

--- a/local-tests/tests/testUseEoaSessionSigsToExecuteJsSigning.ts
+++ b/local-tests/tests/testUseEoaSessionSigsToExecuteJsSigning.ts
@@ -4,8 +4,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUseEoaSessionSigsToExecuteJsSigning
- * ✅ NETWORK=manzano yarn test:local --filter=testUseEoaSessionSigsToExecuteJsSigning
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUseEoaSessionSigsToExecuteJsSigning
+ * ✅ NETWORK=datil-test yarn test:local --filter=testUseEoaSessionSigsToExecuteJsSigning
  * ✅ NETWORK=custom yarn test:local --filter=testUseEoaSessionSigsToExecuteJsSigning
  */
 export const testUseEoaSessionSigsToExecuteJsSigning = async (

--- a/local-tests/tests/testUseEoaSessionSigsToExecuteJsSigningInParallel.ts
+++ b/local-tests/tests/testUseEoaSessionSigsToExecuteJsSigningInParallel.ts
@@ -4,8 +4,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUseEoaSessionSigsToExecuteJsSigningInParallel
- * ✅ NETWORK=manzano yarn test:local --filter=testUseEoaSessionSigsToExecuteJsSigningInParallel
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUseEoaSessionSigsToExecuteJsSigningInParallel
+ * ✅ NETWORK=datil-test yarn test:local --filter=testUseEoaSessionSigsToExecuteJsSigningInParallel
  * ✅ NETWORK=custom yarn test:local --filter=testUseEoaSessionSigsToExecuteJsSigningInParallel
  */
 export const testUseEoaSessionSigsToExecuteJsSigningInParallel = async (

--- a/local-tests/tests/testUseEoaSessionSigsToPkpSign.ts
+++ b/local-tests/tests/testUseEoaSessionSigsToPkpSign.ts
@@ -4,8 +4,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUseEoaSessionSigsToPkpSign
- * ✅ NETWORK=manzano yarn test:local --filter=testUseEoaSessionSigsToPkpSign
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUseEoaSessionSigsToPkpSign
+ * ✅ NETWORK=datil-test yarn test:local --filter=testUseEoaSessionSigsToPkpSign
  * ✅ NETWORK=custom yarn test:local --filter=testUseEoaSessionSigsToPkpSign
  */
 export const testUseEoaSessionSigsToPkpSign = async (

--- a/local-tests/tests/testUseInvalidLitActionCodeToGenerateSessionSigs.ts
+++ b/local-tests/tests/testUseInvalidLitActionCodeToGenerateSessionSigs.ts
@@ -4,16 +4,12 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUseInvalidLitActionCodeToGenerateSessionSigs
- * ❌ NOT AVAILABLE IN MANZANO
- * ✅ NETWORK=custom yarn test:local --filter=testUseInvalidLitActionCodeToGenerateSessionSigs
  * ✅ NETWORK=datil-dev yarn test:local --filter=testUseInvalidLitActionCodeToGenerateSessionSigs
+ * ✅ NETWORK=custom yarn test:local --filter=testUseInvalidLitActionCodeToGenerateSessionSigs
  */
 export const testUseInvalidLitActionCodeToGenerateSessionSigs = async (
   devEnv: TinnyEnvironment
 ) => {
-  devEnv.setUnavailable(LIT_NETWORK.Manzano);
-
   const alice = await devEnv.createRandomPerson();
 
   try {

--- a/local-tests/tests/testUseInvalidLitActionIpfsCodeToGenerateSessionSigs.ts
+++ b/local-tests/tests/testUseInvalidLitActionIpfsCodeToGenerateSessionSigs.ts
@@ -3,8 +3,7 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUseInvalidLitActionIpfsCodeToGenerateSessionSigs
- * ❌ NOT AVAILABLE IN MANZANO
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUseInvalidLitActionIpfsCodeToGenerateSessionSigs
  * ✅ NETWORK=custom yarn test:local --filter=testUseInvalidLitActionIpfsCodeToGenerateSessionSigs
  */
 export const testUseInvalidLitActionIpfsCodeToGenerateSessionSigs = async (

--- a/local-tests/tests/testUsePkpSessionSigsToEncryptDecryptFile.ts
+++ b/local-tests/tests/testUsePkpSessionSigsToEncryptDecryptFile.ts
@@ -9,8 +9,8 @@ import { encryptString, decryptToFile } from '@lit-protocol/encryption';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUsePkpSessionSigsToEncryptDecryptFile
- * ✅ NETWORK=manzano yarn test:local --filter=testUsePkpSessionSigsToEncryptDecryptFile
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUsePkpSessionSigsToEncryptDecryptFile
+ * ✅ NETWORK=datil-test yarn test:local --filter=testUsePkpSessionSigsToEncryptDecryptFile
  * ✅ NETWORK=custom yarn test:local --filter=testUsePkpSessionSigsToEncryptDecryptFile
  */
 export const testUsePkpSessionSigsToEncryptDecryptFile = async (

--- a/local-tests/tests/testUsePkpSessionSigsToEncryptDecryptString.ts
+++ b/local-tests/tests/testUsePkpSessionSigsToEncryptDecryptString.ts
@@ -9,8 +9,8 @@ import { encryptString, decryptToString } from '@lit-protocol/encryption';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUsePkpSessionSigsToEncryptDecryptString
- * ✅ NETWORK=manzano yarn test:local --filter=testUsePkpSessionSigsToEncryptDecryptString
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUsePkpSessionSigsToEncryptDecryptString
+ * ✅ NETWORK=datil-test yarn test:local --filter=testUsePkpSessionSigsToEncryptDecryptString
  * ✅ NETWORK=custom yarn test:local --filter=testUsePkpSessionSigsToEncryptDecryptString
  */
 export const testUsePkpSessionSigsToEncryptDecryptString = async (

--- a/local-tests/tests/testUsePkpSessionSigsToExecuteJsClaimKeys.ts
+++ b/local-tests/tests/testUsePkpSessionSigsToExecuteJsClaimKeys.ts
@@ -13,8 +13,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
  * - Note: The key claiming process involves multiple nodes within the Lit network verifying the sessionSigs and collaboratively signing the claim, which results in the generation of a new key pair if successful.
  *
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUsePkpSessionSigsToExecuteJsClaimKeys
- * ✅ NETWORK=manzano yarn test:local --filter=testUsePkpSessionSigsToExecuteJsClaimKeys
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUsePkpSessionSigsToExecuteJsClaimKeys
+ * ✅ NETWORK=datil-test yarn test:local --filter=testUsePkpSessionSigsToExecuteJsClaimKeys
  * ✅ NETWORK=custom yarn test:local --filter=testUsePkpSessionSigsToExecuteJsClaimKeys
  */
 export const testUsePkpSessionSigsToExecuteJsClaimKeys = async (

--- a/local-tests/tests/testUsePkpSessionSigsToExecuteJsClaimMultipleKeys.ts
+++ b/local-tests/tests/testUsePkpSessionSigsToExecuteJsClaimMultipleKeys.ts
@@ -11,8 +11,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
  * - Then: The claim operation should successfully return signatures, derived key IDs, and validate the existence and structure of claimed results.
  * *
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUsePkpSessionSigsToExecuteJsClaimMultipleKeys
- * ✅ NETWORK=manzano yarn test:local --filter=testUsePkpSessionSigsToExecuteJsClaimMultipleKeys
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUsePkpSessionSigsToExecuteJsClaimMultipleKeys
+ * ✅ NETWORK=datil-test yarn test:local --filter=testUsePkpSessionSigsToExecuteJsClaimMultipleKeys
  * ✅ NETWORK=custom yarn test:local --filter=testUsePkpSessionSigsToExecuteJsClaimMultipleKeys
  */
 export const testUsePkpSessionSigsToExecuteJsClaimMultipleKeys = async (

--- a/local-tests/tests/testUsePkpSessionSigsToExecuteJsConsoleLog.ts
+++ b/local-tests/tests/testUsePkpSessionSigsToExecuteJsConsoleLog.ts
@@ -3,8 +3,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUsePkpSessionSigsToExecuteJsConsoleLog
- * ✅ NETWORK=manzano yarn test:local --filter=testUsePkpSessionSigsToExecuteJsConsoleLog
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUsePkpSessionSigsToExecuteJsConsoleLog
+ * ✅ NETWORK=datil-test yarn test:local --filter=testUsePkpSessionSigsToExecuteJsConsoleLog
  * ✅ NETWORK=custom yarn test:local --filter=testUsePkpSessionSigsToExecuteJsConsoleLog
  */
 export const testUsePkpSessionSigsToExecuteJsConsoleLog = async (

--- a/local-tests/tests/testUsePkpSessionSigsToExecuteJsJsonResponse.ts
+++ b/local-tests/tests/testUsePkpSessionSigsToExecuteJsJsonResponse.ts
@@ -3,8 +3,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUsePkpSessionSigsToExecuteJsJsonResponse
- * ✅ NETWORK=manzano yarn test:local --filter=testUsePkpSessionSigsToExecuteJsJsonResponse
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUsePkpSessionSigsToExecuteJsJsonResponse
+ * ✅ NETWORK=datil-test yarn test:local --filter=testUsePkpSessionSigsToExecuteJsJsonResponse
  * ✅ NETWORK=custom yarn test:local --filter=testUsePkpSessionSigsToExecuteJsJsonResponse
  */
 export const testUsePkpSessionSigsToExecuteJsJsonResponse = async (

--- a/local-tests/tests/testUsePkpSessionSigsToExecuteJsSigning.ts
+++ b/local-tests/tests/testUsePkpSessionSigsToExecuteJsSigning.ts
@@ -4,8 +4,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUsePkpSessionSigsToExecuteJsSigning
- * ✅ NETWORK=manzano yarn test:local --filter=testUsePkpSessionSigsToExecuteJsSigning
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUsePkpSessionSigsToExecuteJsSigning
+ * ✅ NETWORK=datil-test yarn test:local --filter=testUsePkpSessionSigsToExecuteJsSigning
  * ✅ NETWORK=custom yarn test:local --filter=testUsePkpSessionSigsToExecuteJsSigning
  */
 export const testUsePkpSessionSigsToExecuteJsSigning = async (

--- a/local-tests/tests/testUsePkpSessionSigsToExecuteJsSigningInParallel.ts
+++ b/local-tests/tests/testUsePkpSessionSigsToExecuteJsSigningInParallel.ts
@@ -4,8 +4,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUsePkpSessionSigsToExecuteJsSigningInParallel
- * ✅ NETWORK=manzano yarn test:local --filter=testUsePkpSessionSigsToExecuteJsSigningInParallel
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUsePkpSessionSigsToExecuteJsSigningInParallel
+ * ✅ NETWORK=datil-test yarn test:local --filter=testUsePkpSessionSigsToExecuteJsSigningInParallel
  * ✅ NETWORK=custom yarn test:local --filter=testUsePkpSessionSigsToExecuteJsSigningInParallel
  */
 export const testUsePkpSessionSigsToExecuteJsSigningInParallel = async (

--- a/local-tests/tests/testUsePkpSessionSigsToPkpSign.ts
+++ b/local-tests/tests/testUsePkpSessionSigsToPkpSign.ts
@@ -4,8 +4,8 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUsePkpSessionSigsToPkpSign
- * ✅ NETWORK=manzano yarn test:local --filter=testUsePkpSessionSigsToPkpSign
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUsePkpSessionSigsToPkpSign
+ * ✅ NETWORK=datil-test yarn test:local --filter=testUsePkpSessionSigsToPkpSign
  * ✅ NETWORK=custom yarn test:local --filter=testUsePkpSessionSigsToPkpSign
  */
 export const testUsePkpSessionSigsToPkpSign = async (

--- a/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptFile.ts
+++ b/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptFile.ts
@@ -10,14 +10,13 @@ import { encryptString, decryptToFile } from '@lit-protocol/encryption';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptFile
- * ✅ NETWORK=manzano yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptFile
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptFile
+ * ✅ NETWORK=datil-test yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptFile
  * ✅ NETWORK=custom yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptFile
  * ✅ NETWORK=datil-dev yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptFile
  */
 export const testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptFile =
   async (devEnv: TinnyEnvironment) => {
-    devEnv.setUnavailable(LIT_NETWORK.Manzano);
     const alice = await devEnv.createRandomPerson();
 
     const message = 'Hello world';

--- a/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptString.ts
+++ b/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptString.ts
@@ -10,16 +10,12 @@ import { encryptString, decryptToString } from '@lit-protocol/encryption';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptString
- * ❌ NOT AVAILABLE IN MANZANO
- * ✅ NETWORK=custom yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptString
  * ✅ NETWORK=datil-dev yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptString
+ * ✅ NETWORK=custom yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptString
  *
  */
 export const testUseValidLitActionCodeGeneratedSessionSigsToEncryptDecryptString =
   async (devEnv: TinnyEnvironment) => {
-    devEnv.setUnavailable(LIT_NETWORK.Manzano);
-
     const alice = await devEnv.createRandomPerson();
     // set access control conditions for encrypting and decrypting
     const accs = AccessControlConditions.getEmvBasicAccessControlConditions({

--- a/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsClaimKeys.ts
+++ b/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsClaimKeys.ts
@@ -13,15 +13,11 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
  * - Then: The claim operation should successfully return signatures, derived key IDs, and validate the existence and structure of claimed results.
  * *
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsClaimMultipleKeys
- * ❌ Not supported in Manzano
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsClaimMultipleKeys
  * ✅ NETWORK=custom yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsClaimKeys
- * ✅ NETWORK=datil-dev yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsClaimKeys
  */
 export const testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsClaimKeys =
   async (devEnv: TinnyEnvironment) => {
-    devEnv.setUnavailable(LIT_NETWORK.Manzano);
-
     const alice = await devEnv.createRandomPerson();
     const litActionSessionSigs = await getLitActionSessionSigs(devEnv, alice, [
       {

--- a/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsClaimMultipleKeys.ts
+++ b/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsClaimMultipleKeys.ts
@@ -12,15 +12,11 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
  * - Then: The claim operation should successfully return signatures, derived key IDs, and validate the existence and structure of claimed results.
  * *
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsClaimMultipleKeys
- * ❌ Not supported in Manzano
- * ✅ NETWORK=custom yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsClaimMultipleKeys
  * ✅ NETWORK=datil-dev yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsClaimMultipleKeys
+ * ✅ NETWORK=custom yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsClaimMultipleKeys
  */
 export const testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsClaimMultipleKeys =
   async (devEnv: TinnyEnvironment) => {
-    devEnv.setUnavailable(LIT_NETWORK.Manzano);
-
     const alice = await devEnv.createRandomPerson();
 
     const litActionSessionSigs = await getLitActionSessionSigs(devEnv, alice);

--- a/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsConsoleLog.ts
+++ b/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsConsoleLog.ts
@@ -5,15 +5,11 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsConsoleLog
- * ❌ Not supported on manzano
- * ✅ NETWORK=custom yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsConsoleLog
  * ✅ NETWORK=datil-dev yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsConsoleLog
+ * ✅ NETWORK=custom yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsConsoleLog
  */
 export const testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsConsoleLog =
   async (devEnv: TinnyEnvironment) => {
-    devEnv.setUnavailable(LIT_NETWORK.Manzano);
-
     const alice = await devEnv.createRandomPerson();
 
     const litActionSessionSigs = await getLitActionSessionSigs(devEnv, alice, [

--- a/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsJsonResponse.ts
+++ b/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsJsonResponse.ts
@@ -1,18 +1,13 @@
-import { LIT_NETWORK } from '@lit-protocol/constants';
 import { getLitActionSessionSigs } from 'local-tests/setup/session-sigs/get-lit-action-session-sigs';
 import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsJsonResponse
- * ❌ Not supported on manzano
- * ✅ NETWORK=custom yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsJsonResponse
  * ✅ NETWORK=datil-dev yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsJsonResponse
+ * ✅ NETWORK=custom yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsJsonResponse
  */
 export const testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsJsonResponse =
   async (devEnv: TinnyEnvironment) => {
-    devEnv.setUnavailable(LIT_NETWORK.Manzano);
-
     const alice = await devEnv.createRandomPerson();
     const litActionSessionSigs = await getLitActionSessionSigs(devEnv, alice);
 

--- a/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsSigning.ts
+++ b/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsSigning.ts
@@ -6,16 +6,12 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsSigning
- * ❌ NOT AVAILABLE IN HABANERO
- * ✅ NETWORK=custom yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsSigning
  * ✅ NETWORK=datil-dev yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsSigning
+ * ✅ NETWORK=custom yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsSigning
  */
 export const testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsSigning =
   async (devEnv: TinnyEnvironment) => {
     //
-    // devEnv.setUnavailable(LIT_NETWORK.Manzano);
-
     const alice = await devEnv.createRandomPerson();
     const litActionSessionSigs = await getLitActionSessionSigs(devEnv, alice, [
       {

--- a/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsSigningInParallel.ts
+++ b/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsSigningInParallel.ts
@@ -5,15 +5,11 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsSigningInParallel
- * ❌ Not available in Habanero
- * ✅ NETWORK=custom yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsSigningInParallel
  * ✅ NETWORK=datil-dev yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsSigningInParallel
+ * ✅ NETWORK=custom yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsSigningInParallel
  */
 export const testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsSigningInParallel =
   async (devEnv: TinnyEnvironment) => {
-    devEnv.setUnavailable(LIT_NETWORK.Manzano);
-
     const alice = await devEnv.createRandomPerson();
 
     const litActionSessionSigs = await getLitActionSessionSigs(devEnv, alice);

--- a/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToPkpSign.ts
+++ b/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToPkpSign.ts
@@ -5,17 +5,13 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToPkpSign
- * ❌ NOT AVAILABLE IN HABANERO
- * ✅ NETWORK=custom yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToPkpSign
  * ✅ NETWORK=datil-dev yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToPkpSign
+ * ✅ NETWORK=custom yarn test:local --filter=testUseValidLitActionCodeGeneratedSessionSigsToPkpSign
  *
  **/
 export const testUseValidLitActionCodeGeneratedSessionSigsToPkpSign = async (
   devEnv: TinnyEnvironment
 ) => {
-  devEnv.setUnavailable(LIT_NETWORK.Manzano);
-
   const alice = await devEnv.createRandomPerson();
   const litActionSessionSigs = await getLitActionSessionSigs(devEnv, alice);
 

--- a/local-tests/tests/testUseValidLitActionIpfsCodeGeneratedSessionSigsToExecuteJsSigning.ts
+++ b/local-tests/tests/testUseValidLitActionIpfsCodeGeneratedSessionSigsToExecuteJsSigning.ts
@@ -6,8 +6,7 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUseValidLitActionIpfsCodeGeneratedSessionSigsToExecuteJsSigning
- * ❌ NOT AVAILABLE IN HABANERO
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUseValidLitActionIpfsCodeGeneratedSessionSigsToExecuteJsSigning
  * ✅ NETWORK=custom yarn test:local --filter=testUseValidLitActionIpfsCodeGeneratedSessionSigsToExecuteJsSigning
  */
 export const testUseValidLitActionIpfsCodeGeneratedSessionSigsToExecuteJsSigning =

--- a/local-tests/tests/testUseValidLitActionIpfsCodeGeneratedSessionSigsToPkpSign.ts
+++ b/local-tests/tests/testUseValidLitActionIpfsCodeGeneratedSessionSigsToPkpSign.ts
@@ -4,8 +4,7 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testUseValidLitActionIpfsCodeGeneratedSessionSigsToPkpSign
- * ❌ NOT AVAILABLE IN HABANERO
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUseValidLitActionIpfsCodeGeneratedSessionSigsToPkpSign
  * ❌ NETWORK=custom yarn test:local --filter=testUseValidLitActionIpfsCodeGeneratedSessionSigsToPkpSign
  *
  **/

--- a/local-tests/tests/wrapped-keys/testEthereumBroadcastTransactionGeneratedKey.ts
+++ b/local-tests/tests/wrapped-keys/testEthereumBroadcastTransactionGeneratedKey.ts
@@ -9,8 +9,8 @@ const { signTransactionWithEncryptedKey, generatePrivateKey } = api;
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testEthereumBroadcastTransactionGeneratedKey
- * ✅ NETWORK=manzano yarn test:local --filter=testEthereumBroadcastTransactionGeneratedKey
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testEthereumBroadcastTransactionGeneratedKey
+ * ✅ NETWORK=datil-test yarn test:local --filter=testEthereumBroadcastTransactionGeneratedKey
  * ✅ NETWORK=custom yarn test:local --filter=testEthereumBroadcastTransactionGeneratedKey
  */
 export const testEthereumBroadcastTransactionGeneratedKey = async (

--- a/local-tests/tests/wrapped-keys/testEthereumBroadcastTransactionWrappedKey.ts
+++ b/local-tests/tests/wrapped-keys/testEthereumBroadcastTransactionWrappedKey.ts
@@ -9,8 +9,8 @@ const { importPrivateKey, signTransactionWithEncryptedKey } = api;
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testEthereumBroadcastTransactionWrappedKey
- * ✅ NETWORK=manzano yarn test:local --filter=testEthereumBroadcastTransactionWrappedKey
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testEthereumBroadcastTransactionWrappedKey
+ * ✅ NETWORK=datil-test yarn test:local --filter=testEthereumBroadcastTransactionWrappedKey
  * ✅ NETWORK=custom yarn test:local --filter=testEthereumBroadcastTransactionWrappedKey
  */
 export const testEthereumBroadcastTransactionWrappedKey = async (

--- a/local-tests/tests/wrapped-keys/testEthereumBroadcastWrappedKeyWithFetchGasParams.ts
+++ b/local-tests/tests/wrapped-keys/testEthereumBroadcastWrappedKeyWithFetchGasParams.ts
@@ -9,8 +9,8 @@ const { importPrivateKey, signTransactionWithEncryptedKey } = api;
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testEthereumBroadcastWrappedKeyWithFetchGasParams
- * ✅ NETWORK=manzano yarn test:local --filter=testEthereumBroadcastWrappedKeyWithFetchGasParams
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testEthereumBroadcastWrappedKeyWithFetchGasParams
+ * ✅ NETWORK=datil-test yarn test:local --filter=testEthereumBroadcastWrappedKeyWithFetchGasParams
  * ✅ NETWORK=custom yarn test:local --filter=testEthereumBroadcastWrappedKeyWithFetchGasParams
  */
 export const testEthereumBroadcastWrappedKeyWithFetchGasParams = async (

--- a/local-tests/tests/wrapped-keys/testEthereumSignMessageGeneratedKey.ts
+++ b/local-tests/tests/wrapped-keys/testEthereumSignMessageGeneratedKey.ts
@@ -8,8 +8,8 @@ const { generatePrivateKey, signMessageWithEncryptedKey } = api;
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testEthereumSignMessageGeneratedKey
- * ✅ NETWORK=manzano yarn test:local --filter=testEthereumSignMessageGeneratedKey
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testEthereumSignMessageGeneratedKey
+ * ✅ NETWORK=datil-test yarn test:local --filter=testEthereumSignMessageGeneratedKey
  * ✅ NETWORK=custom yarn test:local --filter=testEthereumSignMessageGeneratedKey
  */
 export const testEthereumSignMessageGeneratedKey = async (

--- a/local-tests/tests/wrapped-keys/testEthereumSignMessageWrappedKey.ts
+++ b/local-tests/tests/wrapped-keys/testEthereumSignMessageWrappedKey.ts
@@ -8,8 +8,8 @@ const { importPrivateKey, signMessageWithEncryptedKey } = api;
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testEthereumSignMessageWrappedKey
- * ✅ NETWORK=manzano yarn test:local --filter=testEthereumSignMessageWrappedKey
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testEthereumSignMessageWrappedKey
+ * ✅ NETWORK=datil-test yarn test:local --filter=testEthereumSignMessageWrappedKey
  * ✅ NETWORK=custom yarn test:local --filter=testEthereumSignMessageWrappedKey
  */
 export const testEthereumSignMessageWrappedKey = async (

--- a/local-tests/tests/wrapped-keys/testEthereumSignTransactionWrappedKey.ts
+++ b/local-tests/tests/wrapped-keys/testEthereumSignTransactionWrappedKey.ts
@@ -11,8 +11,8 @@ const { importPrivateKey, signTransactionWithEncryptedKey } = api;
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testEthereumSignTransactionWrappedKey
- * ✅ NETWORK=manzano yarn test:local --filter=testEthereumSignTransactionWrappedKey
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testEthereumSignTransactionWrappedKey
+ * ✅ NETWORK=datil-test yarn test:local --filter=testEthereumSignTransactionWrappedKey
  * ✅ NETWORK=custom yarn test:local --filter=testEthereumSignTransactionWrappedKey
  */
 export const testEthereumSignTransactionWrappedKey = async (

--- a/local-tests/tests/wrapped-keys/testExportWrappedKey.ts
+++ b/local-tests/tests/wrapped-keys/testExportWrappedKey.ts
@@ -7,8 +7,8 @@ import { randomSolanaPrivateKey } from '../../setup/tinny-utils';
 const { exportPrivateKey, importPrivateKey } = api;
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testExportWrappedKey
- * ✅ NETWORK=manzano yarn test:local --filter=testExportWrappedKey
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testExportWrappedKey
+ * ✅ NETWORK=datil-test yarn test:local --filter=testExportWrappedKey
  * ✅ NETWORK=custom yarn test:local --filter=testExportWrappedKey
  */
 export const testExportWrappedKey = async (devEnv: TinnyEnvironment) => {

--- a/local-tests/tests/wrapped-keys/testFailEthereumSignTransactionWrappedKeyInvalidDecryption.ts
+++ b/local-tests/tests/wrapped-keys/testFailEthereumSignTransactionWrappedKeyInvalidDecryption.ts
@@ -12,8 +12,8 @@ import { GLOBAL_OVERWRITE_IPFS_CODE_BY_NETWORK } from '@lit-protocol/constants';
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testFailEthereumSignTransactionWrappedKeyInvalidDecryption
- * ✅ NETWORK=manzano yarn test:local --filter=testFailEthereumSignTransactionWrappedKeyInvalidDecryption
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testFailEthereumSignTransactionWrappedKeyInvalidDecryption
+ * ✅ NETWORK=datil-test yarn test:local --filter=testFailEthereumSignTransactionWrappedKeyInvalidDecryption
  * ✅ NETWORK=custom yarn test:local --filter=testFailEthereumSignTransactionWrappedKeyInvalidDecryption
  */
 export const testFailEthereumSignTransactionWrappedKeyInvalidDecryption =

--- a/local-tests/tests/wrapped-keys/testFailEthereumSignTransactionWrappedKeyWithInvalidParam.ts
+++ b/local-tests/tests/wrapped-keys/testFailEthereumSignTransactionWrappedKeyWithInvalidParam.ts
@@ -8,8 +8,8 @@ import { getBaseTransactionForNetwork } from './util';
 const { importPrivateKey, signTransactionWithEncryptedKey } = api;
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testFailEthereumSignTransactionWrappedKeyWithInvalidParam
- * ✅ NETWORK=manzano yarn test:local --filter=testFailEthereumSignTransactionWrappedKeyWithInvalidParam
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testFailEthereumSignTransactionWrappedKeyWithInvalidParam
+ * ✅ NETWORK=datil-test yarn test:local --filter=testFailEthereumSignTransactionWrappedKeyWithInvalidParam
  * ✅ NETWORK=custom yarn test:local --filter=testFailEthereumSignTransactionWrappedKeyWithInvalidParam
  */
 export const testFailEthereumSignTransactionWrappedKeyWithInvalidParam = async (

--- a/local-tests/tests/wrapped-keys/testFailEthereumSignTransactionWrappedKeyWithMissingParam.ts
+++ b/local-tests/tests/wrapped-keys/testFailEthereumSignTransactionWrappedKeyWithMissingParam.ts
@@ -8,8 +8,8 @@ import { getChainForNetwork } from './util';
 const { importPrivateKey, signTransactionWithEncryptedKey } = api;
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testFailEthereumSignTransactionWrappedKeyWithMissingParam
- * ✅ NETWORK=manzano yarn test:local --filter=testFailEthereumSignTransactionWrappedKeyWithMissingParam
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testFailEthereumSignTransactionWrappedKeyWithMissingParam
+ * ✅ NETWORK=datil-test yarn test:local --filter=testFailEthereumSignTransactionWrappedKeyWithMissingParam
  * ✅ NETWORK=custom yarn test:local --filter=testFailEthereumSignTransactionWrappedKeyWithMissingParam
  */
 export const testFailEthereumSignTransactionWrappedKeyWithMissingParam = async (

--- a/local-tests/tests/wrapped-keys/testFailImportWrappedKeysWithEoaSessionSig.ts
+++ b/local-tests/tests/wrapped-keys/testFailImportWrappedKeysWithEoaSessionSig.ts
@@ -7,8 +7,8 @@ const { importPrivateKey } = api;
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testFailImportWrappedKeysWithEoaSessionSig
- * ✅ NETWORK=manzano yarn test:local --filter=testFailImportWrappedKeysWithEoaSessionSig
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testFailImportWrappedKeysWithEoaSessionSig
+ * ✅ NETWORK=datil-test yarn test:local --filter=testFailImportWrappedKeysWithEoaSessionSig
  * ✅ NETWORK=custom yarn test:local --filter=testFailImportWrappedKeysWithEoaSessionSig
  */
 export const testFailImportWrappedKeysWithEoaSessionSig = async (

--- a/local-tests/tests/wrapped-keys/testFailImportWrappedKeysWithExpiredSessionSig.ts
+++ b/local-tests/tests/wrapped-keys/testFailImportWrappedKeysWithExpiredSessionSig.ts
@@ -7,8 +7,8 @@ const { importPrivateKey } = api;
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testFailImportWrappedKeysWithExpiredSessionSig
- * ✅ NETWORK=manzano yarn test:local --filter=testFailImportWrappedKeysWithExpiredSessionSig
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testFailImportWrappedKeysWithExpiredSessionSig
+ * ✅ NETWORK=datil-test yarn test:local --filter=testFailImportWrappedKeysWithExpiredSessionSig
  * ✅ NETWORK=custom yarn test:local --filter=testFailImportWrappedKeysWithExpiredSessionSig
  */
 export const testFailImportWrappedKeysWithExpiredSessionSig = async (

--- a/local-tests/tests/wrapped-keys/testFailImportWrappedKeysWithInvalidSessionSig.ts
+++ b/local-tests/tests/wrapped-keys/testFailImportWrappedKeysWithInvalidSessionSig.ts
@@ -8,8 +8,8 @@ const { importPrivateKey } = api;
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testFailImportWrappedKeysWithInvalidSessionSig
- * ✅ NETWORK=manzano yarn test:local --filter=testFailImportWrappedKeysWithInvalidSessionSig
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testFailImportWrappedKeysWithInvalidSessionSig
+ * ✅ NETWORK=datil-test yarn test:local --filter=testFailImportWrappedKeysWithInvalidSessionSig
  * ✅ NETWORK=custom yarn test:local --filter=testFailImportWrappedKeysWithInvalidSessionSig
  */
 export const testFailImportWrappedKeysWithInvalidSessionSig = async (

--- a/local-tests/tests/wrapped-keys/testFailImportWrappedKeysWithMaxExpirySessionSig.ts
+++ b/local-tests/tests/wrapped-keys/testFailImportWrappedKeysWithMaxExpirySessionSig.ts
@@ -7,8 +7,8 @@ const { importPrivateKey } = api;
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testFailImportWrappedKeysWithMaxExpirySessionSig
- * ✅ NETWORK=manzano yarn test:local --filter=testFailImportWrappedKeysWithMaxExpirySessionSig
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testFailImportWrappedKeysWithMaxExpirySessionSig
+ * ✅ NETWORK=datil-test yarn test:local --filter=testFailImportWrappedKeysWithMaxExpirySessionSig
  * ✅ NETWORK=custom yarn test:local --filter=testFailImportWrappedKeysWithMaxExpirySessionSig
  */
 export const testFailImportWrappedKeysWithMaxExpirySessionSig = async (

--- a/local-tests/tests/wrapped-keys/testFailImportWrappedKeysWithSamePrivateKey.ts
+++ b/local-tests/tests/wrapped-keys/testFailImportWrappedKeysWithSamePrivateKey.ts
@@ -5,8 +5,8 @@ import { getPkpSessionSigs } from 'local-tests/setup/session-sigs/get-pkp-sessio
 const { importPrivateKey } = api;
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testFailImportWrappedKeysWithSamePrivateKey
- * ✅ NETWORK=manzano yarn test:local --filter=testFailImportWrappedKeysWithSamePrivateKey
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testFailImportWrappedKeysWithSamePrivateKey
+ * ✅ NETWORK=datil-test yarn test:local --filter=testFailImportWrappedKeysWithSamePrivateKey
  * ✅ NETWORK=custom yarn test:local --filter=testFailImportWrappedKeysWithSamePrivateKey
  */
 export const testFailImportWrappedKeysWithSamePrivateKey = async (

--- a/local-tests/tests/wrapped-keys/testGenerateEthereumWrappedKey.ts
+++ b/local-tests/tests/wrapped-keys/testGenerateEthereumWrappedKey.ts
@@ -9,8 +9,8 @@ const { generatePrivateKey } = api;
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testGenerateEthereumWrappedKey
- * ✅ NETWORK=manzano yarn test:local --filter=testGenerateEthereumWrappedKey
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testGenerateEthereumWrappedKey
+ * ✅ NETWORK=datil-test yarn test:local --filter=testGenerateEthereumWrappedKey
  * ✅ NETWORK=custom yarn test:local --filter=testGenerateEthereumWrappedKey
  */
 export const testGenerateEthereumWrappedKey = async (

--- a/local-tests/tests/wrapped-keys/testGenerateSolanaWrappedKey.ts
+++ b/local-tests/tests/wrapped-keys/testGenerateSolanaWrappedKey.ts
@@ -11,8 +11,8 @@ const { generatePrivateKey, signMessageWithEncryptedKey, exportPrivateKey } =
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testGenerateSolanaWrappedKey
- * ✅ NETWORK=manzano yarn test:local --filter=testGenerateSolanaWrappedKey
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testGenerateSolanaWrappedKey
+ * ✅ NETWORK=datil-test yarn test:local --filter=testGenerateSolanaWrappedKey
  * ✅ NETWORK=custom yarn test:local --filter=testGenerateSolanaWrappedKey
  */
 export const testGenerateSolanaWrappedKey = async (

--- a/local-tests/tests/wrapped-keys/testImportWrappedKey.ts
+++ b/local-tests/tests/wrapped-keys/testImportWrappedKey.ts
@@ -10,8 +10,8 @@ const { importPrivateKey } = api;
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testImportWrappedKey
- * ✅ NETWORK=manzano yarn test:local --filter=testImportWrappedKey
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testImportWrappedKey
+ * ✅ NETWORK=datil-test yarn test:local --filter=testImportWrappedKey
  * ✅ NETWORK=custom yarn test:local --filter=testImportWrappedKey
  */
 export const testImportWrappedKey = async (devEnv: TinnyEnvironment) => {

--- a/local-tests/tests/wrapped-keys/testSignMessageWithSolanaEncryptedKey.ts
+++ b/local-tests/tests/wrapped-keys/testSignMessageWithSolanaEncryptedKey.ts
@@ -10,8 +10,8 @@ const { importPrivateKey, signMessageWithEncryptedKey } = api;
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testSignMessageWithSolanaEncryptedKey
- * ✅ NETWORK=manzano yarn test:local --filter=testSignMessageWithSolanaEncryptedKey
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testSignMessageWithSolanaEncryptedKey
+ * ✅ NETWORK=datil-test yarn test:local --filter=testSignMessageWithSolanaEncryptedKey
  * ✅ NETWORK=custom yarn test:local --filter=testSignMessageWithSolanaEncryptedKey
  */
 export const testSignMessageWithSolanaEncryptedKey = async (

--- a/local-tests/tests/wrapped-keys/testSignTransactionWithSolanaEncryptedKey.ts
+++ b/local-tests/tests/wrapped-keys/testSignTransactionWithSolanaEncryptedKey.ts
@@ -16,8 +16,8 @@ const { importPrivateKey, signTransactionWithEncryptedKey } = api;
 
 /**
  * Test Commands:
- * ✅ NETWORK=cayenne yarn test:local --filter=testSignTransactionWithSolanaEncryptedKey
- * ✅ NETWORK=manzano yarn test:local --filter=testSignTransactionWithSolanaEncryptedKey
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testSignTransactionWithSolanaEncryptedKey
+ * ✅ NETWORK=datil-test yarn test:local --filter=testSignTransactionWithSolanaEncryptedKey
  * ✅ NETWORK=custom yarn test:local --filter=testSignTransactionWithSolanaEncryptedKey
  */
 export const testSignTransactionWithSolanaEncryptedKey = async (

--- a/local-tests/tests/wrapped-keys/util.ts
+++ b/local-tests/tests/wrapped-keys/util.ts
@@ -8,13 +8,6 @@ export function getChainForNetwork(network: LIT_NETWORKS_KEYS): {
   chainId: number;
 } {
   switch (network) {
-    case 'cayenne':
-    case 'habanero':
-    case 'manzano':
-      return {
-        chain: 'chronicleTestnet',
-        chainId: LIT_CHAINS['chronicleTestnet'].chainId,
-      };
     case 'datil-dev':
       return {
         chain: 'yellowstone',
@@ -40,13 +33,6 @@ export function getGasParamsForNetwork(network: LIT_NETWORKS_KEYS): {
   gasLimit: number;
 } {
   switch (network) {
-    case 'cayenne':
-    case 'habanero':
-    case 'manzano':
-      return {
-        gasPrice: '0.001',
-        gasLimit: 30000,
-      };
     case 'datil-dev':
       return { gasLimit: 5000000 };
     case 'datil-test':

--- a/packages/auth-helpers/src/lib/recap/resource-builder.spec.ts
+++ b/packages/auth-helpers/src/lib/recap/resource-builder.spec.ts
@@ -1,4 +1,4 @@
-import { LitAbility } from '../models';
+import { LIT_ABILITY } from '@lit-protocol/constants';
 import {
   LitAccessControlConditionResource,
   LitActionResource,
@@ -26,11 +26,11 @@ describe('ResourceAbilityRequestBuilder', () => {
       JSON.stringify([
         {
           resource: new LitPKPResource('123'),
-          ability: LitAbility.PKPSigning,
+          ability: LIT_ABILITY.PKPSigning,
         },
         {
           resource: new LitActionResource('456'),
-          ability: LitAbility.LitActionExecution,
+          ability: LIT_ABILITY.LitActionExecution,
         },
       ])
     );
@@ -49,23 +49,23 @@ describe('ResourceAbilityRequestBuilder', () => {
       JSON.stringify([
         {
           resource: new LitPKPResource('123'),
-          ability: LitAbility.PKPSigning,
+          ability: LIT_ABILITY.PKPSigning,
         },
         {
           resource: new LitActionResource('456'),
-          ability: LitAbility.LitActionExecution,
+          ability: LIT_ABILITY.LitActionExecution,
         },
         {
           resource: new LitAccessControlConditionResource('789'),
-          ability: LitAbility.AccessControlConditionSigning,
+          ability: LIT_ABILITY.AccessControlConditionSigning,
         },
         {
           resource: new LitAccessControlConditionResource('abc'),
-          ability: LitAbility.AccessControlConditionDecryption,
+          ability: LIT_ABILITY.AccessControlConditionDecryption,
         },
         {
           resource: new LitRLIResource('def'),
-          ability: LitAbility.RateLimitIncreaseAuth,
+          ability: LIT_ABILITY.RateLimitIncreaseAuth,
         },
       ])
     );

--- a/packages/constants/src/lib/constants/constants.ts
+++ b/packages/constants/src/lib/constants/constants.ts
@@ -27,21 +27,6 @@ export const LIT_AUTH_SIG_CHAIN_KEYS: string[] = [
 export const AUTH_SIGNATURE_BODY =
   'I am creating an account to use Lit Protocol at {{timestamp}}';
 
-const oldChronicleChain = {
-  contractAddress: null,
-  chainId: 175177,
-  name: 'Chronicle - Lit Protocol Testnet',
-  symbol: 'tstLIT',
-  decimals: 18,
-  rpcUrls: [
-    'https://lit-protocol.calderachain.xyz/replica-http',
-    'https://chain-rpc.litprotocol.com/http',
-  ],
-  blockExplorerUrls: ['https://chain.litprotocol.com/'],
-  type: null,
-  vmType: 'EVM',
-};
-
 const yellowstoneChain = {
   contractAddress: null,
   chainId: 175188,
@@ -507,19 +492,11 @@ export const LIT_CHAINS: LITChain<LITEVMChain> = {
   },
 
   /**
-   * Chainlist entry for the Chronicle Testnet.
-   * https://chainlist.org/chain/175177
-   */
-  chronicleTestnet: oldChronicleChain,
-
-  /**
-   * Use this for `>= DatilTest` network.
+   * Use this for `>= Datil` network.
    * Chainlist entry for the Chronicle Yellowstone Testnet.
    * https://chainlist.org/chain/175188
    */
   yellowstone: yellowstoneChain,
-
-  lit: oldChronicleChain,
 
   chiado: {
     contractAddress: null,
@@ -776,22 +753,6 @@ export const LIT_CHAINS: LITChain<LITEVMChain> = {
  */
 export const METAMASK_CHAIN_INFO = {
   /**
-   * Information about the "chronicle" chain.
-   */
-  chronicle: {
-    chainId: LIT_CHAINS['chronicleTestnet'].chainId,
-    chainName: LIT_CHAINS['chronicleTestnet'].name,
-    nativeCurrency: {
-      name: LIT_CHAINS['chronicleTestnet'].symbol,
-      symbol: LIT_CHAINS['chronicleTestnet'].symbol,
-      decimals: LIT_CHAINS['chronicleTestnet'].decimals,
-    },
-    rpcUrls: LIT_CHAINS['chronicleTestnet'].rpcUrls,
-    blockExplorerUrls: LIT_CHAINS['chronicleTestnet'].blockExplorerUrls,
-    iconUrls: ['future'],
-  },
-
-  /**
    * Information about the "chronicleYellowstone" chain.
    */
   yellowstone: {
@@ -831,11 +792,6 @@ export const LIT_RPC = {
   LOCAL_ANVIL: 'http://127.0.0.1:8545',
 
   /**
-   * Chronicle RPC endpoint - Used for Cayenne, Manzano, Habanero
-   */
-  CHRONICLE: 'https://chain-rpc.litprotocol.com/http',
-
-  /**
    * Chronicle Yellowstone RPC endpoint - used for >= Datil-test
    * More info: https://app.conduit.xyz/published/view/chronicle-yellowstone-testnet-9qgmzfcohk
    */
@@ -848,9 +804,6 @@ export const LIT_EVM_CHAINS = LIT_CHAINS;
  * Represents the Lit Network constants.
  */
 export const LIT_NETWORK = {
-  Cayenne: 'cayenne',
-  Manzano: 'manzano',
-  Habanero: 'habanero',
   DatilDev: 'datil-dev',
   DatilTest: 'datil-test',
   Datil: 'datil',
@@ -886,9 +839,6 @@ export type LIT_NETWORK_VALUES = (typeof LIT_NETWORK)[keyof typeof LIT_NETWORK];
  * A mapping of network names to their corresponding RPC URLs.
  */
 export const RPC_URL_BY_NETWORK: { [key in LIT_NETWORK_VALUES]: string } = {
-  cayenne: LIT_RPC.CHRONICLE,
-  manzano: LIT_RPC.CHRONICLE,
-  habanero: LIT_RPC.CHRONICLE,
   'datil-dev': LIT_RPC.CHRONICLE_YELLOWSTONE,
   'datil-test': LIT_RPC.CHRONICLE_YELLOWSTONE,
   datil: LIT_RPC.CHRONICLE_YELLOWSTONE,
@@ -901,9 +851,6 @@ export const RPC_URL_BY_NETWORK: { [key in LIT_NETWORK_VALUES]: string } = {
 export const RELAYER_URL_BY_NETWORK: {
   [key in LIT_NETWORK_VALUES]: string;
 } = {
-  cayenne: 'https://relayer-server-staging-cayenne.getlit.dev',
-  manzano: 'https://manzano-relayer.getlit.dev',
-  habanero: 'https://habanero-relayer.getlit.dev',
   'datil-dev': 'https://datil-dev-relayer.getlit.dev',
   'datil-test': 'https://datil-test-relayer.getlit.dev',
   datil: 'https://datil-relayer.getlit.dev',
@@ -915,11 +862,8 @@ export const RELAYER_URL_BY_NETWORK: {
  */
 export const METAMASK_CHAIN_INFO_BY_NETWORK: Record<
   LIT_NETWORK_VALUES,
-  typeof METAMASK_CHAIN_INFO.chronicle | typeof METAMASK_CHAIN_INFO.yellowstone
+  typeof METAMASK_CHAIN_INFO.yellowstone
 > = {
-  cayenne: METAMASK_CHAIN_INFO.chronicle,
-  manzano: METAMASK_CHAIN_INFO.chronicle,
-  habanero: METAMASK_CHAIN_INFO.chronicle,
   'datil-dev': METAMASK_CHAIN_INFO.yellowstone,
   'datil-test': METAMASK_CHAIN_INFO.yellowstone,
   datil: METAMASK_CHAIN_INFO.yellowstone,
@@ -936,9 +880,6 @@ export const HTTP_BY_NETWORK: Record<
   LIT_NETWORK_VALUES,
   typeof HTTP | typeof HTTPS
 > = {
-  cayenne: HTTPS,
-  manzano: HTTPS,
-  habanero: HTTPS,
   'datil-dev': HTTPS,
   'datil-test': HTTPS,
   datil: HTTPS,
@@ -952,9 +893,6 @@ export const CENTRALISATION_BY_NETWORK: Record<
   LIT_NETWORK_VALUES,
   'centralised' | 'decentralised' | 'unknown'
 > = {
-  cayenne: 'centralised',
-  manzano: 'decentralised',
-  habanero: 'decentralised',
   'datil-dev': 'centralised',
   'datil-test': 'decentralised',
   datil: 'decentralised',
@@ -1100,22 +1038,14 @@ export const SYMM_KEY_ALGO_PARAMS = {
 };
 
 /**
- * Default node URL for Cayenne network
- */
-export const CAYENNE_URL = 'https://cayenne.litgateway.com';
-
-/**
  * Default node URLs for each LIT network
- * Note: Dynamic networks such as Habanero have no default node URLS; they are always
+ * Note: Dynamic networks have no default node URLS; they are always
  * loaded from the chain during initialization
  */
 export const LIT_NETWORKS: { [key in LIT_NETWORK_VALUES]: string[] } = {
-  cayenne: [],
-  manzano: [],
   'datil-dev': [],
   'datil-test': [],
   datil: [],
-  habanero: [],
   custom: [],
 };
 

--- a/packages/constants/src/lib/constants/mappers.ts
+++ b/packages/constants/src/lib/constants/mappers.ts
@@ -1,13 +1,6 @@
 import depd from 'depd';
 
-import {
-  cayenne,
-  manzano,
-  habanero,
-  datilDev,
-  datilTest,
-  datil,
-} from '@lit-protocol/contracts';
+import { datilDev, datilTest, datil } from '@lit-protocol/contracts';
 
 import { LIT_NETWORK_VALUES } from './constants';
 
@@ -18,16 +11,10 @@ const deprecated = depd('lit-js-sdk:constants:mappers');
  */
 export const NETWORK_CONTEXT_BY_NETWORK: {
   [key in LIT_NETWORK_VALUES]:
-    | typeof cayenne
-    | typeof manzano
-    | typeof habanero
     | typeof datilDev
     | typeof datilTest
     | typeof datil;
 } = {
-  cayenne: cayenne,
-  manzano: manzano,
-  habanero: habanero,
   'datil-dev': datilDev,
   'datil-test': datilTest,
   datil: datil,
@@ -39,9 +26,6 @@ export const NETWORK_CONTEXT_BY_NETWORK: {
 export const GLOBAL_OVERWRITE_IPFS_CODE_BY_NETWORK: {
   [key in LIT_NETWORK_VALUES]: boolean;
 } = {
-  cayenne: false,
-  manzano: false,
-  habanero: true,
   'datil-dev': false,
   'datil-test': false,
   datil: false,

--- a/packages/contracts-sdk/src/lib/contracts-sdk.ts
+++ b/packages/contracts-sdk/src/lib/contracts-sdk.ts
@@ -220,7 +220,7 @@ export class LitContracts {
     this.randomPrivateKey = args?.randomPrivatekey ?? false;
     this.options = args?.options;
     this.debug = args?.debug ?? false;
-    this.network = args?.network || 'cayenne';
+    this.network = args?.network || LIT_NETWORK.DatilDev;
     // if rpc is not specified, use the default rpc
     if (!this.rpc) {
       this.rpc = RPC_URL_BY_NETWORK[this.network];
@@ -1028,26 +1028,6 @@ export class LitContracts {
         // Fallback to HTTP if no other conditions are met
         HTTP;
 
-      // Check for specific conditions in centralised networks
-      if (centralisation === 'centralised') {
-        // Validate if it's cayenne AND port range is 8470 - 8479, if not, throw error
-        if (
-          network === LIT_NETWORK.Cayenne &&
-          !port.toString().startsWith('8')
-        ) {
-          throw new NetworkError(
-            {
-              info: {
-                ip,
-                port,
-                network,
-              },
-            },
-            `Invalid port: ${port} for the ${centralisation} ${network} network. Expected range: 8470 - 8479`
-          );
-        }
-      }
-
       const url = `${protocol}${ip}:${port}`;
 
       LitContracts.logger.debug("Validator's URL:", url);
@@ -1144,19 +1124,6 @@ export class LitContracts {
         (port === 443 ? HTTPS : HTTP_BY_NETWORK[litNetwork]) ||
         // Fallback to HTTP if no other conditions are met
         HTTP;
-
-      // Check for specific conditions in centralised networks
-      if (centralisation === 'centralised') {
-        // Validate if it's cayenne AND port range is 8470 - 8479, if not, throw error
-        if (
-          litNetwork === LIT_NETWORK.Cayenne &&
-          !(port >= 8470 && port <= 8479)
-        ) {
-          throw new Error(
-            `Invalid port: ${port} for the ${centralisation} ${litNetwork} network. Expected range: 8470 - 8479`
-          );
-        }
-      }
 
       const url = `${protocol}${ip}:${port}`;
 

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -118,8 +118,6 @@ const BLOCKHASH_SYNC_INTERVAL = 30_000;
 
 // Intentionally not including datil-dev here per discussion with Howard
 const NETWORKS_REQUIRING_SEV: string[] = [
-  LIT_NETWORK.Habanero,
-  LIT_NETWORK.Manzano,
   LIT_NETWORK.DatilTest,
   LIT_NETWORK.Datil,
 ];
@@ -140,7 +138,7 @@ export class LitCore {
     debug: true,
     connectTimeout: 20000,
     checkNodeAttestation: false,
-    litNetwork: 'cayenne', // Default to cayenne network. will be replaced by custom config.
+    litNetwork: LIT_NETWORK.Custom,
     minNodeCount: 2, // Default value, should be replaced
     bootstrapUrls: [], // Default value, should be replaced
     nodeProtocol: null,
@@ -179,10 +177,7 @@ export class LitCore {
     // Initialize default config based on litNetwork
     switch (config?.litNetwork) {
       // Official networks; default value for `checkNodeAttestation` according to network provided.
-      case LIT_NETWORK.Cayenne:
       case LIT_NETWORK.DatilDev:
-      case LIT_NETWORK.Manzano:
-      case LIT_NETWORK.Habanero:
         this.config = {
           ...this.config,
           checkNodeAttestation: NETWORKS_REQUIRING_SEV.includes(

--- a/packages/lit-auth-client/src/lib/relay.ts
+++ b/packages/lit-auth-client/src/lib/relay.ts
@@ -65,11 +65,11 @@ export class LitRelay implements IRelay {
    *
    * @param {LitRelayConfig} config
    * @param {string} [config.relayApiKey] - API key for Lit's relay server
-   * @param {string} [config.relayUrl] - URL for Lit's relay server. If not provided, will default to the Cayenne relay server.
+   * @param {string} [config.relayUrl] - URL for Lit's relay server. If not provided, will default to the last dev relay server.
    */
   constructor(config: LitRelayConfig) {
     this.relayUrl =
-      config.relayUrl || LitRelay.getRelayUrl(LIT_NETWORK.Cayenne);
+      config.relayUrl || LitRelay.getRelayUrl(LIT_NETWORK.DatilDev);
     this.relayApiKey = config.relayApiKey || '';
     log("Lit's relay server URL:", this.relayUrl);
   }

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.spec.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.spec.ts
@@ -5,6 +5,8 @@
 // [Lit-JS-SDK v2.2.39] ✅ [ECDSA SDK NodeJS] wasmECDSA loaded.
 global.jestTesting = true;
 
+import { LIT_NETWORK } from '@lit-protocol/constants';
+
 import { LitNodeClientNodeJs } from './lit-node-client-nodejs';
 
 const isClass = (v) => {
@@ -20,14 +22,14 @@ describe('LitNodeClientNodeJs', () => {
 
   it('should be able to instantiate a new LitNodeClientNodeJs to custom', async () => {
     const litNodeClient = new LitNodeClientNodeJs({
-      litNetwork: 'custom',
+      litNetwork: LIT_NETWORK.Custom,
     });
     expect(litNodeClient).toBeDefined();
   });
 
-  it('should be able to instantiate a new LitNodeClientNodeJs to cayenne', async () => {
+  it('should be able to instantiate a new LitNodeClientNodeJs to datil dev', async () => {
     const litNodeClient = new LitNodeClientNodeJs({
-      litNetwork: 'cayenne',
+      litNetwork: LIT_NETWORK.DatilDev,
     });
     expect(litNodeClient).toBeDefined();
   });
@@ -37,7 +39,7 @@ describe('LitNodeClientNodeJs', () => {
     Object.defineProperty(globalThis, 'localStorage', { value: undefined });
     const ls = require('node-localstorage').LocalStorage;
     const litNodeClient = new LitNodeClientNodeJs({
-      litNetwork: 'custom',
+      litNetwork: LIT_NETWORK.Custom,
       storageProvider: {
         provider: new ls('./storage.test.db'),
       },

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -35,7 +35,6 @@ import {
   UnknownError,
   InvalidSignatureError,
   UnsupportedMethodError,
-  LIT_ERROR,
   InvalidSessionSigs,
 } from '@lit-protocol/constants';
 import { LitCore, composeLitUrl } from '@lit-protocol/core';

--- a/packages/lit-node-client/src/lib/lit-node-client.ts
+++ b/packages/lit-node-client/src/lib/lit-node-client.ts
@@ -14,7 +14,7 @@ import { CustomNetwork, LitNodeClientConfig } from '@lit-protocol/types';
  * import { LIT_NETWORK } from '@lit-protocol/constants';
  *
  * const litNodeClient = new LitNodeClient({
-    litNetwork: LIT_NETWORK.Habanero,
+    litNetwork: LIT_NETWORK.DatilTest,
    });
  * ```
  */

--- a/packages/misc/src/lib/misc.ts
+++ b/packages/misc/src/lib/misc.ts
@@ -578,7 +578,7 @@ export const defaultMintClaimCallback: MintCallback<
   RelayClaimProcessor
 > = async (
   params: ClaimResult<RelayClaimProcessor>,
-  network: LIT_NETWORK_VALUES = 'cayenne'
+  network: LIT_NETWORK_VALUES = LIT_NETWORK.DatilDev
 ): Promise<string> => {
   isSupportedLitNetwork(network);
 

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -736,17 +736,6 @@ export interface NodeErrorV1 {
   errorCode?: string;
 }
 
-// V3 - Cayenne
-// {
-//   errorKind: 'Unexpected',
-//   errorCode: 'NodeUnknownError',
-//   status: 400,
-//   message: 'Unknown error occured',
-//   correlationId: 'lit_ef00fbaebb614',
-//   details: [
-//     'unexpected error: ECDSA signing failed: unexpected error: unexpected error: Message length to be signed is not 32 bytes.  Please hash it before sending it to the node to sign.  You can use SHA256 or Keccak256 for example'
-//   ]
-// }
 export interface NodeErrorV3 {
   errorKind: string;
   errorCode: string;

--- a/packages/types/src/lib/types.ts
+++ b/packages/types/src/lib/types.ts
@@ -112,14 +112,7 @@ export type LITCosmosChain = LITChainRequiredProps & {
  */
 export type LITChain<T> = Record<string, T>;
 
-export type LIT_NETWORKS_KEYS =
-  | 'cayenne'
-  | 'datil-dev'
-  | 'datil-test'
-  | 'datil'
-  | 'custom'
-  | 'habanero'
-  | 'manzano';
+export type LIT_NETWORKS_KEYS = 'datil-dev' | 'datil-test' | 'datil' | 'custom';
 
 export type SymmetricKey = Uint8Array | string | CryptoKey | BufferSource;
 export type EncryptedSymmetricKey = string | Uint8Array | any;

--- a/packages/wrapped-keys/src/lib/api/generate-private-key.ts
+++ b/packages/wrapped-keys/src/lib/api/generate-private-key.ts
@@ -39,11 +39,6 @@ export async function generatePrivateKey(
 ): Promise<GeneratePrivateKeyResult> {
   const { pkpSessionSigs, network, litNodeClient, memo } = params;
 
-  if (litNodeClient.config.litNetwork === 'habanero') {
-    throw new Error(
-      'generatePrivateKey is not available for `habanero`; this feature is still in beta and should not be used for production data yet.'
-    );
-  }
   const firstSessionSig = getFirstSessionSig(pkpSessionSigs);
   const pkpAddress = getPkpAddressFromSessionSig(firstSessionSig);
   const allowPkpAddressToDecrypt = getPkpAccessControlCondition(pkpAddress);

--- a/packages/wrapped-keys/src/lib/service-client/constants.ts
+++ b/packages/wrapped-keys/src/lib/service-client/constants.ts
@@ -12,9 +12,6 @@ export const SERVICE_URL_BY_LIT_NETWORK: Record<SupportedNetworks, string> = {
   [LIT_NETWORK.DatilDev]: SERVICE_URL_BY_NETWORKTYPE.TestNetworks,
   [LIT_NETWORK.DatilTest]: SERVICE_URL_BY_NETWORKTYPE.TestNetworks,
   [LIT_NETWORK.Datil]: SERVICE_URL_BY_NETWORKTYPE.Production,
-  [LIT_NETWORK.Cayenne]: SERVICE_URL_BY_NETWORKTYPE.TestNetworks,
-  [LIT_NETWORK.Manzano]: SERVICE_URL_BY_NETWORKTYPE.TestNetworks,
-  [LIT_NETWORK.Habanero]: SERVICE_URL_BY_NETWORKTYPE.Production,
 };
 
 export const LIT_SESSIONSIG_AUTHORIZATION_SCHEMA_PREFIX = 'LitSessionSig:';

--- a/packages/wrapped-keys/src/lib/service-client/types.ts
+++ b/packages/wrapped-keys/src/lib/service-client/types.ts
@@ -16,7 +16,7 @@ export type ListKeysParams = BaseApiParams;
 
 export type SupportedNetworks = Extract<
   LIT_NETWORK_VALUES,
-  'cayenne' | 'manzano' | 'habanero' | 'datil-dev' | 'datil-test' | 'datil'
+  'datil-dev' | 'datil-test' | 'datil'
 >;
 
 export interface StoreKeyParams extends BaseApiParams {

--- a/packages/wrapped-keys/src/lib/service-client/utils.ts
+++ b/packages/wrapped-keys/src/lib/service-client/utils.ts
@@ -20,9 +20,6 @@ function composeAuthHeader(sessionSig: AuthSig) {
 }
 
 const supportedNetworks: SupportedNetworks[] = [
-  'cayenne',
-  'manzano',
-  'habanero',
   'datil-dev',
   'datil-test',
   'datil',


### PR DESCRIPTION
# Description

This PR removes `cayenne`, `habanero` and `manzano` support from the SDK. They are replaced with `datil` family of networks

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration testing

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
