### PR TITLE
fix #760 wrapped-keys test to expect a single ACC object instead of an array

### DIFF
--- a/packages/wrapped-keys/src/lib/api/utils.spec.ts
+++ b/packages/wrapped-keys/src/lib/api/utils.spec.ts
@@ -87,19 +87,17 @@ describe('getPkpAccessControlCondition', () => {
   it('should correctly create the ACC', () => {
     const pkpAddress = '0xd1Af1AAC50aC837C873200D17b78664aFCde597C';
     const acc = getPkpAccessControlCondition(pkpAddress);
-    expect(acc).toEqual([
-      {
-        contractAddress: '',
-        standardContractType: '',
-        chain: CHAIN_ETHEREUM,
-        method: '',
-        parameters: [':userAddress'],
-        returnValueTest: {
-          comparator: '=',
-          value: pkpAddress,
-        },
+    expect(acc).toEqual({
+      contractAddress: '',
+      standardContractType: '',
+      chain: CHAIN_ETHEREUM,
+      method: '',
+      parameters: [':userAddress'],
+      returnValueTest: {
+        comparator: '=',
+        value: pkpAddress,
       },
-    ]);
+    });
   });
 
   it('should throw an error for non-Ethereum address', () => {


### PR DESCRIPTION
# Description

This pull request fixes the failing test in `packages/wrapped-keys/src/lib/api/utils.spec.ts`, which currently expects an array of access control conditions. However, the actual implementation of `getPkpAccessControlCondition` returns a **single** `AccsDefaultParams` object, as documented:

```packages/wrapped-keys/src/lib/api/utils.ts
/**
 *
 * Creates the access control condition used to gate the access for Wrapped Key decryption
 *
 * @param { string } pkpAddress - The wallet address of the PKP which can decrypt the encrypted Wrapped Key
 *
 * @returns { AccsDefaultParams } - The access control condition that only allows the PKP address to decrypt
 */
export function getPkpAccessControlCondition(
  pkpAddress: string
): AccsDefaultParams {
  if (!ethers.utils.isAddress(pkpAddress)) {
    throw new Error(
      `pkpAddress is not a valid Ethereum Address: ${pkpAddress}`
    );
  }

  return {
    contractAddress: '',
    standardContractType: '',
    chain: CHAIN_ETHEREUM,
    method: '',
    parameters: [':userAddress'],
    returnValueTest: {
      comparator: '=',
      value: pkpAddress,
    },
  };
}

```

To align with the function’s intended return type (a single ACC object), this PR updates the test `should correctly create the ACC` to check for an object instead of an array.

**Related Issue**: 
- Fix #760 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. **Local**  
   - Ran `npx nx run wrapped-keys:test` locally after changing the test to expect a single object. All tests pass successfully now.

```bash
❯ npx nx run wrapped-keys:test                  

> nx run wrapped-keys:test  [existing outputs match the cache, left as is]

watchman warning:  Recrawled this watch 9 times, most recently because:
MustScanSubDirs UserDroppedTo resolve, please review the information on
https://facebook.github.io/watchman/docs/troubleshooting.html#recrawl
To clear this warning, run:
`watchman watch-del '/Users/susumu/js-sdk' ; watchman watch-project '/Users/susumu/js-sdk'`

ts-jest[versions] (WARN) Version 27.5.1 of jest installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=29.0.0 <30.0.0-0). Please do not report issues in ts-jest if you are using unsupported versions.
ts-jest[versions] (WARN) Version 27.5.1 of jest installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=29.0.0 <30.0.0-0). Please do not report issues in ts-jest if you are using unsupported versions.
ts-jest[versions] (WARN) Version 27.5.1 of jest installed has not been tested with ts-jest. If you're experiencing issues, consider using a supported version (>=29.0.0 <30.0.0-0). Please do not report issues in ts-jest if you are using unsupported versions.
ts-jest[ts-jest-transformer] (WARN) Define `ts-jest` config under `globals` is deprecated. Please do
transform: {
    <transform_regex>: ['ts-jest', { /* ts-jest config goes here in Jest */ }],
},
See more at https://kulshekhar.github.io/ts-jest/docs/getting-started/presets#advanced
ts-jest[ts-jest-transformer] (WARN) Define `ts-jest` config under `globals` is deprecated. Please do
transform: {
    <transform_regex>: ['ts-jest', { /* ts-jest config goes here in Jest */ }],
},
See more at https://kulshekhar.github.io/ts-jest/docs/getting-started/presets#advanced
(node:13220) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
 PASS   types  packages/wrapped-keys/src/lib/lit-actions-client/code-repository.spec.ts
Sat, 04 Jan 2025 12:52:56 GMT lit-js-sdk:constants:errors deprecated LitErrorKind is deprecated and will be removed in a future version. Use LIT_ERROR_KIND instead. at node_modules/jest-runtime/build/index.js:1646:24
(node:13219) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
 PASS   types  packages/wrapped-keys/src/lib/api/utils.spec.ts

Test Suites: 2 passed, 2 total
Tests:       13 passed, 13 total
Snapshots:   0 total
Time:        2.13 s
Ran all test suites.

 ————————————————————————————————————————————————————————————————————————————————————————————————————

 >  NX   Successfully ran target test for project wrapped-keys (113ms)
 
   Nx read the output from the cache instead of running the command for 1 out of 1 tasks.
```

```bash
❯ yarn nx format:check --all
yarn run v1.22.22
$ /Users/susumu/js-sdk/node_modules/.bin/nx format:check --all
[warn] jsxBracketSameLine is deprecated.
✨  Done in 7.55s.
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

**Note**: If in the future we decide that an array of ACCs is actually required for broader usage, we can revisit and update both the implementation and the docstring. For now, this PR ensures the test is consistent with the current single-object return.