### PR TITLE
Feature/lit 4086 hide sessionsigs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
         run: cp .env.ci .env
       - name: Run End to End Tests
         if: steps.build.outputs.exit_code == 0
-        run: yarn test:local --filter=testUseEoaSessionSigsToExecuteJsSigning,testUseEoaSessionSigsToPkpSign,testUsePkpSessionSigsToExecuteJsSigning,testUsePkpSessionSigsToPkpSign,testUseValidLitActionCodeGeneratedSessionSigsToPkpSign,testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsSigning,testDelegatingCapacityCreditsNFTToAnotherWalletToExecuteJs,testEthAuthSigToEncryptDecryptString,testExecuteJsSignAndCombineEcdsa,testExecutJsDecryptAndCombine,testExecuteJsBroadcastAndCollect --exclude=Parallel
+        run: yarn test:local --filter=testUseEoaSessionSigsToExecuteJsSigning,testUseEoaAuthContextToPkpSign,testUseEoaSessionSigsToPkpSign,testUsePkpSessionSigsToExecuteJsSigning,testUsePkpSessionSigsToPkpSign,testUseValidLitActionCodeGeneratedSessionSigsToPkpSign,testUseValidLitActionCodeGeneratedSessionSigsToExecuteJsSigning,testDelegatingCapacityCreditsNFTToAnotherWalletToExecuteJs,testEthAuthSigToEncryptDecryptString,testExecuteJsSignAndCombineEcdsa,testExecutJsDecryptAndCombine,testExecuteJsBroadcastAndCollect --exclude=Parallel
       - name: Get Container Logs
         if: always()
         run: docker logs shiva

--- a/local-tests/test.ts
+++ b/local-tests/test.ts
@@ -2,6 +2,7 @@ import { TinnyEnvironment } from './setup/tinny-environment';
 import { runInBand, runTestsParallel } from './setup/tinny-operations';
 // import { testBundleSpeed } from './tests/test-bundle-speed';
 // import { testExample } from './tests/test-example';
+import { testUseEoaAuthContextToPkpSign } from 'local-tests/tests/testUseEoaAuthContextToPkpSign';
 import { testUseEoaSessionSigsToExecuteJsSigning } from './tests/testUseEoaSessionSigsToExecuteJsSigning';
 import { testUseEoaSessionSigsToPkpSign } from './tests/testUseEoaSessionSigsToPkpSign';
 import { testUsePkpSessionSigsToExecuteJsSigning } from './tests/testUsePkpSessionSigsToExecuteJsSigning';
