### PR TITLE
feat: only wait for threshold nodes when signing session keys

### DIFF
--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -1869,7 +1869,7 @@ export class LitNodeClientNodeJs
       res = await this.handleNodePromises(
         nodePromises,
         requestId,
-        this.connectedNodes.size
+        this.config.minNodeCount
       );
       log('signSessionKey node promises:', res);
     } catch (e) {

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -1934,7 +1934,11 @@ export class LitNodeClientNodeJs
         for (const field of requiredFields) {
           const key: keyof BlsResponseData = field as keyof BlsResponseData;
 
-          if (!data[key] || data[key] === '') {
+          if (
+            data[key] === undefined ||
+            data[key] === null ||
+            data[key] === ''
+          ) {
             log(
               `[signSessionKey] Invalid signed data. "${field}" is missing. Not a problem, we only need ${this.config.minNodeCount} nodes to sign the session key.`
             );


### PR DESCRIPTION
# Description

This PR requires only the threshold nodes to sign sessions as it uses BLS, not ECDSA. Also fixes a check that was discarding node responses with an index value of `0` because it is considered `falsy` in JS

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Integration tests validate this part of code (failed before the index fix)
- [x] Locally with a script that uses PKPs and LAs with session keys

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
