### PR TITLE
fix: `connection` is undefined when connecting to LitContracts

### DIFF
--- a/packages/contracts-sdk/src/lib/contracts-sdk.ts
+++ b/packages/contracts-sdk/src/lib/contracts-sdk.ts
@@ -415,12 +415,12 @@ export class LitContracts {
     }
 
     this.log('Your Signer:', this.signer);
-    this.log('Your Provider:', this.provider.connection);
+    this.log('Your Provider:', this.provider?.connection!);
 
     if (!this.provider) {
       this.log('No provider found. Will try to use the one from the signer.');
       this.provider = this.signer.provider;
-      this.log('Your Provider(from signer):', this.provider.connection);
+      this.log('Your Provider(from signer):', this.provider?.connection!);
     }
 
     const addresses: any = await LitContracts.getContractAddresses(


### PR DESCRIPTION
# Description

Fix for this: (Unable to connect using the LitContracts client)
<img width="653" alt="image" src="https://github.com/user-attachments/assets/1b28c99e-5d85-44df-bde7-65d6375ad839">

Due to this was added in the PR:
https://github.com/LIT-Protocol/js-sdk/pull/639/files#diff-2dcc2c94e7788b1bbaef5e6cf9158025a2580d238f807bd3cb923bbe355eb47bR401-R406

And we need this patch for the following affected versions:
- https://github.com/LIT-Protocol/js-sdk/pull/648
- https://github.com/LIT-Protocol/js-sdk/pull/658
- https://github.com/LIT-Protocol/js-sdk/pull/666

Anything <= 6.5.3 are working