### PR TITLE
fix: blockhash syncing v6 - 2

### DIFF
--- a/packages/core/jest.config.ts
+++ b/packages/core/jest.config.ts
@@ -6,6 +6,7 @@ export default {
     'ts-jest': {
       tsconfig: '<rootDir>/tsconfig.spec.json',
     },
+    fetch: global.fetch,
   },
   transform: {
     '^.+\\.[t]s$': 'ts-jest',

--- a/packages/core/src/lib/lit-core.spec.ts
+++ b/packages/core/src/lib/lit-core.spec.ts
@@ -1,0 +1,175 @@
+import { LitCore } from './lit-core';
+
+describe('LitCore', () => {
+  let core: LitCore;
+
+  describe('getLatestBlockhash', () => {
+    let originalFetch: typeof fetch;
+    let originalDateNow: typeof Date.now;
+    const mockBlockhashUrl =
+      'https://block-indexer-url.com/get_most_recent_valid_block';
+
+    beforeEach(() => {
+      core = new LitCore({
+        litNetwork: 'custom',
+      });
+      core['_blockHashUrl'] = mockBlockhashUrl;
+      originalFetch = fetch;
+      originalDateNow = Date.now;
+    });
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+      Date.now = originalDateNow;
+      jest.clearAllMocks();
+    });
+
+    it('should return cached blockhash if still valid', async () => {
+      // Setup
+      const mockBlockhash = '0x1234';
+      const currentTime = 1000000;
+      core.latestBlockhash = mockBlockhash;
+      core.lastBlockHashRetrieved = currentTime;
+      Date.now = jest.fn().mockReturnValue(currentTime + 15000); // 15 seconds later
+      global.fetch = jest.fn();
+
+      // Execute
+      const result = await core.getLatestBlockhash();
+
+      // Assert
+      expect(result).toBe(mockBlockhash);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should fetch new blockhash when cache is expired', async () => {
+      // Setup
+      const mockBlockhash = '0x5678';
+      const currentTime = 1000000;
+      core.latestBlockhash = '0x1234';
+      core.lastBlockHashRetrieved = currentTime - 31000; // 31 seconds ago currentTime
+      const blockNumber = 12345;
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            blockhash: mockBlockhash,
+            timestamp: currentTime,
+            blockNumber,
+          }),
+      });
+      Date.now = jest.fn().mockReturnValue(currentTime);
+
+      // Execute
+      const result = await core.getLatestBlockhash();
+
+      // Assert
+      expect(result).toBe(mockBlockhash);
+      expect(fetch).toHaveBeenCalledWith(mockBlockhashUrl);
+    });
+
+    it('should throw error when blockhash is not available', async () => {
+      // Setup
+      core.latestBlockhash = null;
+      core.lastBlockHashRetrieved = null;
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+      });
+      core['_getProviderWithFallback'] = jest.fn(() => Promise.resolve(null));
+
+      // Execute & Assert
+      await expect(core.getLatestBlockhash()).rejects.toThrow(
+        'latestBlockhash is not available. Received: "null"'
+      );
+    });
+
+    it('should handle fetch failure and use fallback RPC', async () => {
+      // Setup
+      const mockBlockhash = '0xabc';
+      const currentTime = 1000000;
+      Date.now = jest.fn().mockReturnValue(currentTime);
+      global.fetch = jest.fn().mockRejectedValue(new Error('Fetch failed'));
+      const mockProvider = {
+        getBlockNumber: jest.fn().mockResolvedValue(12345),
+        getBlock: jest.fn().mockResolvedValue({
+          hash: mockBlockhash,
+          number: 12345,
+          timestamp: currentTime,
+        }),
+      };
+      jest.spyOn(core as any, '_getProviderWithFallback').mockResolvedValue({
+        ...mockProvider,
+      });
+
+      // Execute
+      const result = await core.getLatestBlockhash();
+
+      // Assert
+      expect(fetch).toHaveBeenCalledWith(mockBlockhashUrl);
+      expect(mockProvider.getBlock).toHaveBeenCalledWith(-1); // safety margin
+      expect(result).toBe(mockBlockhash);
+    });
+
+    it('should handle empty blockhash response with fallback RPC URLs', async () => {
+      // Setup
+      const mockBlockhash = '0xabc';
+      const currentTime = 1000000;
+      Date.now = jest.fn().mockReturnValue(currentTime);
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            blockhash: null,
+            blockNumber: null,
+          }),
+      });
+      const mockProvider = {
+        getBlockNumber: jest.fn().mockResolvedValue(12345),
+        getBlock: jest.fn().mockResolvedValue({
+          hash: mockBlockhash,
+          number: 12345,
+          timestamp: currentTime,
+        }),
+      };
+      jest.spyOn(core as any, '_getProviderWithFallback').mockResolvedValue({
+        ...mockProvider,
+      });
+
+      // Execute
+      const result = await core.getLatestBlockhash();
+
+      // Assert
+      expect(fetch).toHaveBeenCalledWith(mockBlockhashUrl);
+      expect(mockProvider.getBlock).toHaveBeenCalledWith(-1); // safety margin
+      expect(result).toBe(mockBlockhash);
+    });
+
+    it('should handle network timeouts gracefully', async () => {
+      // Setup
+      const currentTime = 1000000;
+      Date.now = jest.fn().mockReturnValue(currentTime);
+
+      global.fetch = jest
+        .fn()
+        .mockImplementation(
+          () =>
+            new Promise((_, reject) =>
+              setTimeout(() => reject(new Error('Network timeout')), 1000)
+            )
+        );
+
+      const mockProvider = {
+        getBlockNumber: jest.fn().mockResolvedValue(12345),
+        getBlock: jest.fn().mockResolvedValue(null), // Provider also fails
+      };
+
+      jest.spyOn(core as any, '_getProviderWithFallback').mockResolvedValue({
+        ...mockProvider,
+      });
+
+      // Execute & Assert
+      await expect(() => core.getLatestBlockhash()).rejects.toThrow(
+        'latestBlockhash is not available. Received: "null"'
+      );
+    });
+  });
+});


### PR DESCRIPTION
# Description

This is just a backport of #727 for our v6 SDK

Added some safety measures when syncing blockhash. More specifically:
- verify fetch response from block-indexer is successful to avoid using error responses with `undefined` `blockhash`es
- use previous-to-last blockhash from public providers on fallback to avoid using a blockhash not yet propagated to nodes
- use block `timestamp` instead of user one as that is the one that defines if `blockhash` is still valid

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added unit tests for LitCore
- [x] Local run of CI tests 

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
