### PR TITLE
Fix/double wrapping issue

### DIFF
--- a/packages/crypto/src/lib/crypto.ts
+++ b/packages/crypto/src/lib/crypto.ts
@@ -135,6 +135,13 @@ export const combineSignatureShares = async (
   shares: BlsSignatureShare[]
 ): Promise<string> => {
   const signature = await doCombineSignatureShares(shares);
+  const hex = Buffer.from(signature).toString('hex');
+  
+  if (hex.length !== 192) {
+    throw new Error(
+      `❌ Invalid signature length: ${hex.length}. Expected 192.`
+    );
+  }
 
   return Buffer.from(signature).toString('hex');
 };

--- a/packages/wasm/rust/src/bls.rs
+++ b/packages/wasm/rust/src/bls.rs
@@ -64,8 +64,19 @@ impl<C: BlsSignatureImpl> Bls<C>
         JsError::new(&format!("Failed to serialize signature to JSON: {}", e))
       )?;
 
-    let signature_bytes = signature_json.as_bytes().to_vec();
-    Ok(Uint8Array::from(signature_bytes.as_slice()))
+    // Parse the signature JSON to get the ProofOfPossession value
+    let signature_json: serde_json::Value = serde_json::from_str(&signature_json)?;
+    let proof_of_possession = signature_json
+        .get("ProofOfPossession")
+        .ok_or_else(|| JsError::new("Missing ProofOfPossession field"))?
+        .as_str()
+        .ok_or_else(|| JsError::new("ProofOfPossession is not a string"))?;
+
+    // Convert hex string to bytes
+    let proof_bytes = hex::decode(proof_of_possession)
+        .map_err(|e| JsError::new(&format!("Failed to decode hex: {}", e)))?;
+
+    Ok(Uint8Array::from(proof_bytes.as_slice()))
   }
 
   pub fn verify(


### PR DESCRIPTION
# WHAT

Previously this is how the ProofOfPossession value look like in the signedMessage:
```
signedMessage: {"sessionKey":"7c1572ecbf2559d18985f5083a71f1a0953de4635629586a07f01aa8c5a1b02d","resourceAbilityRequests":[{"resource":{"resource":"*","resourcePrefix":"lit-pkp"},"ability":"pkp-signing"},{"resource":{"resource":"*","resourcePrefix":"lit-litaction"},"ability":"lit-action-execution"},{"resource":{"resource":"*","resourcePrefix":"lit-litaction"},"ability":"lit-action-execution"}],"capabilities":[{"sig":"{\\"ProofOfPossession\\":\\"7b2250726f6f664f66506f7373657373696f6e223a22613037353734346566373762613966646166666332653434356433313164666165346666616337616265383665666336643464306339326565336165663761353033343065613736623534393537383239366564613362343830663837323034303335303135363866323234666633333338313361393538363730316563326630616237326639303037666339623462383464383335353230336138393432333162643131333337343736326330303762313564363563323539396361316236227d\\"}.....
```

Notice the value is extremely long and when we decode it's actually `{"ProofOfPossession: "xxx...."}`

So we need to parse the signature JSON to get the ProofOfPossession value