### PR TITLE
Fix: apply low-s `s` flips also to `v` on ecdsa signature shares combination

### DIFF
--- a/local-tests/tests/testDelegatingCapacityCreditsNFTToAnotherWalletToPkpSign.ts
+++ b/local-tests/tests/testDelegatingCapacityCreditsNFTToAnotherWalletToPkpSign.ts
@@ -1,3 +1,5 @@
+import { ethers } from 'ethers';
+
 import { getEoaSessionSigsWithCapacityDelegations } from 'local-tests/setup/session-sigs/get-eoa-session-sigs';
 import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
@@ -90,6 +92,22 @@ export const testDelegatingCapacityCreditsNFTToAnotherWalletToPkpSign = async (
   // -- recid must be parseable as a number
   if (isNaN(res.recid)) {
     throw new Error(`Expected "recid" to be parseable as a number`);
+  }
+
+  const signature = ethers.utils.joinSignature({
+    r: '0x' + res.r,
+    s: '0x' + res.s,
+    recoveryParam: res.recid,
+  });
+  const recoveredPubKey = ethers.utils.recoverPublicKey(
+    alice.loveLetter,
+    signature
+  );
+  if (recoveredPubKey !== `0x${res.publicKey.toLowerCase()}`) {
+    throw new Error(`Expected recovered public key to match res.publicKey`);
+  }
+  if (recoveredPubKey !== `0x${bob.pkp.publicKey.toLowerCase()}`) {
+    throw new Error(`Expected recovered public key to match bob.pkp.publicKey`);
   }
 
   console.log('✅ res:', res);

--- a/local-tests/tests/testUseCapacityDelegationAuthSigWithUnspecifiedCapacityTokenIdToPkpSign.ts
+++ b/local-tests/tests/testUseCapacityDelegationAuthSigWithUnspecifiedCapacityTokenIdToPkpSign.ts
@@ -1,3 +1,5 @@
+import { ethers } from 'ethers';
+
 import { getEoaSessionSigsWithCapacityDelegations } from 'local-tests/setup/session-sigs/get-eoa-session-sigs';
 import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
@@ -92,6 +94,24 @@ export const testUseCapacityDelegationAuthSigWithUnspecifiedCapacityTokenIdToPkp
     // -- recid must be parseable as a number
     if (isNaN(res.recid)) {
       throw new Error(`Expected "recid" to be parseable as a number`);
+    }
+
+    const signature = ethers.utils.joinSignature({
+      r: '0x' + res.r,
+      s: '0x' + res.s,
+      recoveryParam: res.recid,
+    });
+    const recoveredPubKey = ethers.utils.recoverPublicKey(
+      alice.loveLetter,
+      signature
+    );
+    if (recoveredPubKey !== `0x${res.publicKey.toLowerCase()}`) {
+      throw new Error(`Expected recovered public key to match res.publicKey`);
+    }
+    if (recoveredPubKey !== `0x${bob.pkp.publicKey.toLowerCase()}`) {
+      throw new Error(
+        `Expected recovered public key to match bob.pkp.publicKey`
+      );
     }
 
     console.log('✅ res:', res);

--- a/local-tests/tests/testUseCapacityDelegationAuthSigWithUnspecifiedDelegateesToPkpSign.ts
+++ b/local-tests/tests/testUseCapacityDelegationAuthSigWithUnspecifiedDelegateesToPkpSign.ts
@@ -1,3 +1,5 @@
+import { ethers } from 'ethers';
+
 import { getEoaSessionSigsWithCapacityDelegations } from 'local-tests/setup/session-sigs/get-eoa-session-sigs';
 import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
 
@@ -84,6 +86,26 @@ export const testUseCapacityDelegationAuthSigWithUnspecifiedDelegateesToPkpSign 
     // signature must start with 0x
     if (!runWithSessionSigs.signature.startsWith('0x')) {
       throw new Error(`Expected "signature" to start with 0x`);
+    }
+
+    const signature = ethers.utils.joinSignature({
+      r: '0x' + runWithSessionSigs.r,
+      s: '0x' + runWithSessionSigs.s,
+      recoveryParam: runWithSessionSigs.recid,
+    });
+    const recoveredPubKey = ethers.utils.recoverPublicKey(
+      alice.loveLetter,
+      signature
+    );
+    if (recoveredPubKey !== `0x${runWithSessionSigs.publicKey.toLowerCase()}`) {
+      throw new Error(
+        `Expected recovered public key to match runWithSessionSigs.publicKey`
+      );
+    }
+    if (recoveredPubKey !== `0x${bob.pkp.publicKey.toLowerCase()}`) {
+      throw new Error(
+        `Expected recovered public key to match bob.pkp.publicKey`
+      );
     }
 
     // recid must be parseable as a number

--- a/local-tests/tests/testUseEoaSessionSigsToPkpSign.ts
+++ b/local-tests/tests/testUseEoaSessionSigsToPkpSign.ts
@@ -1,3 +1,5 @@
+import { ethers } from 'ethers';
+
 import { log } from '@lit-protocol/misc';
 import { getEoaSessionSigs } from 'local-tests/setup/session-sigs/get-eoa-session-sigs';
 import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
@@ -56,6 +58,26 @@ export const testUseEoaSessionSigsToPkpSign = async (
   // recid must be parseable as a number
   if (isNaN(runWithSessionSigs.recid)) {
     throw new Error(`Expected "recid" to be parseable as a number`);
+  }
+
+  const signature = ethers.utils.joinSignature({
+    r: '0x' + runWithSessionSigs.r,
+    s: '0x' + runWithSessionSigs.s,
+    recoveryParam: runWithSessionSigs.recid,
+  });
+  const recoveredPubKey = ethers.utils.recoverPublicKey(
+    alice.loveLetter,
+    signature
+  );
+  if (recoveredPubKey !== `0x${runWithSessionSigs.publicKey.toLowerCase()}`) {
+    throw new Error(
+      `Expected recovered public key to match runWithSessionSigs.publicKey`
+    );
+  }
+  if (recoveredPubKey !== `0x${alice.pkp.publicKey.toLowerCase()}`) {
+    throw new Error(
+      `Expected recovered public key to match alice.pkp.publicKey`
+    );
   }
 
   log('✅ testUseEoaSessionSigsToPkpSign');

--- a/local-tests/tests/testUsePkpSessionSigsToPkpSign.ts
+++ b/local-tests/tests/testUsePkpSessionSigsToPkpSign.ts
@@ -1,3 +1,5 @@
+import { ethers } from 'ethers';
+
 import { log } from '@lit-protocol/misc';
 import { getPkpSessionSigs } from 'local-tests/setup/session-sigs/get-pkp-session-sigs';
 import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
@@ -56,6 +58,26 @@ export const testUsePkpSessionSigsToPkpSign = async (
   // recid must be parseable as a number
   if (isNaN(res.recid)) {
     throw new Error(`Expected "recid" to be parseable as a number`);
+  }
+
+  const signature = ethers.utils.joinSignature({
+    r: '0x' + res.r,
+    s: '0x' + res.s,
+    recoveryParam: res.recid,
+  });
+  const recoveredPubKey = ethers.utils.recoverPublicKey(
+    alice.loveLetter,
+    signature
+  );
+  if (recoveredPubKey !== `0x${res.publicKey.toLowerCase()}`) {
+    throw new Error(`Expected recovered public key to match res.publicKey`);
+  }
+  if (
+    recoveredPubKey !== `0x${alice.authMethodOwnedPkp.publicKey.toLowerCase()}`
+  ) {
+    throw new Error(
+      `Expected recovered public key to match alice.authMethodOwnedPkp.publicKey`
+    );
   }
 
   log('✅ res:', res);

--- a/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToPkpSign.ts
+++ b/local-tests/tests/testUseValidLitActionCodeGeneratedSessionSigsToPkpSign.ts
@@ -1,3 +1,5 @@
+import { ethers } from 'ethers';
+
 import { log } from '@lit-protocol/misc';
 import { LIT_NETWORK } from '@lit-protocol/constants';
 import { getLitActionSessionSigs } from 'local-tests/setup/session-sigs/get-lit-action-session-sigs';
@@ -56,6 +58,26 @@ export const testUseValidLitActionCodeGeneratedSessionSigsToPkpSign = async (
   // recid must be parseable as a number
   if (isNaN(res.recid)) {
     throw new Error(`Expected "recid" to be parseable as a number`);
+  }
+
+  const signature = ethers.utils.joinSignature({
+    r: '0x' + res.r,
+    s: '0x' + res.s,
+    recoveryParam: res.recid,
+  });
+  const recoveredPubKey = ethers.utils.recoverPublicKey(
+    alice.loveLetter,
+    signature
+  );
+  if (recoveredPubKey !== `0x${res.publicKey.toLowerCase()}`) {
+    throw new Error(`Expected recovered public key to match res.publicKey`);
+  }
+  if (
+    recoveredPubKey !== `0x${alice.authMethodOwnedPkp.publicKey.toLowerCase()}`
+  ) {
+    throw new Error(
+      `Expected recovered public key to match alice.authMethodOwnedPkp.publicKey`
+    );
   }
 
   log('✅ res:', res);

--- a/local-tests/tests/testUseValidLitActionIpfsCodeGeneratedSessionSigsToPkpSign.ts
+++ b/local-tests/tests/testUseValidLitActionIpfsCodeGeneratedSessionSigsToPkpSign.ts
@@ -1,3 +1,5 @@
+import { ethers } from 'ethers';
+
 import { log } from '@lit-protocol/misc';
 import { getLitActionSessionSigsUsingIpfsId } from 'local-tests/setup/session-sigs/get-lit-action-session-sigs';
 import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
@@ -64,6 +66,27 @@ export const testUseValidLitActionIpfsCodeGeneratedSessionSigsToPkpSign =
     // recid must be parseable as a number
     if (isNaN(res.recid)) {
       throw new Error(`Expected "recid" to be parseable as a number`);
+    }
+
+    const signature = ethers.utils.joinSignature({
+      r: '0x' + res.r,
+      s: '0x' + res.s,
+      recoveryParam: res.recid,
+    });
+    const recoveredPubKey = ethers.utils.recoverPublicKey(
+      alice.loveLetter,
+      signature
+    );
+    if (recoveredPubKey !== `0x${res.publicKey.toLowerCase()}`) {
+      throw new Error(`Expected recovered public key to match res.publicKey`);
+    }
+    if (
+      recoveredPubKey !==
+      `0x${alice.authMethodOwnedPkp.publicKey.toLowerCase()}`
+    ) {
+      throw new Error(
+        `Expected recovered public key to match alice.authMethodOwnedPkp.publicKey`
+      );
     }
 
     log('✅ res:', res);

--- a/packages/crypto/src/lib/crypto.ts
+++ b/packages/crypto/src/lib/crypto.ts
@@ -202,14 +202,20 @@ export const combineEcdsaShares = async (
     Buffer.from(share.signatureShare, 'hex')
   );
 
-  const [r, s, v] = await ecdsaCombine(variant!, presignature, signatureShares);
+  const [r, s, recId] = await ecdsaCombine(
+    variant!,
+    presignature,
+    signatureShares
+  );
 
   const publicKey = Buffer.from(anyValidShare.publicKey, 'hex');
   const messageHash = Buffer.from(anyValidShare.dataSigned!, 'hex');
 
-  await ecdsaVerify(variant!, messageHash, publicKey, [r, s, v]);
+  await ecdsaVerify(variant!, messageHash, publicKey, [r, s, recId]);
 
-  const signature = splitSignature(Buffer.concat([r, s, Buffer.from([v])]));
+  const signature = splitSignature(
+    Buffer.concat([r, s, Buffer.from([recId + 27])])
+  );
 
   return {
     r: signature.r.slice('0x'.length),

--- a/packages/lit-node-client-nodejs/src/lib/helpers/get-signatures.ts
+++ b/packages/lit-node-client-nodejs/src/lib/helpers/get-signatures.ts
@@ -259,7 +259,7 @@ export const getSignatures = async <T>(params: {
     const encodedSig = joinSignature({
       r: '0x' + signature.r,
       s: '0x' + signature.s,
-      v: signature.recid,
+      recoveryParam: signature.recid,
     });
 
     signatures[key] = {

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -42,7 +42,7 @@ export interface AuthSig {
   /**
    * The signature produced by signing the `signMessage` property with the corresponding private key for the `address` property.
    */
-  sig: any;
+  sig: string;
 
   /**
    * The method used to derive the signature (e.g, `web3.eth.personal.sign`).
@@ -598,7 +598,7 @@ export interface SigResponse {
   r: string;
   s: string;
   recid: number;
-  signature: string; // 0x...
+  signature: `0x${string}`;
   publicKey: string; // pkp public key (no 0x prefix)
   dataSigned: string;
 }


### PR DESCRIPTION
# Description

This PR corrects the low-s rule by linking the `s` flips with the `v` value when combining ecdsa signatures

When the multiple shares are combined and the final signature created, if the `s` value is in the top half of the curve order, then it is flipped. However that flip also had to flip the `v` value. With the changes in this PR now we are doing that `v` flip
The signature was always valid as it is composed of the `(r,s)` tuple without caring of which `s` value (positive or negative) was used. But, when trying to recover the public key or address of the signer, we need the correct `v` value and having it unlinked from the s flips created a situation where a signature could recover a wrong public address unless the consumer knows the result already and fixes the `v` value itself

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Updated unit tests
- [x] Locally by running a script with 100 pkpSign operations and validating the recovered address agains the used pkp one

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
