### PR TITLE
Feature/lit 3945 js sdk add sendtosinglenode feature

### DIFF
--- a/local-tests/test.ts
+++ b/local-tests/test.ts
@@ -107,6 +107,7 @@ import { testSignTransactionWithSolanaEncryptedKey } from './tests/wrapped-keys/
 import { testBatchGeneratePrivateKeys } from './tests/wrapped-keys/testBatchGeneratePrivateKeys';
 
 import { setLitActionsCodeToLocal } from './tests/wrapped-keys/util';
+import { testUseEoaSessionSigsToRequestSingleResponse } from './tests/testUseEoaSessionSigsToRequestSingleResponse';
 
 // Use the current LIT action code to test against
 setLitActionsCodeToLocal();
@@ -170,6 +171,7 @@ setLitActionsCodeToLocal();
     testUseEoaSessionSigsToEncryptDecryptString,
     testUseEoaSessionSigsToEncryptDecryptFile,
     testUseEoaSessionSigsToEncryptDecryptZip,
+    testUseEoaSessionSigsToRequestSingleResponse,
   };
 
   const pkpSessionSigsTests = {

--- a/local-tests/tests/testUseEoaSessionSigsToRequestSingleResponse.ts
+++ b/local-tests/tests/testUseEoaSessionSigsToRequestSingleResponse.ts
@@ -13,18 +13,18 @@ export const testUseEoaSessionSigsToRequestSingleResponse = async (
   const alice = await devEnv.createRandomPerson();
 
   try {
-      const eoaSessionSigs = await getEoaSessionSigs(devEnv, alice);
-    
-      const res = await devEnv.litNodeClient.executeJs({
-        sessionSigs: eoaSessionSigs,
-        code: `(async () => {
+    const eoaSessionSigs = await getEoaSessionSigs(devEnv, alice);
+
+    const res = await devEnv.litNodeClient.executeJs({
+      sessionSigs: eoaSessionSigs,
+      code: `(async () => {
           console.log('hello world')
         })();`,
-        numResponsesRequired: 1,
-      });
-    } finally {
-      devEnv.releasePrivateKeyFromUser(alice);
-    }
+      numResponsesRequired: 1,
+    });
+  } finally {
+    devEnv.releasePrivateKeyFromUser(alice);
+  }
   console.log('res:', res);
 
   // Expected output:

--- a/local-tests/tests/testUseEoaSessionSigsToRequestSingleResponse.ts
+++ b/local-tests/tests/testUseEoaSessionSigsToRequestSingleResponse.ts
@@ -1,0 +1,55 @@
+import { getEoaSessionSigs } from 'local-tests/setup/session-sigs/get-eoa-session-sigs';
+import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
+
+/**
+ * Test Commands:
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUseEoaSessionSigsToRequestSingleResponse
+ * ✅ NETWORK=datil-test yarn test:local --filter=testUseEoaSessionSigsToRequestSingleResponse
+ * ✅ NETWORK=datil yarn test:local --filter=testUseEoaSessionSigsToRequestSingleResponse
+ */
+export const testUseEoaSessionSigsToRequestSingleResponse = async (
+  devEnv: TinnyEnvironment
+) => {
+  const alice = await devEnv.createRandomPerson();
+
+  const eoaSessionSigs = await getEoaSessionSigs(devEnv, alice);
+
+  const res = await devEnv.litNodeClient.executeJs({
+    sessionSigs: eoaSessionSigs,
+    code: `(async () => {
+      console.log('hello world')
+    })();`,
+    numResponsesRequired: 1,
+  });
+
+  devEnv.releasePrivateKeyFromUser(alice);
+
+  console.log('res:', res);
+
+  // Expected output:
+  // {
+  //   success: true,
+  //   signedData: {},
+  //   decryptedData: {},
+  //   claimData: {},
+  //   response: "",
+  //   logs: "hello world\n",
+  // }
+
+  // -- assertions
+  if (res.response) {
+    throw new Error(`Expected "response" to be falsy`);
+  }
+
+  if (!res.logs) {
+    throw new Error(`Expected "logs" in res`);
+  }
+
+  if (!res.logs.includes('hello world')) {
+    throw new Error(`Expected "logs" to include 'hello world'`);
+  }
+
+  if (!res.success) {
+    throw new Error(`Expected "success" in res`);
+  }
+};

--- a/local-tests/tests/testUseEoaSessionSigsToRequestSingleResponse.ts
+++ b/local-tests/tests/testUseEoaSessionSigsToRequestSingleResponse.ts
@@ -12,18 +12,19 @@ export const testUseEoaSessionSigsToRequestSingleResponse = async (
 ) => {
   const alice = await devEnv.createRandomPerson();
 
-  const eoaSessionSigs = await getEoaSessionSigs(devEnv, alice);
-
-  const res = await devEnv.litNodeClient.executeJs({
-    sessionSigs: eoaSessionSigs,
-    code: `(async () => {
-      console.log('hello world')
-    })();`,
-    numResponsesRequired: 1,
-  });
-
-  devEnv.releasePrivateKeyFromUser(alice);
-
+  try {
+      const eoaSessionSigs = await getEoaSessionSigs(devEnv, alice);
+    
+      const res = await devEnv.litNodeClient.executeJs({
+        sessionSigs: eoaSessionSigs,
+        code: `(async () => {
+          console.log('hello world')
+        })();`,
+        numResponsesRequired: 1,
+      });
+    } finally {
+      devEnv.releasePrivateKeyFromUser(alice);
+    }
   console.log('res:', res);
 
   // Expected output:

--- a/local-tests/tests/wrapped-keys/testBatchGeneratePrivateKeys.ts
+++ b/local-tests/tests/wrapped-keys/testBatchGeneratePrivateKeys.ts
@@ -93,7 +93,6 @@ export const testBatchGeneratePrivateKeys = async (
 
     const solanaMessageToSign = 'This is a test solana message';
     const evmMessageToSign = 'This is a test evm message';
-    const results = await batchGeneratePrivateKeys({
     const { results } = await batchGeneratePrivateKeys({
       pkpSessionSigs: pkpSessionSigsSigning,
       actions: [

--- a/packages/lit-node-client-nodejs/src/lib/helpers/get-signatures.ts
+++ b/packages/lit-node-client-nodejs/src/lib/helpers/get-signatures.ts
@@ -146,7 +146,7 @@ export const getSignatures = <T>(params: {
 
   if (allKeys.length !== initialKeys.length) {
     throwError({
-      message: 'total number of valid signatures does not match requested',
+      message: `Total number of valid signatures does not match requested. Valid signatures: ${allKeys.length}, Requested signatures: ${initialKeys.length}`,
       errorKind: LIT_ERROR.NO_VALID_SHARES.kind,
       errorCode: LIT_ERROR.NO_VALID_SHARES.code,
     });

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -135,7 +135,8 @@ import type {
 
 export class LitNodeClientNodeJs
   extends LitCore
-  implements LitClientSessionManager, ILitNodeClient {
+  implements LitClientSessionManager, ILitNodeClient
+{
   defaultAuthCallback?: (authSigParams: AuthCallbackParams) => Promise<AuthSig>;
 
   // ========== Constructor ==========
@@ -1276,8 +1277,8 @@ export class LitNodeClientNodeJs
         // -- optional params
         ...(params.authMethods &&
           params.authMethods.length > 0 && {
-          authMethods: params.authMethods,
-        }),
+            authMethods: params.authMethods,
+          }),
       };
 
       logWithRequestId(requestId, 'reqBody:', reqBody);
@@ -2075,8 +2076,8 @@ export class LitNodeClientNodeJs
     const sessionCapabilityObject = params.sessionCapabilityObject
       ? params.sessionCapabilityObject
       : await this.generateSessionCapabilityObjectWithWildcards(
-        params.resourceAbilityRequests.map((r) => r.resource)
-      );
+          params.resourceAbilityRequests.map((r) => r.resource)
+        );
     const expiration = params.expiration || LitNodeClientNodeJs.getExpiration();
 
     // -- (TRY) to get the wallet signature
@@ -2159,10 +2160,10 @@ export class LitNodeClientNodeJs
 
     const capabilities = params.capacityDelegationAuthSig
       ? [
-        ...(params.capabilityAuthSigs ?? []),
-        params.capacityDelegationAuthSig,
-        authSig,
-      ]
+          ...(params.capabilityAuthSigs ?? []),
+          params.capacityDelegationAuthSig,
+          authSig,
+        ]
       : [...(params.capabilityAuthSigs ?? []), authSig];
 
     const signingTemplate = {

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -135,8 +135,7 @@ import type {
 
 export class LitNodeClientNodeJs
   extends LitCore
-  implements LitClientSessionManager, ILitNodeClient
-{
+  implements LitClientSessionManager, ILitNodeClient {
   defaultAuthCallback?: (authSigParams: AuthCallbackParams) => Promise<AuthSig>;
 
   // ========== Constructor ==========
@@ -1098,7 +1097,7 @@ export class LitNodeClientNodeJs
     const res = await this.handleNodePromises(
       nodePromises,
       requestId,
-      this.connectedNodes.size
+      params.numResponsesRequired || this.connectedNodes.size
     );
 
     // -- case: promises rejected
@@ -1162,7 +1161,7 @@ export class LitNodeClientNodeJs
     const signatures = getSignatures({
       requestId,
       networkPubKeySet: this.networkPubKeySet,
-      minNodeCount: this.config.minNodeCount,
+      minNodeCount: params.numResponsesRequired || this.config.minNodeCount,
       signedData: signedDataList,
     });
 
@@ -1277,8 +1276,8 @@ export class LitNodeClientNodeJs
         // -- optional params
         ...(params.authMethods &&
           params.authMethods.length > 0 && {
-            authMethods: params.authMethods,
-          }),
+          authMethods: params.authMethods,
+        }),
       };
 
       logWithRequestId(requestId, 'reqBody:', reqBody);
@@ -2076,8 +2075,8 @@ export class LitNodeClientNodeJs
     const sessionCapabilityObject = params.sessionCapabilityObject
       ? params.sessionCapabilityObject
       : await this.generateSessionCapabilityObjectWithWildcards(
-          params.resourceAbilityRequests.map((r) => r.resource)
-        );
+        params.resourceAbilityRequests.map((r) => r.resource)
+      );
     const expiration = params.expiration || LitNodeClientNodeJs.getExpiration();
 
     // -- (TRY) to get the wallet signature
@@ -2160,10 +2159,10 @@ export class LitNodeClientNodeJs
 
     const capabilities = params.capacityDelegationAuthSig
       ? [
-          ...(params.capabilityAuthSigs ?? []),
-          params.capacityDelegationAuthSig,
-          authSig,
-        ]
+        ...(params.capabilityAuthSigs ?? []),
+        params.capacityDelegationAuthSig,
+        authSig,
+      ]
       : [...(params.capabilityAuthSigs ?? []), authSig];
 
     const signingTemplate = {

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -314,7 +314,7 @@ export interface JsonSignChainDataRequest {
 
 export interface JsonSignSessionKeyRequestV1
   extends Pick<LitActionSdkParams, 'jsParams'>,
-    Pick<LitActionSdkParams, 'litActionIpfsId'> {
+  Pick<LitActionSdkParams, 'litActionIpfsId'> {
   sessionKey: string;
   authMethods: AuthMethod[];
   pkpPublicKey?: string;
@@ -502,7 +502,8 @@ export interface JsonExecutionSdkParamsTargetNode
 }
 
 export interface JsonExecutionSdkParams
-  extends Pick<LitActionSdkParams, 'jsParams'> {
+  extends Pick<LitActionSdkParams, 'jsParams'>,
+  ExecuteJsAdvancedOptions {
   /**
    *  JS code to run on the nodes
    */
@@ -522,6 +523,9 @@ export interface JsonExecutionSdkParams
    * auth methods to resolve
    */
   authMethods?: AuthMethod[];
+}
+
+export interface ExecuteJsAdvancedOptions {
 
   /**
    * a strategy for proccessing `reponse` objects returned from the
@@ -529,7 +533,20 @@ export interface JsonExecutionSdkParams
    */
   responseStrategy?: LitActionResponseStrategy;
 
+  /**
+   * Allow overriding the default `code` property in the `JsonExecutionSdkParams`
+   */
   ipfsOptions?: IpfsOptions;
+
+  /**
+   * number of responses required to consider the execution successful
+   */
+  numResponsesRequired?: number;
+
+  /**
+   * idea: the number of nodes to pay for running executions
+   */
+  // numNodesToRunOn?: number;
 }
 
 export interface JsonExecutionRequestTargetNode extends JsonExecutionRequest {
@@ -568,7 +585,7 @@ export interface SessionSigsOrAuthSig {
 
 export interface DecryptRequestBase
   extends SessionSigsOrAuthSig,
-    MultipleAccessControlConditions {
+  MultipleAccessControlConditions {
   /**
    * The chain name of the chain that this contract is deployed on.  See LIT_CHAINS for currently supported chains.
    */
@@ -613,7 +630,7 @@ export interface EncryptFileRequest extends DecryptRequestBase {
   file: AcceptedFileType;
 }
 
-export interface DecryptRequest extends EncryptResponse, DecryptRequestBase {}
+export interface DecryptRequest extends EncryptResponse, DecryptRequestBase { }
 
 export interface DecryptResponse {
   // The decrypted data as a Uint8Array
@@ -635,10 +652,10 @@ export interface SigResponse {
 
 export interface ExecuteJsResponseBase {
   signatures:
-    | {
-        sig: SigResponse;
-      }
-    | any;
+  | {
+    sig: SigResponse;
+  }
+  | any;
 }
 
 /**
@@ -668,7 +685,7 @@ export interface ExecuteJsNoSigningResponse extends ExecuteJsResponseBase {
   logs: string;
 }
 
-export interface LitNodePromise {}
+export interface LitNodePromise { }
 
 export interface SendNodeCommand {
   url: string;
@@ -677,17 +694,17 @@ export interface SendNodeCommand {
 }
 export interface SigShare {
   sigType:
-    | 'BLS'
-    | 'K256'
-    | 'ECDSA_CAIT_SITH' // Legacy alias of K256
-    | 'EcdsaCaitSithP256';
+  | 'BLS'
+  | 'K256'
+  | 'ECDSA_CAIT_SITH' // Legacy alias of K256
+  | 'EcdsaCaitSithP256';
 
   signatureShare: string;
   shareIndex?: number;
   bigr?: string; // backward compatibility
   bigR?: string;
   publicKey: string;
-  dataSigned?: string;
+  dataSigned?: string | 'fail';
   siweMessage?: string;
   sigName?: string;
 }
@@ -704,6 +721,8 @@ export interface PkpSignedData {
 export interface NodeShare {
   claimData: any;
   shareIndex: any;
+
+  // I think this is deprecated
   unsignedJwt: any;
   signedData: SigShare;
   decryptedData: any;
@@ -1146,7 +1165,7 @@ export interface CommonGetSessionSigsProps {
 
 export interface BaseProviderGetSessionSigsProps
   extends CommonGetSessionSigsProps,
-    LitActionSdkParams {
+  LitActionSdkParams {
   /**
    * This is a callback that will be used to generate an AuthSig within the session signatures. It's inclusion is required, as it defines the specific resources and abilities that will be allowed for the current session.
    */
@@ -1155,7 +1174,7 @@ export interface BaseProviderGetSessionSigsProps
 
 export interface GetSessionSigsProps
   extends CommonGetSessionSigsProps,
-    LitActionSdkParams {
+  LitActionSdkParams {
   /**
    * This is a callback that will be used to generate an AuthSig within the session signatures. It's inclusion is required, as it defines the specific resources and abilities that will be allowed for the current session.
    */
@@ -1679,7 +1698,7 @@ export interface LoginUrlParams {
   error: string | null;
 }
 
-export interface BaseAuthenticateOptions {}
+export interface BaseAuthenticateOptions { }
 
 export interface EthWalletAuthenticateOptions extends BaseAuthenticateOptions {
   /**
@@ -1745,9 +1764,9 @@ export interface MintCapacityCreditsPerKilosecond
 }
 export interface MintCapacityCreditsContext
   extends MintCapacityCreditsPerDay,
-    MintCapacityCreditsPerSecond,
-    MintCapacityCreditsPerKilosecond,
-    GasLimitParam {}
+  MintCapacityCreditsPerSecond,
+  MintCapacityCreditsPerKilosecond,
+  GasLimitParam { }
 export interface MintCapacityCreditsRes {
   rliTxHash: string;
   capacityTokenId: any;
@@ -1870,12 +1889,12 @@ export interface LitActionSdkParams {
    * An object that contains params to expose to the Lit Action.  These will be injected to the JS runtime before your code runs, so you can use any of these as normal variables in your Lit Action.
    */
   jsParams?:
-    | {
-        [key: string]: any;
-        publicKey?: string;
-        sigName?: string;
-      }
-    | any;
+  | {
+    [key: string]: any;
+    publicKey?: string;
+    sigName?: string;
+  }
+  | any;
 }
 
 export interface LitEndpoint {
@@ -1897,7 +1916,7 @@ export interface SignerLike {
 
 export interface GetPkpSessionSigs
   extends CommonGetSessionSigsProps,
-    LitActionSdkParams {
+  LitActionSdkParams {
   pkpPublicKey: string;
 
   /**
@@ -1923,11 +1942,11 @@ export type GetLitActionSessionSigs = CommonGetSessionSigsProps &
   Pick<Required<LitActionSdkParams>, 'jsParams'> &
   (
     | (Pick<Required<LitActionSdkParams>, 'litActionCode'> & {
-        litActionIpfsId?: never;
-      })
+      litActionIpfsId?: never;
+    })
     | (Pick<Required<LitActionSdkParams>, 'litActionIpfsId'> & {
-        litActionCode?: never;
-      })
+      litActionCode?: never;
+    })
   ) & {
     ipfsOptions?: IpfsOptions;
   };

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -314,7 +314,7 @@ export interface JsonSignChainDataRequest {
 
 export interface JsonSignSessionKeyRequestV1
   extends Pick<LitActionSdkParams, 'jsParams'>,
-  Pick<LitActionSdkParams, 'litActionIpfsId'> {
+    Pick<LitActionSdkParams, 'litActionIpfsId'> {
   sessionKey: string;
   authMethods: AuthMethod[];
   pkpPublicKey?: string;
@@ -503,7 +503,7 @@ export interface JsonExecutionSdkParamsTargetNode
 
 export interface JsonExecutionSdkParams
   extends Pick<LitActionSdkParams, 'jsParams'>,
-  ExecuteJsAdvancedOptions {
+    ExecuteJsAdvancedOptions {
   /**
    *  JS code to run on the nodes
    */
@@ -526,7 +526,6 @@ export interface JsonExecutionSdkParams
 }
 
 export interface ExecuteJsAdvancedOptions {
-
   /**
    * a strategy for proccessing `reponse` objects returned from the
    * Lit Action execution context
@@ -585,7 +584,7 @@ export interface SessionSigsOrAuthSig {
 
 export interface DecryptRequestBase
   extends SessionSigsOrAuthSig,
-  MultipleAccessControlConditions {
+    MultipleAccessControlConditions {
   /**
    * The chain name of the chain that this contract is deployed on.  See LIT_CHAINS for currently supported chains.
    */
@@ -630,7 +629,7 @@ export interface EncryptFileRequest extends DecryptRequestBase {
   file: AcceptedFileType;
 }
 
-export interface DecryptRequest extends EncryptResponse, DecryptRequestBase { }
+export interface DecryptRequest extends EncryptResponse, DecryptRequestBase {}
 
 export interface DecryptResponse {
   // The decrypted data as a Uint8Array
@@ -652,10 +651,10 @@ export interface SigResponse {
 
 export interface ExecuteJsResponseBase {
   signatures:
-  | {
-    sig: SigResponse;
-  }
-  | any;
+    | {
+        sig: SigResponse;
+      }
+    | any;
 }
 
 /**
@@ -685,7 +684,7 @@ export interface ExecuteJsNoSigningResponse extends ExecuteJsResponseBase {
   logs: string;
 }
 
-export interface LitNodePromise { }
+export interface LitNodePromise {}
 
 export interface SendNodeCommand {
   url: string;
@@ -694,10 +693,10 @@ export interface SendNodeCommand {
 }
 export interface SigShare {
   sigType:
-  | 'BLS'
-  | 'K256'
-  | 'ECDSA_CAIT_SITH' // Legacy alias of K256
-  | 'EcdsaCaitSithP256';
+    | 'BLS'
+    | 'K256'
+    | 'ECDSA_CAIT_SITH' // Legacy alias of K256
+    | 'EcdsaCaitSithP256';
 
   signatureShare: string;
   shareIndex?: number;
@@ -1165,7 +1164,7 @@ export interface CommonGetSessionSigsProps {
 
 export interface BaseProviderGetSessionSigsProps
   extends CommonGetSessionSigsProps,
-  LitActionSdkParams {
+    LitActionSdkParams {
   /**
    * This is a callback that will be used to generate an AuthSig within the session signatures. It's inclusion is required, as it defines the specific resources and abilities that will be allowed for the current session.
    */
@@ -1174,7 +1173,7 @@ export interface BaseProviderGetSessionSigsProps
 
 export interface GetSessionSigsProps
   extends CommonGetSessionSigsProps,
-  LitActionSdkParams {
+    LitActionSdkParams {
   /**
    * This is a callback that will be used to generate an AuthSig within the session signatures. It's inclusion is required, as it defines the specific resources and abilities that will be allowed for the current session.
    */
@@ -1698,7 +1697,7 @@ export interface LoginUrlParams {
   error: string | null;
 }
 
-export interface BaseAuthenticateOptions { }
+export interface BaseAuthenticateOptions {}
 
 export interface EthWalletAuthenticateOptions extends BaseAuthenticateOptions {
   /**
@@ -1764,9 +1763,9 @@ export interface MintCapacityCreditsPerKilosecond
 }
 export interface MintCapacityCreditsContext
   extends MintCapacityCreditsPerDay,
-  MintCapacityCreditsPerSecond,
-  MintCapacityCreditsPerKilosecond,
-  GasLimitParam { }
+    MintCapacityCreditsPerSecond,
+    MintCapacityCreditsPerKilosecond,
+    GasLimitParam {}
 export interface MintCapacityCreditsRes {
   rliTxHash: string;
   capacityTokenId: any;
@@ -1889,12 +1888,12 @@ export interface LitActionSdkParams {
    * An object that contains params to expose to the Lit Action.  These will be injected to the JS runtime before your code runs, so you can use any of these as normal variables in your Lit Action.
    */
   jsParams?:
-  | {
-    [key: string]: any;
-    publicKey?: string;
-    sigName?: string;
-  }
-  | any;
+    | {
+        [key: string]: any;
+        publicKey?: string;
+        sigName?: string;
+      }
+    | any;
 }
 
 export interface LitEndpoint {
@@ -1916,7 +1915,7 @@ export interface SignerLike {
 
 export interface GetPkpSessionSigs
   extends CommonGetSessionSigsProps,
-  LitActionSdkParams {
+    LitActionSdkParams {
   pkpPublicKey: string;
 
   /**
@@ -1942,11 +1941,11 @@ export type GetLitActionSessionSigs = CommonGetSessionSigsProps &
   Pick<Required<LitActionSdkParams>, 'jsParams'> &
   (
     | (Pick<Required<LitActionSdkParams>, 'litActionCode'> & {
-      litActionIpfsId?: never;
-    })
+        litActionIpfsId?: never;
+      })
     | (Pick<Required<LitActionSdkParams>, 'litActionIpfsId'> & {
-      litActionCode?: never;
-    })
+        litActionCode?: never;
+      })
   ) & {
     ipfsOptions?: IpfsOptions;
   };


### PR DESCRIPTION
# Description

- add `numResponsesRequired` param to `executeJs`.

❗️❗️Note that setting the number of required responses to less than the threshold will cause `Lit.Actions.signEcdsa` to fail when running `executeJs` because ECDSA requires a minimum number of participants (the threshold) to collaboratively generate a valid signature. If fewer nodes participate, the signature cannot be formed, leading to a failure.

eg.

❌ Not good
```ts
  const res = await devEnv.litNodeClient.executeJs({
    sessionSigs: eoaSessionSigs,
    code: `(async () => {
      const sigShare = await LitActions.signEcdsa({ <== 👈 Signing using ECDSA 
        toSign: dataToSign,
        publicKey,
        sigName: "sig",
      });
    })();`,
    jsParams: {
      dataToSign: alice.loveLetter,
      publicKey: alice.pkp.publicKey,
    },
    numResponsesRequired: 1, <=== ❌ This will fail, eg. need at least 5 if we have connected to 9 nodes
  });
```
✅ This is good 

```ts
  const res = await devEnv.litNodeClient.executeJs({
    sessionSigs: eoaSessionSigs,
    code: `(async () => {
        console.log("testing"); <=== 👈 Only console.logging
    })();`,
    jsParams: {
      dataToSign: alice.loveLetter,
      publicKey: alice.pkp.publicKey,
    },
    numResponsesRequired: 1, <=== ✅ Das ist gut 
  });
```