### PR TITLE
LIT-4207 - Implement node price re-fetching when running lit node commands

### DIFF
--- a/packages/constants/src/index.ts
+++ b/packages/constants/src/index.ts
@@ -5,7 +5,6 @@ export * from './lib/version';
 export * from './lib/constants/constants';
 export * from './lib/constants/mappers';
 export * from './lib/constants/endpoints';
-export * from './lib/constants/mappers';
 export * from './lib/constants/curves';
 
 // ----------- Interfaces -----------

--- a/packages/contracts-sdk/src/index.ts
+++ b/packages/contracts-sdk/src/index.ts
@@ -1,2 +1,6 @@
+import { getPriceFeedInfo, getNodePrices } from './lib/price-feed-info-manager';
+
 export * from './lib/contracts-sdk';
 export * from './lib/utils';
+
+export { getPriceFeedInfo, getNodePrices };

--- a/packages/contracts-sdk/src/lib/price-feed-info-manager.ts
+++ b/packages/contracts-sdk/src/lib/price-feed-info-manager.ts
@@ -1,0 +1,141 @@
+// import * as util from 'node:util'; // For inspecting bigInt payloads for pricing data
+
+import { HTTP, HTTPS, PRODUCT_IDS } from '@lit-protocol/constants';
+import {
+  LIT_NETWORKS_KEYS,
+  LitContractContext,
+  LitContractResolverContext,
+} from '@lit-protocol/types';
+
+import { LitContracts } from './contracts-sdk';
+
+import type { ValidatorWithPrices } from './types';
+
+type GetPriceFeedInfoArgs = Parameters<typeof LitContracts.getPriceFeedInfo>;
+type PriceFeedInfo = Awaited<ReturnType<typeof fetchPriceFeedInfo>>;
+
+const STALE_PRICES_SECONDS = 3 * 1000; // Update prices if > X seconds old
+const PRODUCT_IDS_ARRAY = Object.values(PRODUCT_IDS);
+
+let priceFeedInfo: PriceFeedInfo | null = null;
+let fetchingPriceFeedInfo: null | Promise<PriceFeedInfo> = null;
+let lastUpdatedTimestamp = 0;
+
+async function fetchPriceFeedInfo({
+  realmId,
+  litNetwork,
+  networkContext,
+  rpcUrl,
+  nodeProtocol,
+}: {
+  realmId: number;
+  litNetwork: LIT_NETWORKS_KEYS;
+  networkContext?: LitContractContext | LitContractResolverContext;
+  rpcUrl?: string;
+  nodeProtocol?: typeof HTTP | typeof HTTPS | null;
+}) {
+  const priceFeedContract = await LitContracts.getPriceFeedContract(
+    litNetwork,
+    networkContext,
+    rpcUrl
+  );
+
+  const nodesForRequest = await priceFeedContract['getNodesForRequest'](
+    realmId,
+    PRODUCT_IDS_ARRAY
+  );
+
+  const epochId: number[] = nodesForRequest[0].toNumber();
+  const minNodeCount: number[] = nodesForRequest[1].toNumber();
+  const nodesAndPrices: ValidatorWithPrices[] = nodesForRequest[2];
+
+  const networkUrls = LitContracts.generateValidatorURLs({
+    activeValidatorStructs: nodesAndPrices.map(({ validator }) => validator),
+    litNetwork,
+    nodeProtocol,
+  });
+
+  const prices = networkUrls
+    .reduce<{ url: string; prices: bigint[] }[]>((acc, network, index) => {
+      acc.push({
+        url: network,
+        prices: nodesAndPrices[index].prices.map((ethersPrice) =>
+          ethersPrice.toBigInt()
+        ),
+      });
+      return acc;
+    }, [])
+    .sort(({ prices: pricesA }, { prices: pricesB }) => {
+      // Sort by any price since the cheapest for _any_ product will be the cheapest for _all_ products
+      const diff = pricesA[0] - pricesB[0];
+      if (diff > 0n) {
+        return 1;
+      } else if (diff < 0n) {
+        return -1;
+      } else {
+        return 0;
+      }
+    });
+
+  // console.log(
+  //   'getPriceFeedInfo()',
+  //   util.inspect(
+  //     {
+  //       epochId,
+  //       minNodeCount,
+  //       networkPrices: {
+  //         mapByAddress: networkPriceMap,
+  //       },
+  //     },
+  //     { depth: 4 }
+  //   )
+  // );
+
+  return {
+    epochId,
+    minNodeCount,
+    networkPrices: prices,
+  };
+}
+
+async function fetchNodePricesWithLocalPromise(
+  ...params: GetPriceFeedInfoArgs
+): Promise<PriceFeedInfo> {
+  try {
+    fetchingPriceFeedInfo = fetchPriceFeedInfo(...params);
+
+    priceFeedInfo = await fetchingPriceFeedInfo;
+    lastUpdatedTimestamp = Date.now();
+
+    return priceFeedInfo;
+  } finally {
+    fetchingPriceFeedInfo = null;
+  }
+}
+
+export async function getPriceFeedInfo(...params: GetPriceFeedInfoArgs) {
+  // If there's a local promise, an update is in progress; wait for that
+  if (fetchingPriceFeedInfo) {
+    return fetchingPriceFeedInfo;
+  }
+
+  // If we have updated prices in the last 2 seconds, return our current prices
+  if (
+    priceFeedInfo &&
+    Date.now() - lastUpdatedTimestamp < STALE_PRICES_SECONDS
+  ) {
+    return priceFeedInfo;
+  }
+
+  // If we get here, we've got prices that are at least 2 seconds out-of-date.
+  // Fetch the new ones, update local cache values, and return them
+  return fetchNodePricesWithLocalPromise(...params);
+}
+
+export async function getNodePrices(
+  ...params: GetPriceFeedInfoArgs
+): Promise<PriceFeedInfo['networkPrices']> {
+  const priceInfo = await getPriceFeedInfo(...params);
+
+  return priceInfo.networkPrices;
+}