@@ -163,6 +164,7 @@ setLitActionsCodeToLocal();
   };
 
   const eoaSessionSigsTests = {
+    testUseEoaAuthContextToPkpSign,
     testUseEoaSessionSigsToExecuteJsSigning,
     testUseEoaSessionSigsToPkpSign,
     testUseEoaSessionSigsToExecuteJsSigningInParallel,

--- a/local-tests/tests/testPkpEthersWithEoaSessionSigsToSignWithAuthContext.ts
+++ b/local-tests/tests/testPkpEthersWithEoaSessionSigsToSignWithAuthContext.ts
@@ -24,7 +24,6 @@ export const testPkpEthersWithEoaSessionSigsToSignWithAuthContext = async (
     pkpPubKey: alice.pkp.publicKey,
     litNodeClient: devEnv.litNodeClient,
     authContext: {
-      client: devEnv.litNodeClient,
       getSessionSigsProps: {
         authNeededCallback: async function (
           params: AuthCallbackParams

--- a/local-tests/tests/testUseEoaAuthContextToPkpSign.ts
+++ b/local-tests/tests/testUseEoaAuthContextToPkpSign.ts
@@ -1,6 +1,11 @@
 import { ethers } from 'ethers';
 
-import { createSiweMessageWithRecaps, generateAuthSig, LitPKPResource } from '@lit-protocol/auth-helpers';
+import {
+  createSiweMessageWithRecaps,
+  generateAuthSig,
+  LitActionResource,
+  LitPKPResource,
+} from '@lit-protocol/auth-helpers';
 import { LIT_ABILITY } from '@lit-protocol/constants';
 import { log } from '@lit-protocol/misc';
 import { AuthCallbackParams, AuthSig } from '@lit-protocol/types';
@@ -23,6 +28,10 @@ export const testUseEoaAuthContextToPkpSign = async (
     {
       resource: new LitPKPResource('*'),
       ability: LIT_ABILITY.PKPSigning,
+    },
+    {
+      resource: new LitActionResource('*'),
+      ability: LIT_ABILITY.LitActionExecution,
     },
   ];
   const litNodeClient = alice.envConfig.litNodeClient;

--- a/local-tests/tests/testUseEoaAuthContextToPkpSign.ts
+++ b/local-tests/tests/testUseEoaAuthContextToPkpSign.ts
@@ -1,0 +1,127 @@
+import { ethers } from 'ethers';
+
+import { LitPKPResource } from '@lit-protocol/auth-helpers';
+import { LIT_ABILITY } from '@lit-protocol/constants';
+import { EthWalletProvider } from '@lit-protocol/lit-auth-client';
+import { LitNodeClient } from '@lit-protocol/lit-node-client';
+import { log } from '@lit-protocol/misc';
+import { AuthCallbackParams, AuthSig } from '@lit-protocol/types';
+import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
+
+/**
+ * Test Commands:
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testUseEoaAuthContextToPkpSign
+ * ✅ NETWORK=datil-test yarn test:local --filter=testUseEoaAuthContextToPkpSign
+ * ✅ NETWORK=custom yarn test:local --filter=testUseEoaAuthContextToPkpSign
+ */
+export const testUseEoaAuthContextToPkpSign = async (
+  devEnv: TinnyEnvironment
+) => {
+  const alice = await devEnv.createRandomPerson();
+
+  const ONE_MINUTE = 1 * 60 * 1000;
+  const expiration = new Date(Date.now() + ONE_MINUTE).toISOString();
+  const resourceAbilityRequests = [
+    {
+      resource: new LitPKPResource('*'),
+      ability: LIT_ABILITY.PKPSigning,
+    },
+  ];
+  const litNodeClient = new LitNodeClient({
+    litNetwork: alice.envConfig.network,
+    authContext: {
+      getSessionSigsProps: {
+        resourceAbilityRequests,
+        expiration,
+        authNeededCallback: async function (
+          params: AuthCallbackParams
+        ): Promise<AuthSig> {
+          const response = await litNodeClient.signSessionKey({
+            sessionKey: params.sessionKey,
+            statement: params.statement || 'Some custom statement.',
+            authMethods: [
+              await EthWalletProvider.authenticate({
+                signer: alice.wallet,
+                litNodeClient: litNodeClient,
+                expiration: params.expiration,
+              }),
+            ],
+            pkpPublicKey: alice.pkp.publicKey,
+            expiration: params.expiration,
+            resources: params.resources,
+            chainId: 1,
+
+            // -- required fields
+            resourceAbilityRequests: params.resourceAbilityRequests,
+          });
+
+          return response.authSig;
+        },
+      },
+    },
+  });
+
+  const runWithAuthContext = await litNodeClient.pkpSign({
+    toSign: alice.loveLetter,
+    pubKey: alice.pkp.publicKey,
+  });
+
+  devEnv.releasePrivateKeyFromUser(alice);
+
+  // Expected output:
+  // {
+  //   r: "25fc0d2fecde8ed801e9fee5ad26f2cf61d82e6f45c8ad1ad1e4798d3b747fd9",
+  //   s: "549fe745b4a09536e6e7108d814cf7e44b93f1d73c41931b8d57d1b101833214",
+  //   recid: 1,
+  //   signature: "0x25fc0d2fecde8ed801e9fee5ad26f2cf61d82e6f45c8ad1ad1e4798d3b747fd9549fe745b4a09536e6e7108d814cf7e44b93f1d73c41931b8d57d1b1018332141c",
+  //   publicKey: "04A3CD53CCF63597D3FFCD1DF1E8236F642C7DF8196F532C8104625635DC55A1EE59ABD2959077432FF635DF2CED36CC153050902B71291C4D4867E7DAAF964049",
+  //   dataSigned: "7D87C5EA75F7378BB701E404C50639161AF3EFF66293E9F375B5F17EB50476F4",
+  // }
+
+  // -- assertions
+  // r, s, dataSigned, and public key should be present
+  if (!runWithAuthContext.r) {
+    throw new Error(`Expected "r" in runWithAuthContext`);
+  }
+  if (!runWithAuthContext.s) {
+    throw new Error(`Expected "s" in runWithAuthContext`);
+  }
+  if (!runWithAuthContext.dataSigned) {
+    throw new Error(`Expected "dataSigned" in runWithAuthContext`);
+  }
+  if (!runWithAuthContext.publicKey) {
+    throw new Error(`Expected "publicKey" in runWithAuthContext`);
+  }
+
+  // signature must start with 0x
+  if (!runWithAuthContext.signature.startsWith('0x')) {
+    throw new Error(`Expected "signature" to start with 0x`);
+  }
+
+  // recid must be parseable as a number
+  if (isNaN(runWithAuthContext.recid)) {
+    throw new Error(`Expected "recid" to be parseable as a number`);
+  }
+
+  const signature = ethers.utils.joinSignature({
+    r: '0x' + runWithAuthContext.r,
+    s: '0x' + runWithAuthContext.s,
+    recoveryParam: runWithAuthContext.recid,
+  });
+  const recoveredPubKey = ethers.utils.recoverPublicKey(
+    alice.loveLetter,
+    signature
+  );
+  if (recoveredPubKey !== `0x${runWithAuthContext.publicKey.toLowerCase()}`) {
+    throw new Error(
+      `Expected recovered public key to match runWithAuthContext.publicKey`
+    );
+  }
+  if (recoveredPubKey !== `0x${alice.pkp.publicKey.toLowerCase()}`) {
+    throw new Error(
+      `Expected recovered public key to match alice.pkp.publicKey`
+    );
+  }
+
+  log('✅ testUseEoaAuthContextToPkpSign');
+};

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -560,6 +560,13 @@ export class LitCore {
     }
   }
 
+  protected async assertConnected() {
+    // -- if it's not ready yet, then connect
+    if (!this.ready) {
+      await this.connect();
+    }
+  }
+
   private async _handshakeAndVerifyNodeAttestation({
     url,
     requestId,

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -1130,6 +1130,8 @@ export class LitNodeClientNodeJs
    * @param [params.getSessionSigsPropsOverride] - The props override when obtaining sessionSigs from the auth context
    */
   pkpSign = async (params: JsonPkpSignSdkParams): Promise<SigResponse> => {
+    await this.assertConnected();
+
     // -- validate required params
     const requiredParamKeys = ['toSign', 'pubKey'];
     (requiredParamKeys as (keyof JsonPkpSignSdkParams)[]).forEach((key) => {

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -184,10 +184,7 @@ export class LitNodeClientNodeJs
       await params.dAppOwnerWallet.getAddress()
     );
 
-    // -- if it's not ready yet, then connect
-    if (!this.ready) {
-      await this.connect();
-    }
+    await this.assertConnected();
 
     const siweMessage = await createSiweMessageWithCapacityDelegation({
       uri: 'lit:capability:delegation',
@@ -890,13 +887,7 @@ export class LitNodeClientNodeJs
   executeJs = async (
     params: JsonExecutionSdkParams
   ): Promise<ExecuteJsResponse> => {
-    // ========== Validate Params ==========
-    if (!this.ready) {
-      const message =
-        '[executeJs] LitNodeClient is not ready.  Please call await litNodeClient.connect() first.';
-
-      throw new LitNodeClientNotReadyError({}, message);
-    }
+    await this.assertConnected();
 
     const paramsIsSafe = safeParams({
       functionName: 'executeJs',
@@ -1226,15 +1217,9 @@ export class LitNodeClientNodeJs
    * @throws { Error } if the subnetPubKey is null
    */
   encrypt = async (params: EncryptSdkParams): Promise<EncryptResponse> => {
-    // ========== Validate Params ==========
-    // -- validate if it's ready
-    if (!this.ready) {
-      throw new LitNodeClientNotReadyError(
-        {},
-        '6 LitNodeClient is not ready.  Please call await litNodeClient.connect() first.'
-      );
-    }
+    await this.assertConnected();
 
+    // ========== Validate Params ==========
     // -- validate if this.subnetPubKey is null
     if (!this.subnetPubKey) {
       throw new LitNodeClientNotReadyError({}, 'subnetPubKey cannot be null');
@@ -1316,15 +1301,9 @@ export class LitNodeClientNodeJs
     const { sessionSigs, authSig, chain, ciphertext, dataToEncryptHash } =
       params;
 
-    // ========== Validate Params ==========
-    // -- validate if it's ready
-    if (!this.ready) {
-      throw new LitNodeClientNotReadyError(
-        {},
-        '6 LitNodeClient is not ready.  Please call await litNodeClient.connect() first.'
-      );
-    }
+    await this.assertConnected();
 
+    // ========== Validate Params ==========
     // -- validate if this.subnetPubKey is null
     if (!this.subnetPubKey) {
       throw new LitNodeClientNotReadyError({}, 'subnetPubKey cannot be null');
@@ -1521,15 +1500,9 @@ export class LitNodeClientNodeJs
   ): Promise<SignSessionKeyResponse> => {
     log(`[signSessionKey] params:`, params);
 
-    // ========== Validate Params ==========
-    // -- validate: If it's NOT ready
-    if (!this.ready) {
-      throw new LitNodeClientNotReadyError(
-        {},
-        '[signSessionKey] ]LitNodeClient is not ready.  Please call await litNodeClient.connect() first.'
-      );
-    }
+    await this.assertConnected();
 
+    // ========== Validate Params ==========
     // -- construct SIWE message that will be signed by node to generate an authSig.
     const _expiration =
       params.expiration ||
@@ -2195,11 +2168,7 @@ export class LitNodeClientNodeJs
   async claimKeyId(
     params: ClaimRequest<ClaimProcessor>
   ): Promise<ClaimKeyResponse> {
-    if (!this.ready) {
-      const message =
-        'LitNodeClient is not ready.  Please call await litNodeClient.connect() first.';
-      throw new LitNodeClientNotReadyError({}, message);
-    }
+    await this.assertConnected();
 
     if (params.authMethod.authMethodType == AUTH_METHOD_TYPE.WebAuthn) {
       throw new LitNodeClientNotReadyError(

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -924,19 +924,19 @@ export class LitNodeClientNodeJs
 
     // Check if IPFS options are provided and if the code should be fetched from IPFS and overwrite the current code.
     // This will fetch the code from the specified IPFS gateway using the provided ipfsId,
-    // and update the params with the fetched code, removing the ipfsId afterward.
+    // and update the formattedParams with the fetched code, removing the ipfsId afterward.
     const overwriteCode =
       params.ipfsOptions?.overwriteCode ||
       GLOBAL_OVERWRITE_IPFS_CODE_BY_NETWORK[this.config.litNetwork];
 
-    if (overwriteCode && params.ipfsId) {
+    if (overwriteCode && formattedParams.ipfsId) {
       const code = await this._getFallbackIpfsCode(
-        params.ipfsOptions?.gatewayUrl,
-        params.ipfsId
+        formattedParams.ipfsOptions?.gatewayUrl,
+        formattedParams.ipfsId
       );
 
       formattedParams = {
-        ...params,
+        ...formattedParams,
         code: code,
         ipfsId: undefined,
       };
@@ -946,7 +946,7 @@ export class LitNodeClientNodeJs
     // ========== Get Node Promises ==========
     // Handle promises for commands sent to Lit nodes
     const getNodePromises = async () => {
-      if (params.useSingleNode) {
+      if (formattedParams.useSingleNode) {
         return this.getRandomNodePromise((url: string) =>
           this.executeJsNodeRequest(url, formattedParams, requestId)
         );
@@ -962,7 +962,7 @@ export class LitNodeClientNodeJs
     const res = await this.handleNodePromises(
       nodePromises,
       requestId,
-      params.useSingleNode ? 1 : this.connectedNodes.size
+      formattedParams.useSingleNode ? 1 : this.connectedNodes.size
     );
 
     // -- case: promises rejected

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -858,14 +858,14 @@ export class LitNodeClientNodeJs
     requestId: string
   ) {
     // -- choose the right signature
-    const sessionSig = this.getSessionSigByUrl({
+    const authSig = this.getSessionSigByUrl({
       sessionSigs: formattedParams.sessionSigs,
       url,
     });
 
     const reqBody: JsonExecutionRequest = {
       ...formattedParams,
-      authSig: sessionSig,
+      authSig,
     };
 
     const urlWithPath = composeLitUrl({
@@ -1136,21 +1136,15 @@ export class LitNodeClientNodeJs
 
     const nodePromises = this.getNodePromises((url: string) => {
       // -- get the session sig from the url key
-      const sessionSig = this.getSessionSigByUrl({
-        sessionSigs: params.sessionSigs,
+      const authSig = this.getSessionSigByUrl({
+        sessionSigs,
         url,
       });
 
       const reqBody: JsonPkpSignRequest = {
         toSign: normalizeArray(params.toSign),
         pubkey: hexPrefixed(params.pubKey),
-        authSig: sessionSig,
-
-        // -- optional params
-        ...(params.authMethods &&
-          params.authMethods.length > 0 && {
-            authMethods: params.authMethods,
-          }),
+        authSig,
       };
 
       logWithRequestId(requestId, 'reqBody:', reqBody);

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -270,9 +270,10 @@ export class LitNodeClientNodeJs
    * @param obj - The object to check.
    * @returns True if the object is of type SessionKeyPair.
    */
-  isSessionKeyPair(obj: any): obj is SessionKeyPair {
+  isSessionKeyPair(obj: unknown): obj is SessionKeyPair {
     return (
       typeof obj === 'object' &&
+      obj !== null &&
       'publicKey' in obj &&
       'secretKey' in obj &&
       typeof obj.publicKey === 'string' &&
@@ -509,7 +510,7 @@ export class LitNodeClientNodeJs
     resourceAbilityRequests,
   }: {
     authSig: AuthSig;
-    sessionKeyUri: any;
+    sessionKeyUri: string;
     resourceAbilityRequests: LitResourceAbilityRequest[];
   }): Promise<boolean> => {
     const authSigSiweMessage = new SiweMessage(authSig.signedMessage);
@@ -1666,7 +1667,7 @@ export class LitNodeClientNodeJs
 
     // ========== Extract shares from response data ==========
     // -- 1. combine signed data as a list, and get the signatures from it
-    let curveType = responseData[0]?.curveType;
+    const curveType = responseData[0]?.curveType;
 
     if (curveType === 'ECDSA') {
       throw new Error(

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -233,7 +233,6 @@ pub struct JsonExecutionRequest {
  */
 
 export interface BaseJsonPkpSignRequest {
-  authMethods?: AuthMethod[];
   toSign: ArrayLike<number>;
 }
 

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -186,14 +186,18 @@ export interface LitNodeClientConfig {
   contractContext?: LitContractContext | LitContractResolverContext;
   storageProvider?: StorageProvider;
   defaultAuthCallback?: (authSigParams: AuthCallbackParams) => Promise<AuthSig>;
+  authContext?: AuthenticationProps;
   rpcUrl?: string;
 }
 
 export type CustomNetwork = Pick<
   LitNodeClientConfig,
-  'litNetwork' | 'contractContext' | 'checkNodeAttestation'
-> &
-  Partial<Pick<LitNodeClientConfig, 'minNodeCount'>>;
+  | 'litNetwork'
+  | 'contractContext'
+  | 'checkNodeAttestation'
+  | 'authContext'
+  | 'minNodeCount'
+>;
 
 /**
  * Override for LocalStorage and SessionStorage
@@ -238,11 +242,12 @@ export interface BaseJsonPkpSignRequest {
 
 /**
  * The 'pkpSign' function param. Please note that the structure
- * is different than the payload sent to the node.
+ * is different from the payload sent to the node.
  */
 export interface JsonPkpSignSdkParams extends BaseJsonPkpSignRequest {
   pubKey: string;
-  sessionSigs: SessionSigsMap;
+  sessionSigs?: SessionSigsMap;
+  getSessionSigsPropsOverride?: Partial<GetSessionSigsProps>;
 }
 
 /**
@@ -474,12 +479,12 @@ export interface JsonExecutionSdkParams
   /**
    * the session signatures to use to authorize the user with the nodes
    */
-  sessionSigs: SessionSigsMap;
+  sessionSigs?: SessionSigsMap;
 
   /**
-   * auth methods to resolve
+   * the lit node client auth context props to get session sigs override
    */
-  authMethods?: AuthMethod[];
+  getSessionSigsPropsOverride?: Partial<GetSessionSigsProps>;
 }
 
 export interface ExecuteJsAdvancedOptions {

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -1046,7 +1046,7 @@ export interface CommonGetSessionSigsProps {
   /**
    * When this session signature will expire. After this time is up you will need to reauthenticate, generating a new session signature. The default time until expiration is 24 hours. The formatting is an [RFC3339](https://datatracker.ietf.org/doc/html/rfc3339) timestamp.
    */
-  expiration?: any;
+  expiration?: string;
 
   /**
    * The chain to use for the session signature and sign the session key. This value is almost always `ethereum`. If you're using EVM, this parameter isn't very important.


### PR DESCRIPTION
# Description

This PR brings the `authContext` property in `PKP*Wallet` instances down to `LitNodeClient` to allow for automatic management of `sessionSigs` inside its methods

The `authContext` can be configured/updated when creating the `LitNodeClient` instance or afterwards. Having it, it is not needed to pass `sessionSigs` and the instance will use that to create them if needed. When a `sessionSigs` instance is passed, that will take precedence
There is also an option to override specific properties of the configured `authContext` when `sessionSigs` are needed.

With this PR, when using the `authContext`,  `litNodeClient.pkpSign` and `litNodeClient.executeJs` can be executed without receiving `sessionSigs`

```typescript
  const litNodeClient = new LitNodeClient({
    litNetwork: LIT_NETWORK,
    authContext: {
      getSessionSigsProps: {
        resourceAbilityRequests: ...,
        expiration: ...,
        authNeededCallback: ...
      },
    },
  });

  const signature = await litNodeClient.pkpSign({
    // sessionSigs, // <----- NO sessionSigs needed. Internally will call litNodeClient.getSessionSigs(authContext.getSessionSigsProps)
    // Properties to create `sessionSigs` can be overrided
    // getSessionSigsPropsOverride: {
    //   expiration: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(), // (Will fail as `expiration` is in the past)
    // },
    pubKey: pkp.publicKey,
    toSign: MESSAGE_TO_SIGN,
  });
  console.log(`signature: ${JSON.stringify(signature)}`);
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Added integration tests
- [x] Locally with a script signing a message using `PKPEthersWallet`, `LitNodeClient` with `sessionSigs` and `LitNodeClient` with `authContext`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
