### PR TITLE
fix(contracts-sdk): claimAndMint(...) missing stakingContractAddress …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,11 @@ jobs:
           node-version: '20'
           cache: 'yarn'
       - name: Install rust
-        uses: dtolnay/rust-toolchain@1.76.0
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.83.0
+          override: true
+          components: rust-std
       - uses: jetli/wasm-pack-action@v0.4.0
         with:
           # Optional version of wasm-pack to install(eg. 'v0.9.1', 'latest')

--- a/packages/contracts-sdk/src/lib/contracts-sdk.ts
+++ b/packages/contracts-sdk/src/lib/contracts-sdk.ts
@@ -2021,13 +2021,23 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
       claimAndMint: async (
         derivedKeyId: BytesLike,
         signatures: IPubkeyRouter.SignatureStruct[],
-        txOpts: ethers.CallOverrides = {}
+        txOpts: ethers.CallOverrides = {},
+        stakingContractAddress?: string
       ) => {
+
+        let params = [2, derivedKeyId, signatures];
+
+        if (stakingContractAddress) {
+          params.push(stakingContractAddress);
+        }
+
         try {
           const tx = await this._callWithAdjustedOverrides(
             this.pkpNftContract.write,
             'claimAndMint',
-            [2, derivedKeyId, signatures],
+            // @ts-ignore - upcoming refactor will include inferred types from the ABIs instead of using the generated types, which in this case are incorrect/out-of-date
+            // Thanks zach-is-my-name for reporting this issue :)
+            params,
             {
               ...txOpts,
               value:

--- a/packages/contracts-sdk/src/lib/contracts-sdk.ts
+++ b/packages/contracts-sdk/src/lib/contracts-sdk.ts
@@ -2024,7 +2024,6 @@ https://developer.litprotocol.com/v3/sdk/wallets/auth-methods/#auth-method-scope
         txOpts: ethers.CallOverrides = {},
         stakingContractAddress?: string
       ) => {
-
         let params = [2, derivedKeyId, signatures];
 
         if (stakingContractAddress) {


### PR DESCRIPTION
# WHAT

@zach-is-my-name : "

Description of the bug/issue

When I call claimAndMint(...) via the @lit-protocol/contracts-sdk, the SDK only passes 3 parameters (keyType, derivedKeyId, and signatures). However, on the deployed PKPNFT diamond facet, claimAndMint(...) requires a 4th parameter for the stakingContractAddress.

This mismatch leads to either:

Too many arguments errors if my facet expects only 3 parameters but the diamond has 4-arg logic in another place, or
Not enough arguments errors if the diamond facet truly wants all 4 (with stakingContractAddress) but the SDK only calls 3.

Expected Behavior
The SDK should allow me to supply an optional stakingContractAddress (as the 4th parameter) when calling claimAndMint.
The function signature in the SDK’s PKPNFT.sol/PKPNFT.d.ts (or relevant code) should match the on-chain diamond facet signature with all 4 parameters.
Actual Behavior
The SDK only exposes claimAndMint(...) with 3 parameters.
The on-chain PKPNFT facet has a claimAndMint(...) with 4 parameters, causing transaction failure or an ABI mismatch.

Proposed Solution
Update claimAndMint(...) calls in contracts-sdk.js (especially in pkpNftContractUtils.write.claimAndMint) to accept an optional fourth parameter for stakingContractAddress.
If it is not required for some networks, it could default to a zero address or a known address, but it should at least be an optional argument in the method signature.

Additional Context
Observed FunctionNotFound(bytes4 _functionSelector) or too many arguments revert when calling with or without a 4th param.
The snippet from contracts-sdk.js that calls claimAndMint shows [2, derivedKeyId, signatures] only.

Severity of the bug

Can't use the contracts-sdk"