--- a/packages/contracts-sdk/src/lib/price-feed-info-manager.ts
+++ b/packages/contracts-sdk/src/lib/price-feed-info-manager.ts
@@ -98,7 +98,7 @@ async function fetchPriceFeedInfo({
   };
 }
 
-async function fetchNodePricesWithLocalPromise(
+async function fetchPriceFeedInfoWithLocalPromise(
   ...params: GetPriceFeedInfoArgs
 ): Promise<PriceFeedInfo> {
   try {
@@ -129,7 +129,7 @@ export async function getPriceFeedInfo(...params: GetPriceFeedInfoArgs) {
 
   // If we get here, we've got prices that are at least 2 seconds out-of-date.
   // Fetch the new ones, update local cache values, and return them
-  return fetchNodePricesWithLocalPromise(...params);
+  return fetchPriceFeedInfoWithLocalPromise(...params);
 }
 
 export async function getNodePrices(

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -115,8 +115,6 @@ export type LitNodeClientConfigWithDefaults = Required<
     bootstrapUrls: string[];
   } & {
     nodeProtocol?: typeof HTTP | typeof HTTPS | null;
-  } & {
-    nodePrices: { url: string; prices: bigint[] }[]; // eg. <nodeAddress, price[]>
   };
 
 export class LitCore {
@@ -129,7 +127,6 @@ export class LitCore {
     minNodeCount: 2, // Default value, should be replaced
     bootstrapUrls: [], // Default value, should be replaced
     nodeProtocol: null,
-    nodePrices: [],
   };
   connectedNodes = new Set<string>();
   serverKeys: Record<string, JsonHandshakeResponse> = {};
@@ -504,7 +501,6 @@ export class LitCore {
     this._stakingContract = validatorData.stakingContract;
     this.config.minNodeCount = validatorData.minNodeCount;
     this.config.bootstrapUrls = validatorData.bootstrapUrls;
-    this.config.nodePrices = validatorData.nodePrices;
 
     this._epochState = await this._fetchCurrentEpochState(
       validatorData.epochInfo

--- a/packages/core/src/lib/lit-core.ts
+++ b/packages/core/src/lib/lit-core.ts
@@ -1,20 +1,6 @@
 import { ethers } from 'ethers';
 
 import {
-  canonicalAccessControlConditionFormatter,
-  canonicalEVMContractConditionFormatter,
-  canonicalSolRpcConditionFormatter,
-  canonicalUnifiedAccessControlConditionFormatter,
-  hashAccessControlConditions,
-  hashEVMContractConditions,
-  hashSolRpcConditions,
-  hashUnifiedAccessControlConditions,
-  validateAccessControlConditionsSchema,
-  validateEVMContractConditionsSchema,
-  validateSolRpcConditionsSchema,
-  validateUnifiedAccessControlConditionsSchema,
-} from '@lit-protocol/access-control-conditions';
-import {
   CENTRALISATION_BY_NETWORK,
   HTTP,
   HTTPS,
@@ -59,15 +45,12 @@ import {
   CustomNetwork,
   EpochInfo,
   EthBlockhashInfo,
-  FormattedMultipleAccs,
   JsonHandshakeResponse,
   LitNodeClientConfig,
-  MultipleAccessControlConditions,
   NodeSet,
   RejectedNodePromises,
   SessionSigsMap,
   SuccessNodePromises,
-  SupportedJsonRequests,
 } from '@lit-protocol/types';
 
 import { composeLitUrl } from './endpoint-version';

--- a/packages/types/src/lib/ILitNodeClient.ts
+++ b/packages/types/src/lib/ILitNodeClient.ts
@@ -1,3 +1,5 @@
+import { PRODUCT_IDS } from '@lit-protocol/constants';
+
 import {
   AuthenticationContext,
   CapacityCreditsReq,
@@ -14,8 +16,6 @@ import {
   LitNodeClientConfig,
   SigResponse,
 } from './interfaces';
-
-import { PRODUCT_IDS } from '@lit-protocol/constants';
 import { ClaimProcessor, ClaimRequest } from './types';
 
 export interface ILitNodeClient {
@@ -58,7 +58,7 @@ export interface ILitNodeClient {
   getMaxPricesForNodeProduct(params: {
     userMaxPrice?: bigint;
     product: keyof typeof PRODUCT_IDS;
-  }): { url: string; price: bigint }[];
+  }): Promise<{ url: string; price: bigint }[]>;
 
   /**
    * Create capacity delegation authentication signature


### PR DESCRIPTION
# Description

Somewhere in all the code shuffling leading up to our current Naga branch, logic that re-fetched node prices was lost.  This PR adds it back in.

### Details:
- Moved price feed info fetching to `price-feed-info-manager` module, which is responsible for handling caching of fetched data and concurrent requests to fetch the data
- Only 1 fetch promise can be run at a time; concurrent requests chain on any existing pending promise that is already loading price feed data
- Only fetches new data if it has been > 3 seconds since last fetch; since the nodes only update their on-chain price intermittently, this seems like a reasonable constraint to avoid hammering RPC multiple times per second even though the nodes only sync every few seconds.
- Updated static method `getPriceFeedInfo()` on LitContracts class to use the new price feed info manager so any LitContracts SDK consumers get this behaviour
- Removed tracking of nodePrices from LitCore/LitNodeClient since it would be duplicated state that is already being kept in the new manager module

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
- [X] Ran local-tests against current lit-assets 'stable' naga commit

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
