### PR TITLE
feat: Log encryption metadata to compare against node logs

### DIFF
--- a/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
+++ b/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts
@@ -1266,6 +1266,8 @@ export class LitNodeClientNodeJs
     const hashOfConditions: ArrayBuffer | undefined =
       await this.getHashedAccessControlConditions(params);
 
+    log('hashOfConditions', hashOfConditions);
+
     if (!hashOfConditions) {
       throw new InvalidArgumentException(
         {
@@ -1282,22 +1284,29 @@ export class LitNodeClientNodeJs
       'base16'
     );
 
+    log('hashOfConditionsStr', hashOfConditionsStr);
+
     // ========== Hashing Private Data ==========
     // hash the private data
     const hashOfPrivateData = await crypto.subtle.digest(
       'SHA-256',
       params.dataToEncrypt
     );
+    log('hashOfPrivateData', hashOfPrivateData);
     const hashOfPrivateDataStr = uint8arrayToString(
       new Uint8Array(hashOfPrivateData),
       'base16'
     );
+
+    log('hashOfPrivateDataStr', hashOfPrivateDataStr);
 
     // ========== Assemble identity parameter ==========
     const identityParam = this._getIdentityParamForEncryption(
       hashOfConditionsStr,
       hashOfPrivateDataStr
     );
+
+    log('identityParam', identityParam);
 
     // ========== Encrypt ==========
     const ciphertext = await encrypt(
@@ -1353,6 +1362,8 @@ export class LitNodeClientNodeJs
     const hashOfConditions: ArrayBuffer | undefined =
       await this.getHashedAccessControlConditions(params);
 
+    log('hashOfConditions', hashOfConditions);
+
     if (!hashOfConditions) {
       throw new InvalidArgumentException(
         {
@@ -1368,6 +1379,8 @@ export class LitNodeClientNodeJs
       new Uint8Array(hashOfConditions),
       'base16'
     );
+
+    log('hashOfConditionsStr', hashOfConditionsStr);
 
     // ========== Formatting Access Control Conditions =========
     const {
@@ -1470,6 +1483,8 @@ export class LitNodeClientNodeJs
     const hashOfConditions: ArrayBuffer | undefined =
       await this.getHashedAccessControlConditions(params);
 
+    log('hashOfConditions', hashOfConditions);
+
     if (!hashOfConditions) {
       throw new InvalidArgumentException(
         {
@@ -1486,16 +1501,21 @@ export class LitNodeClientNodeJs
       'base16'
     );
 
+    log('hashOfConditionsStr', hashOfConditionsStr);
+
     // ========== Hashing Private Data ==========
     // hash the private data
     const hashOfPrivateData = await crypto.subtle.digest(
       'SHA-256',
       params.dataToEncrypt
     );
+    log('hashOfPrivateData', hashOfPrivateData);
     const hashOfPrivateDataStr = uint8arrayToString(
       new Uint8Array(hashOfPrivateData),
       'base16'
     );
+
+    log('hashOfPrivateDataStr', hashOfPrivateDataStr);
 
     return new LitAccessControlConditionResource(
       `${hashOfConditionsStr}/${hashOfPrivateDataStr}`


### PR DESCRIPTION
# Description

Log encryption metadata to compare against the node logs when decryption fails within Lit Actions since the nodes don't format the ACC in exactly the same manner as the SDK.

## Type of change

- [X] Additional Logging (non-breaking change which adds additional logging)

# How Has This Been Tested?

Just logs no tests required

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
