### PR TITLE
Feature/lit 3911 add request id aggregation to logger when logging is disabled

### DIFF
--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -71,6 +71,7 @@ import {
 } from '@lit-protocol/types';
 
 import { composeLitUrl } from './endpoint-version';
+import { LogLevel } from '@lit-protocol/logger';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type Listener = (...args: any[]) => void;
@@ -202,7 +203,7 @@ export class LitCore {
 
     // -- set global variables
     globalThis.litConfig = this.config;
-    bootstrapLogManager('core');
+    bootstrapLogManager('core', this.config.debug ? LogLevel.DEBUG : LogLevel.OFF);
 
     // -- configure local storage if not present
     // LitNodeClientNodejs is a base for LitNodeClient
@@ -694,6 +695,7 @@ export class LitCore {
               errorCode: LIT_ERROR.INIT_ERROR.name,
             });
           } catch (e) {
+            logErrorWithRequestId(requestId, e);
             reject(e);
           }
         }, this.config.connectTimeout);

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -203,7 +203,10 @@ export class LitCore {
 
     // -- set global variables
     globalThis.litConfig = this.config;
-    bootstrapLogManager('core', this.config.debug ? LogLevel.DEBUG : LogLevel.OFF);
+    bootstrapLogManager(
+      'core',
+      this.config.debug ? LogLevel.DEBUG : LogLevel.OFF
+    );
 
     // -- configure local storage if not present
     // LitNodeClientNodejs is a base for LitNodeClient

--- a/packages/logger/src/lib/logger.spec.ts
+++ b/packages/logger/src/lib/logger.spec.ts
@@ -111,6 +111,18 @@ describe('logger', () => {
     }
 
     expect(lm.getLogsForId('foo7').length).toEqual(count);
-    expect(lm.LoggerIds.size).toEqual(1);
+    expect(lm.LoggerIds.length).toEqual(10);
+  });
+
+  it('should order logs based on logger creation timestamp', async () => {
+    const loggerA = lm.get('a', '1');
+    await new Promise((res) => setTimeout(res, 100));
+    const loggerB = lm.get('b', '2');
+
+    const requestIds = lm.LoggerIds;
+
+    expect(requestIds.length).toBe(2);
+    expect(loggerA.timestamp).toEqual(requestIds[0]);
+    expect(loggerB.timestamp).toEqual(requestIds[1]);
   });
 });

