### PR TITLE
Feature/lit 4170 sdk bug domain undefined error upon session expiry

### DIFF
--- a/local-tests/setup/session-sigs/get-pkp-session-sigs.ts
+++ b/local-tests/setup/session-sigs/get-pkp-session-sigs.ts
@@ -12,7 +12,8 @@ export const getPkpSessionSigs = async (
   devEnv: TinnyEnvironment,
   alice: TinnyPerson,
   resourceAbilityRequests?: LitResourceAbilityRequest[],
-  expiration?: string
+  expiration?: string,
+  domain?: string
 ) => {
   const centralisation =
     CENTRALISATION_BY_NETWORK[devEnv.litNodeClient.config.litNetwork];
@@ -39,6 +40,7 @@ export const getPkpSessionSigs = async (
     pkpPublicKey: alice.authMethodOwnedPkp.publicKey,
     authMethods: [alice.authMethod],
     expiration,
+    domain,
     resourceAbilityRequests: _resourceAbilityRequests,
 
     ...(centralisation === 'decentralised' && {

--- a/local-tests/test.ts
+++ b/local-tests/test.ts
@@ -1,3 +1,7 @@
+import { ethers } from 'ethers';
+
+import { log } from '@lit-protocol/misc';
+import { getPkpSessionSigs } from 'local-tests/setup/session-sigs/get-pkp-session-sigs';
 import { TinnyEnvironment } from './setup/tinny-environment';
 import { runInBand, runTestsParallel } from './setup/tinny-operations';
 // import { testBundleSpeed } from './tests/test-bundle-speed';
@@ -109,6 +113,7 @@ import { testFailBatchGeneratePrivateKeysAtomic } from './tests/wrapped-keys/tes
 
 import { setLitActionsCodeToLocal } from './tests/wrapped-keys/util';
 import { testUseEoaSessionSigsToRequestSingleResponse } from './tests/testUseEoaSessionSigsToRequestSingleResponse';
+import { testPkpSessionSigsDomain } from './tests/testPkpSessionSigsDomain';
 
 // Use the current LIT action code to test against
 setLitActionsCodeToLocal();
@@ -185,6 +190,7 @@ setLitActionsCodeToLocal();
     testUsePkpSessionSigsToExecuteJsConsoleLog,
     testUsePkpSessionSigsToEncryptDecryptString,
     testUsePkpSessionSigsToEncryptDecryptFile,
+    testPkpSessionSigsDomain,
   };
 
   const litActionSessionSigsTests = {

--- a/local-tests/tests/testPkpSessionSigsDomain.ts
+++ b/local-tests/tests/testPkpSessionSigsDomain.ts
@@ -8,9 +8,7 @@ import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
  * ✅ NETWORK=datil-test yarn test:local --filter=testPkpSessionSigsDomain
  * ✅ NETWORK=custom yarn test:local --filter=testPkpSessionSigsDomain
  */
-export const testPkpSessionSigsDomain = async (
-  devEnv: TinnyEnvironment
-) => {
+export const testPkpSessionSigsDomain = async (devEnv: TinnyEnvironment) => {
   const alice = await devEnv.createRandomPerson();
   const testDomain = 'test.domain.com';
 
@@ -32,7 +30,13 @@ export const testPkpSessionSigsDomain = async (
   //     { resource: [LitActionResource], ability: 'lit-action-execution' }
   //   ]
   // }
-  const pkpSessionSigs = await getPkpSessionSigs(devEnv, alice, undefined, undefined, testDomain);
+  const pkpSessionSigs = await getPkpSessionSigs(
+    devEnv,
+    alice,
+    undefined,
+    undefined,
+    testDomain
+  );
 
   // Get the first session sig to verify
   const firstNodeAddress = Object.keys(pkpSessionSigs)[0];
@@ -40,14 +44,16 @@ export const testPkpSessionSigsDomain = async (
 
   // Parse the signed message to verify domain
   const signedMessage = firstSessionSig.signedMessage;
-  
+
   // Verify that the domain is present in the signed message
   if (!signedMessage.includes(testDomain)) {
-    throw new Error(`Expected domain "${testDomain}" in signed message, but it was not found. Signed message: ${signedMessage}`);
+    throw new Error(
+      `Expected domain "${testDomain}" in signed message, but it was not found. Signed message: ${signedMessage}`
+    );
   }
 
   log('✅ Domain parameter successfully passed through in sessionSigs');
-  
+
   // Clean up
   devEnv.releasePrivateKeyFromUser(alice);
-}; 
+};

--- a/local-tests/tests/testPkpSessionSigsDomain.ts
+++ b/local-tests/tests/testPkpSessionSigsDomain.ts
@@ -1,0 +1,53 @@
+import { log } from '@lit-protocol/misc';
+import { getPkpSessionSigs } from 'local-tests/setup/session-sigs/get-pkp-session-sigs';
+import { TinnyEnvironment } from 'local-tests/setup/tinny-environment';
+
+/**
+ * Test Commands:
+ * ✅ NETWORK=datil-dev yarn test:local --filter=testPkpSessionSigsDomain
+ * ✅ NETWORK=datil-test yarn test:local --filter=testPkpSessionSigsDomain
+ * ✅ NETWORK=custom yarn test:local --filter=testPkpSessionSigsDomain
+ */
+export const testPkpSessionSigsDomain = async (
+  devEnv: TinnyEnvironment
+) => {
+  const alice = await devEnv.createRandomPerson();
+  const testDomain = 'test.domain.com';
+
+  // AuthNeededCallback props:
+  // props: {
+  //   chain: 'ethereum',
+  //   statement: 'I further authorize the stated URI to perform the following actions on my behalf:',
+  //   resources: [ 'urn:recap:eyJhdHQiOnt9LCJwcmYiOltdfQ' ],
+  //   expiration: '2025-02-01T16:51:50.358Z',
+  //   uri: 'lit:session:e43c4bdff81bb83e7bedf079f5546f237d6e1344c9981735fe8d3a0bbc07c371',
+  //   sessionKey: {
+  //     publicKey: 'e43c4bdff81bb83e7bedf079f5546f237d6e1344c9981735fe8d3a0bbc07c371',
+  //     secretKey: 'a5f43862612394a59f64708a847825255d66839fd6972d3538cb5dffce7228aee43c4bdff81bb83e7bedf079f5546f237d6e1344c9981735fe8d3a0bbc07c371'
+  //   },
+  //   nonce: '0x53e14ac177c02e4b460432ef2bd639519c589137f16136027505c58793608ef7',
+  //   domain: 'test.domain.com',
+  //   resourceAbilityRequests: [
+  //     { resource: [LitPKPResource], ability: 'pkp-signing' },
+  //     { resource: [LitActionResource], ability: 'lit-action-execution' }
+  //   ]
+  // }
+  const pkpSessionSigs = await getPkpSessionSigs(devEnv, alice, undefined, undefined, testDomain);
+
+  // Get the first session sig to verify
+  const firstNodeAddress = Object.keys(pkpSessionSigs)[0];
+  const firstSessionSig = pkpSessionSigs[firstNodeAddress];
+
+  // Parse the signed message to verify domain
+  const signedMessage = firstSessionSig.signedMessage;
+  
+  // Verify that the domain is present in the signed message
+  if (!signedMessage.includes(testDomain)) {
+    throw new Error(`Expected domain "${testDomain}" in signed message, but it was not found. Signed message: ${signedMessage}`);
+  }
+
+  log('✅ Domain parameter successfully passed through in sessionSigs');
+  
+  // Clean up
+  devEnv.releasePrivateKeyFromUser(alice);
+}; 

--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -345,6 +345,7 @@ export class LitNodeClientNodeJs
     litActionIpfsId,
     jsParams,
     sessionKey,
+    domain,
   }: GetWalletSigProps): Promise<AuthSig> => {
     let walletSig: AuthSig;
 
@@ -384,6 +385,7 @@ export class LitNodeClientNodeJs
           uri: sessionKeyUri,
           sessionKey: sessionKey,
           nonce,
+          domain,
 
           // for recap
           ...(resourceAbilityRequests && { resourceAbilityRequests }),
@@ -418,6 +420,7 @@ export class LitNodeClientNodeJs
           expiration,
           uri: sessionKeyUri,
           nonce,
+          domain,
         });
       }
 
@@ -1857,7 +1860,7 @@ export class LitNodeClientNodeJs
    *
    * The process follows these steps:
    * 1. Retrieves or generates a session key pair (Ed25519) for the user's device. The session key is either fetched from local storage or newly created if not found. The key does not expire.
-   * 2. Generates an authentication signature (`authSig`) by signing an ERC-5573 “Sign-in with Ethereum” message, which includes resource ability requests, capabilities, expiration, the user's device session public key, and a nonce. The `authSig` is retrieved from local storage, and if it has expired, the user will be prompted to re-sign.
+   * 2. Generates an authentication signature (`authSig`) by signing an ERC-5573 "Sign-in with Ethereum" message, which includes resource ability requests, capabilities, expiration, the user's device session public key, and a nonce. The `authSig` is retrieved from local storage, and if it has expired, the user will be prompted to re-sign.
    * 3. Uses the session private key to sign the session public key along with the resource ability requests, capabilities, issuedAt, and expiration details. This creates a device-generated signature.
    * 4. Constructs the session signatures (`sessionSigs`) by including the device-generated signature and the original message. The `sessionSigs` provide access to Lit Network features such as `executeJs` and `pkpSign`.
    *
@@ -1898,6 +1901,7 @@ export class LitNodeClientNodeJs
       sessionKey: sessionKey,
       sessionKeyUri: sessionKeyUri,
       nonce: await this.getLatestBlockhash(),
+      domain: params.domain,
 
       // -- for recap
       resourceAbilityRequests: params.resourceAbilityRequests,
@@ -2119,6 +2123,7 @@ export class LitNodeClientNodeJs
           expiration: props.expiration,
           resources: props.resources,
           chainId: 1,
+          domain: props.domain,
 
           // -- required fields
           resourceAbilityRequests: props.resourceAbilityRequests,

--- a/packages/types/src/lib/interfaces.ts
+++ b/packages/types/src/lib/interfaces.ts
@@ -114,6 +114,7 @@ export interface AuthCallbackParams extends LitActionSdkParams {
 
   uri?: string;
 
+  domain?: string;
   /**
    * Cosmos wallet type, to support mutliple popular cosmos wallets
    * Keplr & Cypher -> window.keplr
@@ -1018,9 +1019,6 @@ export interface SignSessionKeyProp extends LitActionSdkParams {
 
   chainId?: number;
 
-  /**
-   * domain param is required, when calling from environment that doesn't have the 'location' object. i.e. NodeJs server.
-   */
   domain?: string;
 
   /**
@@ -1091,6 +1089,8 @@ export interface CommonGetSessionSigsProps {
    * Not limited to capacityDelegationAuthSig. Other AuthSigs with other purposes can also be in this array.
    */
   capabilityAuthSigs?: AuthSig[];
+
+  domain?: string;
 }
 
 export interface BaseProviderGetSessionSigsProps
@@ -1149,6 +1149,7 @@ export interface GetWalletSigProps extends LitActionSdkParams {
   sessionKeyUri: string;
   nonce: string;
   resourceAbilityRequests?: LitResourceAbilityRequest[];
+  domain?: string;
 }
 
 export interface SessionSigningTemplate {


### PR DESCRIPTION
# WHAT

Fixed getting an domain `undefined` error in `authNeededCallback`

# TEST

```
NETWORK=datil-dev yarn test:local --filter=testPkpSessionSigsDomain
```
<img width="741" alt="Screenshot 2025-01-31 at 16 53 14" src="https://github.com/user-attachments/assets/c1fcbf20-e065-4386-87a8-d85d5fc01c1c" />

