### PR TITLE
Fix `lit-node-client-nodejs` test by adding `issuedAt` to SIWE message

### DIFF
--- a/packages/lit-node-client-nodejs/src/lib/helpers/validate-bls-session-sigs.spec.ts
+++ b/packages/lit-node-client-nodejs/src/lib/helpers/validate-bls-session-sigs.spec.ts
@@ -56,6 +56,7 @@ describe('BlsSessionSigVerify', () => {
             Date.now() + 1000 * 60 * 60 * 24 * 7
           ).toISOString(),
           notBefore: new Date(Date.now()).toISOString(),
+          issuedAt: new Date().toISOString(),
         })
       )
     ).toBeUndefined();


### PR DESCRIPTION
# Description

This PR fixes the failing test in `packages/lit-node-client-nodejs/src/lib/helpers/validate-bls-session-sigs.spec.ts`. The test currently throws:

```
Invalid SIWE message. Missing expirationTime or issuedAt.
```

because the `SiweMessage` created in the test has `expirationTime` but no `issuedAt`. According to `blsSessionSigVerify` logic in `validate-bls-session-sig.ts`, **both** `issuedAt` and `expirationTime` must be present.

By adding `issuedAt: new Date().toISOString()` to the `new SiweMessage({ ... })`, the test now passes without error, aligning with EIP-4361 which typically includes `issuedAt`.

**Related Issue**: 
fix https://github.com/LIT-Protocol/js-sdk/issues/771

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

---

# How Has This Been Tested?

1. **Local**  
   - Ran `npx nx run lit-node-client-nodejs:test` locally after adding `issuedAt`.  
   - Confirmed the test suite passes without throwing “Invalid SIWE message. Missing expirationTime or issuedAt.”  

```
~/js-sdk bugfix/verify-bls-signature-tests-issue771
❯ npx nx run lit-node-client-nodejs:test                    

> nx run lit-node-client-nodejs:test  [existing outputs match the cache, left as is]

 PASS   lit-node-client-nodejs  packages/lit-node-client-nodejs/src/lib/helpers/validate-bls-session-sigs.spec.ts
Thu, 16 Jan 2025 23:05:36 GMT lit-js-sdk:constants:constants deprecated LogLevel is deprecated and will be removed in a future version. Use LOG_LEVEL instead. at dist/packages/core/src/lib/lit-core.js:451:90
(node:58033) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
 PASS   lit-node-client-nodejs  packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.spec.ts
  ● Console

    console.debug
      [Lit-JS-SDK v7.0.4] [2025-01-16T23:05:36.696Z] [DEBUG] [core] localstorage api not found, injecting persistence instance found in config

      at Logger._log (../../dist/packages/logger/src/lib/logger.js:227:22)


Test Suites: 13 passed, 13 total
Tests:       43 passed, 43 total
Snapshots:   0 total
Time:        4.758 s
Ran all test suites.
 —————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 >  NX   Successfully ran target test for project lit-node-client-nodejs (81ms)
 
   Nx read the output from the cache instead of running the command for 1 out of 1 tasks.
``` 




Test Suites: 13 passed, 13 total
Tests:       43 passed, 43 total
Snapshots:   0 total
Time:        4.758 s
Ran all test suites.

 —————————————————————————————————————————————————————————————————————————————————————————————————————————————————————————

 >  NX   Successfully ran target test for project lit-node-client-nodejs (67ms)
 
   Nx read the output from the cache instead of running the command for 1 out of 1 tasks.

---

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if any)
- [x] My changes generate no new warnings
- [x] I have added tests (or updated the existing test) that confirm my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

**Note**: If in the future we decide that `issuedAt` is not strictly required, we can revisit `blsSessionSigVerify`. For now, EIP-4361 and Lit’s validation logic suggest that `issuedAt` is the correct approach.