### PR TITLE
fix: authSig should be delegated to bob's authMethodOwnedPkp instead …

### DIFF
--- a/local-tests/tests/testDelegatingCapacityCreditsNFTToAnotherPkpToExecuteJs.ts
+++ b/local-tests/tests/testDelegatingCapacityCreditsNFTToAnotherPkpToExecuteJs.ts
@@ -48,7 +48,7 @@ export const testDelegatingCapacityCreditsNFTToAnotherPkpToExecuteJs = async (
 
   // As a dApp owner, create a capacity delegation authSig for Bob's PKP wallet
   const capacityDelegationAuthSig = await alice.createCapacityDelegationAuthSig(
-    [bob.pkp.ethAddress]
+    [bob.authMethodOwnedPkp.ethAddress]
   );
 
   // As a dApp owner, delegate the capacity credits NFT to Bob


### PR DESCRIPTION
# Description

This test is failing cus the capacity delegation auth sig should be delegated to Bob's auth method owned PKP instead of his EOA's PKP