### PR TITLE
Enforce conventional commit messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,3 +114,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update `SIGTYPE` to include new ecdsa types
 - [#107](https://github.com/LIT-Protocol/js-sdk/pull/107) Adds support for new ECDSA implementations for signature recombine
+
+## [Unreleased]
+
+### Added
+
+- Enforced conventional commit message format using commitlint and husky

--- a/README.md
+++ b/README.md
@@ -432,3 +432,33 @@ Object.defineProperty(globalThis, 'crypto', {
 
 **Solution:**
 Make sure your node version is above v18.0.0
+
+# Commit Message Enforcement
+
+We have implemented a git hook to enforce conventional commit message format. This helps in maintaining a consistent commit history and generating changelog documentation based on those messages.
+
+## Commit Message Format
+
+Each commit message should follow this format:
+
+```
+<type>(<scope>): <subject>
+```
+
+Where:
+
+- `type` is the type of change (e.g., feat, fix, docs, style, refactor, test, chore)
+- `scope` is the scope of the change (e.g., module or file name)
+- `subject` is a brief description of the change
+
+Example:
+
+```
+feat(auth): add login functionality
+```
+
+## Using Commitlint and Husky
+
+We use `commitlint` to enforce the commit message format and `husky` to run `commitlint` on commit messages.
+
+To make a commit, simply follow the format above. If the commit message does not follow the format, the commit will be rejected.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "graph": "nx graph",
     "v": "node ./tools/scripts/get-npm-version.mjs",
     "prettier": "nx format:write --all",
-    "prettier:check": "nx format:check --all"
+    "prettier:check": "nx format:check --all",
+    "commitlint": "commitlint --edit $1"
   },
   "private": true,
   "dependencies": {
@@ -121,9 +122,21 @@
     "ts-jest": "29.2.5",
     "typedoc": "^0.26.6",
     "typedoc-theme-hierarchy": "^5.0.0",
-    "typescript": "5.5.4"
+    "typescript": "5.5.4",
+    "commitlint": "^17.0.3",
+    "husky": "^8.0.1"
   },
   "workspaces": [
     "packages/*"
-  ]
+  ],
+  "commitlint": {
+    "extends": [
+      "@commitlint/config-conventional"
+    ]
+  },
+  "husky": {
+    "hooks": {
+      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
+    }
+  }
 }


### PR DESCRIPTION
Implement a git hook to enforce conventional commit message format using commitlint and husky.

* **package.json**
  - Add `commitlint` and `husky` as dev dependencies.
  - Add `commitlint` configuration to enforce conventional commit messages.
  - Add `husky` configuration to run `commitlint` on commit messages.
  - Add a new script to run `commitlint`.

* **CHANGELOG.md**
  - Add a note about the new commit message enforcement.

* **README.md**
  - Add a section about the new commit message enforcement.
  - Provide details on the commit message format and how to use commitlint and husky.

