### PR TITLE
Add viem compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@openagenda/verror": "^3.1.4",
     "@simplewebauthn/browser": "^7.2.0",
     "@simplewebauthn/typescript-types": "^7.0.0",
+    "viem": "^2.22.14",
     "@walletconnect/ethereum-provider": "2.9.2",
     "@walletconnect/jsonrpc-utils": "1.0.8",
     "@walletconnect/types": "2.9.2",

--- a/packages/auth-helpers/src/lib/generate-auth-sig.ts
+++ b/packages/auth-helpers/src/lib/generate-auth-sig.ts
@@ -29,6 +29,14 @@ export const generateAuthSig = async ({
     throw new Error('signer does not have a signMessage method');
   }
 
+  // Viem client compatibility
+  if('undefined' !== typeof signer.account){        
+    signer = new ethers.Wallet(
+      '0x'+signer.account.getHdKey().privKey.toString(16),
+      new ethers.providers.JsonRpcProvider(signer.transport.url)
+    );
+  }
+
   const signature = await signer.signMessage(toSign);
 
   // If address is not provided, derive it from the signer

--- a/packages/contracts-sdk/src/lib/contracts-sdk.ts
+++ b/packages/contracts-sdk/src/lib/contracts-sdk.ts
@@ -426,6 +426,13 @@ export class LitContracts {
         this.isPKP = true;
       }
     }
+    // Viem client compatibility
+    if( 'undefined' !== typeof this.signer.account ){
+        this.signer = new ethers.Wallet(
+           '0x'+this.signer.account.getHdKey().privKey.toString(16),
+           new ethers.providers.JsonRpcProvider(this.signer.transport.url)
+        );
+    }
 
     this.log('Your Signer:', this.signer);
     this.log('Your Provider:', this.provider?.connection!);

--- a/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
+++ b/packages/lit-auth-client/src/lib/providers/EthWalletProvider.ts
@@ -140,10 +140,14 @@ export default class EthWalletProvider extends BaseProvider {
     let authSig: AuthSig;
 
     // convert to EIP-55 format or else SIWE complains
-    address =
-      address ||
-      (await signer?.getAddress!()) ||
-      (signer as ethers.Wallet)?.address;
+    // Viem support
+    if( 'undefined' !== typeof signer.account ){
+      address = signer.account.address;
+    }else{
+      address = address ||
+      (await signer?.getAddress()) ||
+      signer?.address;
+    }
 
     if (!address) {
       throw new InvalidArgumentException(
@@ -158,7 +162,13 @@ export default class EthWalletProvider extends BaseProvider {
     }
 
     address = ethers.utils.getAddress(address);
-
+    // Viem client compatibility
+    if( 'undefined' !== typeof signer.account ){
+      signer = new ethers.Wallet(
+         '0x'+signer.account.getHdKey().privKey.toString(16),
+         new ethers.providers.JsonRpcProvider(signer.transport.url)
+      );
+    }
     if (signer?.signMessage) {
       // Get chain ID or default to Ethereum mainnet
       const selectedChain = LIT_CHAINS[chain];

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -170,6 +170,13 @@ export class LitNodeClientNodeJs
         'dAppOwnerWallet must exist'
       );
     }
+    // Viem client compatibility
+    if( 'undefined' !== typeof params.dAppOwnerWallet.account ){
+        params.dAppOwnerWallet = new ethers.Wallet(
+            '0x'+params.dAppOwnerWallet.account.getHdKey().privKey.toString(16),
+            new ethers.providers.JsonRpcProvider(params.dAppOwnerWallet.transport.url)
+        );
+    }
 
     // Useful log for debugging
     if (!params.delegateeAddresses || params.delegateeAddresses.length === 0) {


### PR DESCRIPTION
# Description

I just add the viem compatibility as a response to #706 (in fact I didn't find differences between ethers5 & ethers6 in term of ethersSigner in which we're interested, other says the update does not concern the ethersSigner, it remains unchanged, both  versions return the same 'class/object', refer to this: [migrating from v5](https://docs.ethers.org/v6/migrating/))
Note: [the viem adapter](https://wagmi.sh/react/guides/ethers) provided by @a1ttech in it's issue does not work, because although they have the same function signMessage(), they not act the same way (the viem signMessage rise an error), so I've derive new ethersSigner from viem walletClient & pass it (create new ethersSinger from viem walletClient by extracting the private key)
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I didn't run any of existing tests, instead I create a micro project that includes the core functionalities described in the docs, & test them with the walletclient (viem) instead ethersSigner, & everything works fine without any warning/error
[use this simple project](https://github.com/BenraouaneSoufiane/lit-sdk-core-functionalities) to test new functionalities
- [ ] Test A
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