--- a/packages/logger/src/lib/logger.ts
+++ b/packages/logger/src/lib/logger.ts
@@ -3,6 +3,7 @@ import { hashMessage } from 'ethers/lib/utils';
 import { version } from '@lit-protocol/constants';
 
 export enum LogLevel {
+  OFF = -1,
   ERROR = 0,
   INFO = 1,
   DEBUG = 2,
@@ -10,7 +11,6 @@ export enum LogLevel {
   FATAL = 4,
   TIMING_START = 5,
   TIMING_END = 6,
-  OFF = -1,
 }
 
 const colours = {

--- a/packages/logger/src/lib/logger.ts
+++ b/packages/logger/src/lib/logger.ts
@@ -444,7 +444,7 @@ export class LogManager {
 
     return keys
       .sort((a: [string, number], b: [string, number]) => {
-        return a[1] > b[1] ? a[1] : b[1];
+        return a[1] - b[1];       
       })
       .map((value: [string, number]) => {
         return value[0];

--- a/packages/logger/src/lib/logger.ts
+++ b/packages/logger/src/lib/logger.ts
@@ -318,7 +318,8 @@ export class Logger {
     const arrayLog = log.toArray();
     if (this._config?.['condenseLogs'] && !this._checkHash(log)) {
       (this._level >= level || level === LogLevel.ERROR) &&
-        this._consoleHandler && this._consoleHandler(...arrayLog);
+        this._consoleHandler &&
+        this._consoleHandler(...arrayLog);
       (this._level >= level || level === LogLevel.ERROR) &&
         this._handler &&
         this._handler(log);
@@ -326,7 +327,8 @@ export class Logger {
       (this._level >= level || level === LogLevel.ERROR) && this._addLog(log);
     } else if (!this._config?.['condenseLogs']) {
       (this._level >= level || level === LogLevel.ERROR) &&
-        this._consoleHandler && this._consoleHandler(...arrayLog);
+        this._consoleHandler &&
+        this._consoleHandler(...arrayLog);
       (this._level >= level || level === LogLevel.ERROR) &&
         this._handler &&
         this._handler(log);
@@ -440,11 +442,13 @@ export class LogManager {
       }
     }
 
-    return keys.sort((a: [string, number], b: [string, number]) => {
-      return a[1] > b[1] ? a[1] : b[1];
-    }).map((value: [string, number]) => {
-      return value[0]; 
-    });
+    return keys
+      .sort((a: [string, number], b: [string, number]) => {
+        return a[1] > b[1] ? a[1] : b[1];
+      })
+      .map((value: [string, number]) => {
+        return value[0];
+      });
   }
 
   // if a logger is given an id it will persist logs under its logger instance

--- a/packages/logger/src/lib/logger.ts
+++ b/packages/logger/src/lib/logger.ts
@@ -444,7 +444,7 @@ export class LogManager {
 
     return keys
       .sort((a: [string, number], b: [string, number]) => {
-        return a[1] - b[1];       
+        return a[1] - b[1];
       })
       .map((value: [string, number]) => {
         return value[0];

--- a/packages/misc/src/lib/misc.ts
+++ b/packages/misc/src/lib/misc.ts
@@ -278,7 +278,7 @@ export const log = (...args: any): void => {
     logBuffer.push(args);
     return;
   }
-  
+
   // if there are there are logs in buffer, print them first and empty the buffer.
   while (logBuffer.length > 0) {
     const log = logBuffer.shift() ?? '';
@@ -328,7 +328,6 @@ export const logErrorWithRequestId = (id: string, ...args: any) => {
     logBuffer.push(args);
     return;
   }
-
 
   // config is loaded, and debug is true
 

--- a/packages/misc/src/lib/misc.ts
+++ b/packages/misc/src/lib/misc.ts
@@ -302,8 +302,6 @@ export const logWithRequestId = (id: string, ...args: any) => {
     return;
   }
 
-  // config is loaded, and debug is true
-
   // if there are there are logs in buffer, print them first and empty the buffer.
   while (logBuffer.length > 0) {
     const log = logBuffer.shift() ?? '';
@@ -329,8 +327,6 @@ export const logErrorWithRequestId = (id: string, ...args: any) => {
     return;
   }
 
-  // config is loaded, and debug is true
-
   // if there are there are logs in buffer, print them first and empty the buffer.
   while (logBuffer.length > 0) {
     const log = logBuffer.shift() ?? '';
@@ -355,11 +351,6 @@ export const logError = (...args: any) => {
     logBuffer.push(args);
     return;
   }
-
-  if (globalThis?.litConfig?.debug !== true) {
-    return;
-  }
-  // config is loaded, and debug is true
 
   // if there are there are logs in buffer, print them first and empty the buffer.
   while (logBuffer.length > 0) {

--- a/packages/misc/src/lib/misc.ts
+++ b/packages/misc/src/lib/misc.ts
@@ -278,12 +278,7 @@ export const log = (...args: any): void => {
     logBuffer.push(args);
     return;
   }
-
-  if (globalThis?.litConfig?.debug !== true) {
-    return;
-  }
-  // config is loaded, and debug is true
-
+  
   // if there are there are logs in buffer, print them first and empty the buffer.
   while (logBuffer.length > 0) {
     const log = logBuffer.shift() ?? '';
@@ -307,9 +302,6 @@ export const logWithRequestId = (id: string, ...args: any) => {
     return;
   }
 
-  if (globalThis?.litConfig?.debug !== true) {
-    return;
-  }
   // config is loaded, and debug is true
 
   // if there are there are logs in buffer, print them first and empty the buffer.
@@ -337,9 +329,7 @@ export const logErrorWithRequestId = (id: string, ...args: any) => {
     return;
   }
 
-  if (globalThis?.litConfig?.debug !== true) {
-    return;
-  }
+
   // config is loaded, and debug is true
 
   // if there are there are logs in buffer, print them first and empty the buffer.


### PR DESCRIPTION
Allows for `request Ids` to be tracked if `debug` is not enabled on `LitNodeClient` by allowing logging calls to pass through the `Logger` instance.


Adds time based sorting to the array of `requests Ids` returned by `getRequestIds` on `LitCore`