### PR TITLE
add rust-toolchain.toml so we autoinstall some necessary rust stuff

### DIFF
--- a/packages/wasm/rust/rust-toolchain.toml
+++ b/packages/wasm/rust/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.83"
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Just adds a rust toolchain file so that it will autoinstall the right rust version and wasm target on build as long as the user has any version of rust already installed