### PR TITLE
fix: add `@lit-protocol/contracts` to auth-browser peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@cosmjs/stargate": "0.30.1",
     "@dotenvx/dotenvx": "^1.6.4",
     "@lit-protocol/accs-schemas": "^0.0.20",
-    "@lit-protocol/contracts": "^0.0.63",
+    "@lit-protocol/contracts": "^0.0.74",
     "@metamask/eth-sig-util": "5.0.2",
     "@mysten/sui.js": "^0.37.1",
     "@openagenda/verror": "^3.1.4",

--- a/packages/auth-browser/package.json
+++ b/packages/auth-browser/package.json
@@ -25,7 +25,8 @@
     "tweetnacl": "^1.0.3",
     "tweetnacl-util": "^0.13.3",
     "util": "^0.12.4",
-    "web-vitals": "^3.0.4"
+    "web-vitals": "^3.0.4",
+    "@lit-protocol/contracts": "^0.0.74"
   },
   "tags": [
     "browser"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3042,10 +3042,10 @@
   dependencies:
     ajv "^8.12.0"
 
-"@lit-protocol/contracts@^0.0.63":
-  version "0.0.63"
-  resolved "https://registry.yarnpkg.com/@lit-protocol/contracts/-/contracts-0.0.63.tgz#8700c37df9d2422e9c97aa27871fb64de6186f6c"
-  integrity sha512-CAorNt72ybIY/g//dDeR837izNGuYQR99XwPSK2X2AJ6c+aZX1kdXCrOnxsbY40BzFrOk/dIFo+ymJ9E3qh48w==
+"@lit-protocol/contracts@^0.0.74":
+  version "0.0.74"
+  resolved "https://registry.yarnpkg.com/@lit-protocol/contracts/-/contracts-0.0.74.tgz#e726a9190c86b10cc6df3a392cd04d19057be27d"
+  integrity sha512-8uV038gzBp7ew7a4884SVt9Zhu8CtiTb+A8dKNnByxVoT1kFt4O4DmsaniV8p9AGjNR13IWfpU1NFChmPHVIpQ==
 
 "@ljharb/resumer@~0.0.1":
   version "0.0.1"


### PR DESCRIPTION
Fix

```
Error: Cannot find module '@lit-protocol/contracts'
Require stack:
/node_modules/@lit-protocol/constants/src/lib/constants/mappers.js
```