### PR TITLE
fix #758 logger tests

### DIFF
--- a/packages/logger/src/lib/logger.spec.ts
+++ b/packages/logger/src/lib/logger.spec.ts
@@ -1,4 +1,4 @@
-import { LOG_LEVEL, LogManager } from './logger';
+import { LOG_LEVEL, LogLevel, LogManager } from './logger';
 
 describe('logger', () => {
   let lm: LogManager;
@@ -25,7 +25,7 @@ describe('logger', () => {
     lm.withConfig({
       condenseLogs: true,
     });
-    let logger = lm.get('category');
+    const logger = lm.get('category');
     expect(logger.Config?.['condenseLogs']).toEqual(true);
   });
 
@@ -33,12 +33,12 @@ describe('logger', () => {
     lm.withConfig({
       condenseLogs: true,
     });
-    let logger = lm.get('category', 'bar');
+    const logger = lm.get('category', 'bar');
     logger.setLevel(LOG_LEVEL.INFO);
     expect(logger.Config?.['condenseLogs']).toEqual(true);
     logger.info('hello');
     logger.info('hello');
-    let logs = lm.getLogsForId('bar');
+    const logs = lm.getLogsForId('bar');
     expect(logs.length).toEqual(1);
   });
 
@@ -47,7 +47,7 @@ describe('logger', () => {
     logger.setLevel(LOG_LEVEL.INFO);
     logger.info('logging');
     logger.debug('shouldnt log');
-    let logs = lm.getLogsForId('foo');
+    const logs = lm.getLogsForId('foo');
     expect(logs.length).toEqual(1);
   });
 
@@ -56,14 +56,14 @@ describe('logger', () => {
     logger.setLevel(LOG_LEVEL.DEBUG);
     logger.debug('logging');
     logger.error('error');
-    let logs = lm.getLogsForId('foo2');
+    const logs = lm.getLogsForId('foo2');
     expect(logs.length).toEqual(2);
   });
 
   it('should safe serialize circular references', () => {
     const logger = lm.get('info-logger', 'foo3');
     logger.setLevel(LOG_LEVEL.DEBUG);
-    let circ: any = { foo: 'bar' };
+    const circ: any = { foo: 'bar' };
     circ.circ = circ;
     logger.debug('circular reference to serialize', circ);
     console.log(lm.getLogsForId('foo3'));
@@ -122,7 +122,8 @@ describe('logger', () => {
     const requestIds = lm.LoggerIds;
 
     expect(requestIds.length).toBe(2);
-    expect(loggerA.timestamp).toEqual(requestIds[0]);
-    expect(loggerB.timestamp).toEqual(requestIds[1]);
+    expect(loggerA.timestamp).toBeLessThan(loggerB.timestamp);
+    expect(requestIds[0]).toBe('1');
+    expect(requestIds[1]).toBe('2');
   });
 });

--- a/packages/logger/src/lib/logger.ts
+++ b/packages/logger/src/lib/logger.ts
@@ -1,6 +1,7 @@
 import { version, LOG_LEVEL, LOG_LEVEL_VALUES } from '@lit-protocol/constants';
 import { hashMessage } from 'ethers/lib/utils';
 
+export { LOG_LEVEL };
 export enum LogLevel {
   OFF = -1,
   ERROR = 0,


### PR DESCRIPTION
## Description

This pull request fixes the logger test so that it no longer fails when importing `LOG_LEVEL` from `logger.ts`. Previously, there was a mismatch between `LOG_LEVEL` (a constant from `@lit-protocol/constants`) and `LogLevel` (an enum). This change ensures that both references can coexist, while favoring `LOG_LEVEL` for future compatibility.  

Additionally, the test that checks creation timestamps (`should order logs based on logger creation timestamp`) has been corrected to compare `loggerA.timestamp` and `loggerB.timestamp` properly, instead of incorrectly matching a numeric timestamp against string IDs.

**Related Issue:**  
- Fix [#758](https://github.com/LIT-Protocol/js-sdk/issues/758)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- **Locally**:  
  - Ran `npx nx run logger:test --coverage` and all tests passed without TypeScript errors.  
  - Verified that `LOG_LEVEL` can be imported, and `LogLevel` still exists for backward compatibility.

```bash
❯ npx nx run logger:test --coverage
:
PASS   logger  packages/logger/src/lib/logger.spec.ts
  logger
    ✓ Log Manager singleton should be defined (1 ms)
    ✓ should make logger with category (1 ms)
    ✓ should make logger with id and category
    ✓ Log Manager should pass config to loggers
    ✓ Hashing enabled should filter non unique logs (17 ms)
    ✓ should respect info logging level (1 ms)
    ✓ should log error at any level
    ✓ should safe serialize circular references (1 ms)
    ✓ should trace logs through multiple categories (1 ms)
    ✓ should not persist logs if level set to OFF (5 ms)
    ✓ should persist logs across categories (1905 ms)
    ✓ should retain logger keys and return from LogManager (1 ms)
    ✓ should order logs based on logger creation timestamp (104 ms)

Test Suites: 1 passed, 1 total
Tests:       13 passed, 13 total
Snapshots:   0 total
Time:        2.856 s, estimated 5 s
Ran all test suites.
 
```

```bash
❯ yarn nx format:check --all                  
yarn run v1.22.22
$ /Users/susumu/js-sdk/node_modules/.bin/nx format:check --all
[warn] jsxBracketSameLine is deprecated.
✨  Done in 4.71s.
```
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
