### PR TITLE
Feature/node 4567 missing addpermittedauthmethod and removepermittedauthmethod

### DIFF
--- a/e2e/src/demo/add-permitted-address-demo.ts
+++ b/e2e/src/demo/add-permitted-address-demo.ts
@@ -1,0 +1,155 @@
+// Run this command for this demo:
+// LOG_LEVEL=silent NETWORK=naga-dev bun run ./e2e/src/demo/add-permitted-address-demo.ts
+
+//
+// This test if a PKP EOA Auth Method could add a permitted address via the PKPViemAccount
+// 
+import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
+import { nonceManager } from 'viem';
+import { fundAccount } from '../helper/fundAccount';
+import { createLitClient } from '@lit-protocol/lit-client';
+import {
+  createAuthManager,
+  storagePlugins,
+  ViemAccountAuthenticator,
+} from '@lit-protocol/auth';
+
+// -- Configurations
+const { nagaLocal } = await import('@lit-protocol/networks');
+const LOCAL_NETWORK_FUNDING_AMOUNT = '1';
+
+// -- Master account to fund the alice(test) account
+const localMasterAccount = privateKeyToAccount(
+  process.env['LOCAL_MASTER_ACCOUNT'] as `0x${string}`,
+  {
+    nonceManager: nonceManager,
+  }
+);
+
+// -- EOA Test account via Viem
+const aliceViemAccount = privateKeyToAccount(generatePrivateKey());
+
+// -- Using the authenticator to get the Auth Data
+const aliceViemAccountAuthData = await ViemAccountAuthenticator.authenticate(
+  aliceViemAccount
+);
+
+console.log("✅ aliceViemAccountAuthData:", aliceViemAccountAuthData);
+
+try {
+  await fundAccount(aliceViemAccount, localMasterAccount, nagaLocal, {
+    ifLessThan: LOCAL_NETWORK_FUNDING_AMOUNT,
+    thenFundWith: LOCAL_NETWORK_FUNDING_AMOUNT,
+  });
+  console.log("✅ Account Funded.")
+} catch (e) {
+  throw new Error("❌ Failed to fund account.")
+}
+
+/**
+ * ====================================
+ * Initialise the LitClient
+ * ====================================
+ */
+const litClient = await createLitClient({ network: nagaLocal });
+console.log("✅ Created Lit Client")
+
+/**
+ * ====================================
+ * Initialise the AuthManager
+ * ====================================
+ */
+const authManager = createAuthManager({
+  storage: storagePlugins.localStorageNode({
+    appName: 'my-local-testing-app',
+    networkName: 'local-test',
+    storagePath: './lit-auth-local',
+  }),
+});
+console.log("✅ Created Auth Manager")
+
+// Minting a new PKP
+const tx = await litClient.mintWithAuth({
+  account: aliceViemAccount,
+  authData: aliceViemAccountAuthData,
+  scopes: ['sign-anything'],
+});
+console.log("✅ TX 1 done");
+console.log("ℹ️ tx:", tx)
+
+const pkpInfo = tx.data;
+console.log("✅ pkpInfo:", pkpInfo);
+
+const pkpPermissionsManagerForAliceViemAccount = await litClient.getPKPPermissionsManager({
+  pkpIdentifier: {
+    tokenId: pkpInfo.tokenId,
+  },
+  account: aliceViemAccount,
+});
+
+console.log("✅ pkpPermissionsManagerForAliceViemAccount:", await pkpPermissionsManagerForAliceViemAccount.getPermissionsContext());
+
+// check is address permitted
+const aliceViemAccountIsPermitted = await pkpPermissionsManagerForAliceViemAccount.isPermittedAddress({
+  address: aliceViemAccount.address,
+});
+
+console.log(`❗️ ${aliceViemAccount.address} is ${aliceViemAccountIsPermitted ? 'permitted' : 'NOT permitted'}`);
+
+// check if pkp address is permitted
+const pkpIsPermitted = await pkpPermissionsManagerForAliceViemAccount.isPermittedAddress({
+  address: pkpInfo.ethAddress,
+});
+
+console.log(`❗️ ${pkpInfo.ethAddress} is ${pkpIsPermitted ? 'permitted' : 'NOT permitted'}`);
+
+
+const authContext = await authManager.createPkpAuthContext({
+  authData: aliceViemAccountAuthData,
+  pkpPublicKey: pkpInfo.pubkey,
+  authConfig: {
+    capabilityAuthSigs: [],
+    expiration: new Date(Date.now() + 1000 * 60 * 60 * 24).toISOString(),
+    statement: "",
+    domain: "",
+    resources: [
+      ["pkp-signing", "*"],
+      ["lit-action-execution", "*"],
+    ],
+  },
+  litClient,
+});
+
+console.log("authContext:", authContext);
+
+const pkpViemAccount = await litClient.getPkpViemAccount({
+  pkpPublicKey: pkpInfo.pubkey,
+  authContext: authContext,
+  chainConfig: nagaLocal.getChainConfig(),
+});
+
+await fundAccount(pkpViemAccount, localMasterAccount, nagaLocal, {
+  ifLessThan: LOCAL_NETWORK_FUNDING_AMOUNT,
+  thenFundWith: LOCAL_NETWORK_FUNDING_AMOUNT,
+});
+
+const pkpViemAccountPermissionsManager = await litClient.getPKPPermissionsManager({
+  pkpIdentifier: {
+    tokenId: pkpInfo.tokenId,
+  },
+  account: pkpViemAccount,
+});
+
+try {
+  const tx2 = await pkpViemAccountPermissionsManager.addPermittedAddress({
+    address: "0x1234567890123456789012345678901234567890",
+    scopes: ["sign-anything"],
+  });
+  console.log('tx2:', tx2)
+} catch (e) {
+  throw new Error(e);
+}
+
+console.log("✅ pkpViemAccountPermissionsManager:", await pkpViemAccountPermissionsManager.getPermissionsContext());
+
+process.exit();

--- a/e2e/src/e2e.spec.ts
+++ b/e2e/src/e2e.spec.ts
@@ -32,7 +32,7 @@ describe('all', () => {
       ctx = await init();
 
       // Create PKP and custom auth contexts using helper functions
-      alicePkpAuthContext = await createPkpAuthContext(ctx);
+      // alicePkpAuthContext = await createPkpAuthContext(ctx);
       aliceCustomAuthContext = await createCustomAuthContext(ctx);
     } catch (e) {
       console.error(e);
@@ -83,29 +83,29 @@ describe('all', () => {
     console.log('🔐 Testing using Programmable Key Pair authentication');
 
     describe('endpoints', () => {
-      it('pkpSign', () => createPkpSignTest(ctx, () => alicePkpAuthContext)());
+      it('pkpSign', () => createPkpSignTest(ctx, () => ctx.alicePkpAuthContext)());
       it('executeJs', () =>
-        createExecuteJsTest(ctx, () => alicePkpAuthContext)());
+        createExecuteJsTest(ctx, () => ctx.alicePkpAuthContext)());
       it('viewPKPsByAddress', () =>
-        createViewPKPsByAddressTest(ctx, () => alicePkpAuthContext)());
+        createViewPKPsByAddressTest(ctx, () => ctx.alicePkpAuthContext)());
       it('viewPKPsByAuthData', () =>
-        createViewPKPsByAuthDataTest(ctx, () => alicePkpAuthContext)());
+        createViewPKPsByAuthDataTest(ctx, () => ctx.alicePkpAuthContext)());
       it('pkpEncryptDecrypt', () =>
-        createPkpEncryptDecryptTest(ctx, () => alicePkpAuthContext)());
+        createPkpEncryptDecryptTest(ctx, () => ctx.alicePkpAuthContext)());
       it('encryptDecryptFlow', () =>
-        createEncryptDecryptFlowTest(ctx, () => alicePkpAuthContext)());
+        createEncryptDecryptFlowTest(ctx, () => ctx.alicePkpAuthContext)());
       it('pkpPermissionsManagerFlow', () =>
-        createPkpPermissionsManagerFlowTest(ctx, () => alicePkpAuthContext)());
+        createPkpPermissionsManagerFlowTest(ctx, () => ctx.alicePkpAuthContext)());
     });
 
     describe('integrations', () => {
       describe('pkp viem account', () => {
         it('sign message', () =>
-          createViemSignMessageTest(ctx, () => alicePkpAuthContext)());
+          createViemSignMessageTest(ctx, () => ctx.alicePkpAuthContext)());
         it('sign transaction', () =>
-          createViemSignTransactionTest(ctx, () => alicePkpAuthContext)());
+          createViemSignTransactionTest(ctx, () => ctx.alicePkpAuthContext)());
         it('sign typed data', () =>
-          createViemSignTypedDataTest(ctx, () => alicePkpAuthContext)());
+          createViemSignTypedDataTest(ctx, () => ctx.alicePkpAuthContext)());
       });
     });
   });

--- a/e2e/src/helper/pkp-utils.ts
+++ b/e2e/src/helper/pkp-utils.ts
@@ -1,0 +1,76 @@
+/**
+ * PKP Utilities
+ * 
+ * This module provides utility functions for managing Programmable Key Pairs (PKPs)
+ * in the Lit Protocol ecosystem. It handles the common pattern of checking for 
+ * existing PKPs and creating new ones when necessary.
+ * 
+ * Usage:
+ *   import { getOrCreatePkp } from './helper/pkp-utils';
+ *   const pkp = await getOrCreatePkp(litClient, authData, account, storagePath, networkName);
+ */
+
+import { storagePlugins } from '@lit-protocol/auth';
+
+// Configuration constants
+const PAGINATION_LIMIT = 5;
+const APP_NAME = 'my-app';
+const PKP_SCOPES = ['sign-anything'];
+
+/**
+ * Gets an existing PKP or creates a new one if none exists
+ * 
+ * @param litClient - The Lit Protocol client instance
+ * @param authData - Authentication data for the account
+ * @param account - The account to associate with the PKP
+ * @param storagePath - Local storage path for PKP tokens
+ * @param networkName - Name of the network being used
+ * @returns Promise<PKP> - The existing or newly created PKP
+ */
+export const getOrCreatePkp = async (
+  litClient: any,
+  authData: any,
+  account: any,
+  storagePath: string,
+  networkName: string
+) => {
+  // Check for existing PKPs
+  const { pkps } = await litClient.viewPKPsByAuthData({
+    authData,
+    pagination: {
+      limit: PAGINATION_LIMIT,
+    },
+    storageProvider: storagePlugins.localStorageNode({
+      appName: APP_NAME,
+      networkName,
+      storagePath,
+    }),
+  });
+
+  // If PKP exists, return it
+  if (pkps && pkps[0]) {
+    return pkps[0];
+  }
+
+  // Otherwise mint new PKP
+  const mintResult = await litClient.mintWithAuth({
+    authData,
+    account,
+    scopes: PKP_SCOPES,
+  });
+
+  // Query again to get the newly minted PKP in the expected format
+  const { pkps: newPkps } = await litClient.viewPKPsByAuthData({
+    authData,
+    pagination: {
+      limit: PAGINATION_LIMIT,
+    },
+    storageProvider: storagePlugins.localStorageNode({
+      appName: APP_NAME,
+      networkName,
+      storagePath,
+    }),
+  });
+
+  return newPkps[0];
+}; 

--- a/e2e/src/helper/tests/pkp-permissions-manager-flow.ts
+++ b/e2e/src/helper/tests/pkp-permissions-manager-flow.ts
@@ -109,5 +109,92 @@ export const createPkpPermissionsManagerFlowTest = (
 
     assert.toBe(finalAddressPermitted, initialAddressPermitted);
     assert.toBe(finalActionPermitted, initialActionPermitted);
+
+    // Test 8: Verify new addPermittedAuthMethod method exists and is callable
+    assert.toBeDefined(pkpPermissionsManager.addPermittedAuthMethod);
+    assert.toBe(typeof pkpPermissionsManager.addPermittedAuthMethod, 'function');
+
+    // Test 9: Verify new removePermittedAuthMethodScope method exists and is callable
+    assert.toBeDefined(pkpPermissionsManager.removePermittedAuthMethodScope);
+    assert.toBe(typeof pkpPermissionsManager.removePermittedAuthMethodScope, 'function');
+
+    // Test 10: Actually test addPermittedAuthMethod functionality
+    const testAuthMethodParams = {
+      authMethodType: 1, // EthWallet
+      authMethodId: '0x1234567890abcdef1234567890abcdef12345678',
+      userPubkey: '0x04abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+      scopes: ['sign-anything'] as const,
+    };
+
+    // Get initial auth methods count
+    const initialAuthMethods = await pkpPermissionsManager.getPermittedAuthMethods();
+    const initialAuthMethodsCount = initialAuthMethods.length;
+
+    console.log('🧪 Adding test auth method...');
+    // Add the test auth method
+    const addAuthMethodTx = await pkpPermissionsManager.addPermittedAuthMethod(testAuthMethodParams);
+    assert.toBeDefined(addAuthMethodTx.hash);
+    assert.toBeDefined(addAuthMethodTx.receipt);
+    assert.toBe(addAuthMethodTx.receipt.status, 'success');
+
+    // Verify the auth method was added
+    const authMethodsAfterAdd = await pkpPermissionsManager.getPermittedAuthMethods();
+    assert.toBe(authMethodsAfterAdd.length, initialAuthMethodsCount + 1);
+
+    // Find our added auth method
+    const addedAuthMethod = authMethodsAfterAdd.find(
+      (am) => 
+        am.id === testAuthMethodParams.authMethodId &&
+        Number(am.authMethodType) === testAuthMethodParams.authMethodType
+    );
+    assert.toBeDefined(addedAuthMethod);
+    console.log('✅ Test auth method successfully added');
+
+    // Test 11: Test removePermittedAuthMethodScope functionality
+    const testScopeParams = {
+      authMethodType: testAuthMethodParams.authMethodType,
+      authMethodId: testAuthMethodParams.authMethodId,
+      scopeId: 1, // SignAnything scope
+    };
+
+    console.log('🧪 Removing scope from test auth method...');
+    // Remove a scope from the auth method
+    const removeScopeTx = await pkpPermissionsManager.removePermittedAuthMethodScope(testScopeParams);
+    assert.toBeDefined(removeScopeTx.hash);
+    assert.toBeDefined(removeScopeTx.receipt);
+    assert.toBe(removeScopeTx.receipt.status, 'success');
+
+    // Verify the scope was removed by checking auth method scopes
+    const authMethodScopes = await pkpPermissionsManager.getPermittedAuthMethodScopes({
+      authMethodType: testAuthMethodParams.authMethodType,
+      authMethodId: testAuthMethodParams.authMethodId,
+      scopeId: 1,
+    });
+    // After removing scope 1, it should return false for that specific scope
+    assert.toBe(authMethodScopes[0], false);
+    console.log('✅ Scope successfully removed from test auth method');
+
+    // Test 12: Cleanup - Remove the test auth method entirely
+    console.log('🧹 Cleaning up test auth method...');
+    const removeAuthMethodTx = await pkpPermissionsManager.removePermittedAuthMethod({
+      authMethodType: testAuthMethodParams.authMethodType,
+      authMethodId: testAuthMethodParams.authMethodId,
+    });
+    assert.toBeDefined(removeAuthMethodTx.hash);
+    assert.toBeDefined(removeAuthMethodTx.receipt);
+    assert.toBe(removeAuthMethodTx.receipt.status, 'success');
+
+    // Verify the auth method was removed
+    const finalAuthMethods = await pkpPermissionsManager.getPermittedAuthMethods();
+    assert.toBe(finalAuthMethods.length, initialAuthMethodsCount);
+
+    // Ensure our test auth method is no longer in the list
+    const removedAuthMethod = finalAuthMethods.find(
+      (am) => 
+        am.id === testAuthMethodParams.authMethodId &&
+        Number(am.authMethodType) === testAuthMethodParams.authMethodType
+    );
+    assert.toBe(removedAuthMethod, undefined);
+    console.log('✅ Test auth method successfully cleaned up');
   };
 };

--- a/packages/networks/src/networks/vNaga/LitChainClient/apis/highLevelApis/PKPPermissionsManager/handlers/addPermittedAuthMethodByIdentifier.ts
+++ b/packages/networks/src/networks/vNaga/LitChainClient/apis/highLevelApis/PKPPermissionsManager/handlers/addPermittedAuthMethodByIdentifier.ts
@@ -1,0 +1,80 @@
+import { z } from 'zod';
+import { DefaultNetworkConfig } from '../../../../../interfaces/NetworkContext';
+import { ScopeStringSchema } from '../../../../schemas/shared/ScopeSchema';
+import {
+  PkpIdentifierRaw,
+  resolvePkpTokenId,
+} from '../../../rawContractApis/permissions/utils/resolvePkpTokenId';
+import { addPermittedAuthMethod } from '../../../rawContractApis/permissions/write/addPermittedAuthMethod';
+import { LitTxVoid } from '../../../types';
+import { ExpectedAccountOrWalletClient } from '../../../../contract-manager/createContractsManager';
+
+// Schema for the request
+const addPermittedAuthMethodByIdentifierSchema = z.intersection(
+  z.object({
+    authMethodType: z.string().or(z.number()).or(z.bigint()),
+    authMethodId: z.string(),
+    userPubkey: z.string(),
+    scopes: z.array(ScopeStringSchema),
+  }),
+  z.union([
+    z.object({ tokenId: z.string().or(z.number()).or(z.bigint()) }),
+    z.object({ pubkey: z.string() }),
+    z.object({ address: z.string() }),
+  ])
+);
+
+type AddPermittedAuthMethodByIdentifierRequest = z.infer<
+  typeof addPermittedAuthMethodByIdentifierSchema
+>;
+
+/**
+ * Adds a permitted authentication method to a PKP token using various identifier types
+ * @param request - Object containing either tokenId/address/pubkey, authMethodType, authMethodId, userPubkey, and scopes
+ * @param networkCtx - Network context for contract interactions
+ * @param accountOrWalletClient - Account or wallet client for signing
+ * @returns Promise resolving to transaction details
+ */
+export async function addPermittedAuthMethodByIdentifier(
+  request: AddPermittedAuthMethodByIdentifierRequest,
+  networkCtx: DefaultNetworkConfig,
+  accountOrWalletClient: ExpectedAccountOrWalletClient
+): Promise<LitTxVoid> {
+  const { authMethodType, authMethodId, userPubkey, scopes, ...identifier } = request;
+  const pkpTokenId = await resolvePkpTokenId(
+    identifier as PkpIdentifierRaw,
+    networkCtx
+  );
+
+  return addPermittedAuthMethod(
+    {
+      tokenId: pkpTokenId.toString(),
+      authMethodType: authMethodType.toString(),
+      id: authMethodId,
+      userPubkey,
+      scopes,
+    },
+    networkCtx,
+    accountOrWalletClient
+  );
+}
+
+// Example usage
+// if (import.meta.main) {
+//   const networkCtx = networkContext;
+
+//   const res = await addPermittedAuthMethodByIdentifier(
+//     {
+//       tokenId:
+//         "76136736151863037541847315168980811654782785653773679312890341037699996601290",
+//       authMethodType: 1, // AuthMethodType.EthWallet
+//       authMethodId: "0x1234567890abcdef1234567890abcdef12345678",
+//       userPubkey: "0x04abcdef...",
+//       scopes: ["sign-anything"],
+//     },
+//     networkCtx,
+//     accountOrWalletClient
+//   );
+
+//   console.log("res", res);
+// } 

--- a/packages/networks/src/networks/vNaga/LitChainClient/apis/highLevelApis/PKPPermissionsManager/handlers/removePermittedAuthMethodScopeByIdentifier.ts
+++ b/packages/networks/src/networks/vNaga/LitChainClient/apis/highLevelApis/PKPPermissionsManager/handlers/removePermittedAuthMethodScopeByIdentifier.ts
@@ -1,0 +1,81 @@
+import { z } from 'zod';
+import { DefaultNetworkConfig } from '../../../../../interfaces/NetworkContext';
+import {
+  PkpIdentifierRaw,
+  resolvePkpTokenId,
+} from '../../../rawContractApis/permissions/utils/resolvePkpTokenId';
+import { removePermittedAuthMethodScope } from '../../../rawContractApis/permissions/write/removePermittedAuthMethodScope';
+import { LitTxVoid } from '../../../types';
+import { ExpectedAccountOrWalletClient } from '../../../../contract-manager/createContractsManager';
+
+// Schema for the request
+const removePermittedAuthMethodScopeByIdentifierSchema = z.intersection(
+  z.object({
+    authMethodType: z.string().or(z.number()).or(z.bigint()),
+    authMethodId: z.string(), // The id field from the contract
+    scopeId: z.string().or(z.number()).or(z.bigint()),
+  }),
+  z.union([
+    z.object({ tokenId: z.string().or(z.number()).or(z.bigint()) }),
+    z.object({ pubkey: z.string() }),
+    z.object({ address: z.string() }),
+  ])
+);
+
+type RemovePermittedAuthMethodScopeByIdentifierRequest = z.infer<
+  typeof removePermittedAuthMethodScopeByIdentifierSchema
+>;
+
+/**
+ * Removes a specific scope from a permitted authentication method for a PKP token using various identifier types
+ * @param request - Object containing either tokenId/address/pubkey, authMethodType, authMethodId, and scopeId
+ * @param networkCtx - Network context for contract interactions
+ * @param accountOrWalletClient - Account or wallet client for signing
+ * @returns Promise resolving to transaction details
+ */
+export async function removePermittedAuthMethodScopeByIdentifier(
+  request: RemovePermittedAuthMethodScopeByIdentifierRequest,
+  networkCtx: DefaultNetworkConfig,
+  accountOrWalletClient: ExpectedAccountOrWalletClient
+): Promise<LitTxVoid> {
+  const { authMethodType, authMethodId, scopeId, ...identifier } = request;
+  const pkpTokenId = await resolvePkpTokenId(
+    identifier as PkpIdentifierRaw,
+    networkCtx
+  );
+
+  console.log('🔥 AUTH METHOD TYPE:', authMethodType);
+  console.log('🔥 AUTH METHOD ID:', authMethodId);
+  console.log('🔥 SCOPE ID:', scopeId);
+  console.log('🔥 PKP TOKEN ID:', pkpTokenId);
+
+  return removePermittedAuthMethodScope(
+    {
+      tokenId: pkpTokenId.toString(),
+      authMethodType: authMethodType.toString(),
+      id: authMethodId,
+      scopeId: scopeId.toString(),
+    },
+    networkCtx,
+    accountOrWalletClient
+  );
+}
+
+// Example usage
+// if (import.meta.main) {
+//   const networkCtx = networkContext;
+
+//   const res = await removePermittedAuthMethodScopeByIdentifier(
+//     {
+//       tokenId:
+//         "76136736151863037541847315168980811654782785653773679312890341037699996601290",
+//       authMethodType: 1, // AuthMethodType.EthWallet
+//       authMethodId: "0x1234567890abcdef1234567890abcdef12345678",
+//       scopeId: 1, // Scope.SignAnything
+//     },
+//     networkCtx,
+//     accountOrWalletClient
+//   );
+
+//   console.log("res", res);
+// } 

--- a/packages/networks/src/networks/vNaga/LitChainClient/apis/rawContractApis/permissions/write/addPermittedAddress.ts
+++ b/packages/networks/src/networks/vNaga/LitChainClient/apis/rawContractApis/permissions/write/addPermittedAddress.ts
@@ -40,8 +40,6 @@ export async function addPermittedAddress(
   const { pkpPermissionsContract, pkpNftContract, publicClient, walletClient } =
     createContractsManager(networkCtx, accountOrWalletClient);
 
-  pkpPermissionsContract.write.addPermittedAddress;
-
   const hash = await callWithAdjustedOverrides(
     pkpPermissionsContract,
     'addPermittedAddress',

--- a/packages/networks/src/networks/vNaga/LitChainClient/apis/rawContractApis/permissions/write/addPermittedAuthMethod.ts
+++ b/packages/networks/src/networks/vNaga/LitChainClient/apis/rawContractApis/permissions/write/addPermittedAuthMethod.ts
@@ -1,0 +1,100 @@
+/**
+ * addPermittedAuthMethod.ts
+ *
+ * Adds a permitted authentication method to a PKP token.
+ * This allows the authentication method to control the PKP.
+ */
+
+import { toBigInt } from '../../../../../../shared/utils/z-transformers';
+import { z } from 'zod';
+import { logger } from '../../../../../../shared/logger';
+import { DefaultNetworkConfig } from '../../../../../interfaces/NetworkContext';
+import {
+  createContractsManager,
+  ExpectedAccountOrWalletClient,
+} from '../../../../contract-manager/createContractsManager';
+import { ScopeSchemaRaw } from '../../../../schemas/shared/ScopeSchema';
+import { LitTxVoid } from '../../../types';
+import { callWithAdjustedOverrides } from '../../../utils/callWithAdjustedOverrides';
+import { decodeLogs } from '../../../utils/decodeLogs';
+
+const addPermittedAuthMethodSchema = z.object({
+  tokenId: toBigInt,
+  authMethodType: toBigInt,
+  id: z.string(), // bytes in the ABI, handled as string (hex format)
+  userPubkey: z.string(), // bytes in the ABI, handled as string (hex format)
+  scopes: z.array(ScopeSchemaRaw),
+});
+
+type AddPermittedAuthMethodRequest = z.input<typeof addPermittedAuthMethodSchema>;
+
+/**
+ * Adds a permitted authentication method to a PKP token
+ * @param request - Object containing tokenId, authMethodType, id, userPubkey, and scopes
+ * @param networkCtx - Network context for the transaction
+ * @param accountOrWalletClient - Account or wallet client for signing
+ * @returns Promise resolving to transaction details
+ */
+export async function addPermittedAuthMethod(
+  request: AddPermittedAuthMethodRequest,
+  networkCtx: DefaultNetworkConfig,
+  accountOrWalletClient: ExpectedAccountOrWalletClient
+): Promise<LitTxVoid> {
+  const validatedRequest = addPermittedAuthMethodSchema.parse(request);
+  logger.debug({ validatedRequest }, 'Adding permitted auth method');
+
+  console.log('🔐 ADD PERMITTED AUTH METHOD:', validatedRequest);
+
+  const { pkpPermissionsContract, publicClient } = createContractsManager(
+    networkCtx,
+    accountOrWalletClient
+  );
+
+  // Create the AuthMethod struct for the contract call
+  const authMethod = {
+    authMethodType: validatedRequest.authMethodType,
+    id: validatedRequest.id,
+    userPubkey: validatedRequest.userPubkey,
+  };
+
+  const hash = await callWithAdjustedOverrides(
+    pkpPermissionsContract,
+    'addPermittedAuthMethod',
+    [
+      validatedRequest.tokenId,
+      authMethod,
+      validatedRequest.scopes,
+    ]
+  );
+
+  const receipt = await publicClient.waitForTransactionReceipt({ hash });
+
+  const decodedLogs = await decodeLogs(
+    receipt.logs,
+    networkCtx,
+    accountOrWalletClient
+  );
+
+  return { hash, receipt, decodedLogs };
+}
+
+// Example usage when running as main
+// if (import.meta.main) {
+//   const networkCtx = await import('../../../../_config');
+//   const { networkContext } = networkCtx;
+
+//   const res = await addPermittedAuthMethod(
+//     {
+//       tokenId:
+//         '76136736151863037541847315168980811654782785653773679312890341037699996601290',
+//       authMethodType: 1, // AuthMethodType.EthWallet
+//       id: '0x1234567890abcdef1234567890abcdef12345678',
+//       userPubkey: '0x04abcdef...',
+//       scopes: ['sign-anything'],
+//     },
+//     networkContext,
+//     accountOrWalletClient
+//   );
+
+//   console.log('res', res);
+// }

--- a/packages/networks/src/networks/vNaga/LitChainClient/apis/rawContractApis/permissions/write/removePermittedAuthMethodScope.ts
+++ b/packages/networks/src/networks/vNaga/LitChainClient/apis/rawContractApis/permissions/write/removePermittedAuthMethodScope.ts
@@ -1,0 +1,93 @@
+/**
+ * removePermittedAuthMethodScope.ts
+ *
+ * Removes a specific scope from a permitted authentication method for a PKP token.
+ * This revokes the authentication method's ability to use a specific scope.
+ */
+
+import { z } from 'zod';
+import { logger } from '../../../../../../shared/logger';
+import { toBigInt } from '../../../../../../shared/utils/z-transformers';
+import { DefaultNetworkConfig } from '../../../../../interfaces/NetworkContext';
+import {
+  createContractsManager,
+  ExpectedAccountOrWalletClient,
+} from '../../../../contract-manager/createContractsManager';
+import { LitTxVoid } from '../../../types';
+import { callWithAdjustedOverrides } from '../../../utils/callWithAdjustedOverrides';
+import { decodeLogs } from '../../../utils/decodeLogs';
+
+const removePermittedAuthMethodScopeSchema = z.object({
+  tokenId: toBigInt,
+  authMethodType: toBigInt,
+  id: z.string(), // bytes in the ABI, handled as string (hex format)
+  scopeId: toBigInt,
+});
+
+type RemovePermittedAuthMethodScopeRequest = z.input<
+  typeof removePermittedAuthMethodScopeSchema
+>;
+
+/**
+ * Removes a specific scope from a permitted authentication method for a PKP token
+ * @param request - Object containing tokenId, authMethodType, id, and scopeId
+ * @param networkCtx - Network context for the transaction
+ * @param accountOrWalletClient - Account or wallet client for signing
+ * @returns Promise resolving to transaction details
+ */
+export async function removePermittedAuthMethodScope(
+  request: RemovePermittedAuthMethodScopeRequest,
+  networkCtx: DefaultNetworkConfig,
+  accountOrWalletClient: ExpectedAccountOrWalletClient
+): Promise<LitTxVoid> {
+  const validatedRequest = removePermittedAuthMethodScopeSchema.parse(request);
+  logger.debug({ validatedRequest }, 'Removing permitted auth method scope');
+
+  console.log('🔥 REMOVE PERMITTED AUTH METHOD SCOPE:', validatedRequest);
+
+  const { pkpPermissionsContract, publicClient } = createContractsManager(
+    networkCtx,
+    accountOrWalletClient
+  );
+
+  const hash = await callWithAdjustedOverrides(
+    pkpPermissionsContract,
+    'removePermittedAuthMethodScope',
+    [
+      validatedRequest.tokenId,
+      validatedRequest.authMethodType,
+      validatedRequest.id,
+      validatedRequest.scopeId,
+    ]
+  );
+
+  const receipt = await publicClient.waitForTransactionReceipt({ hash });
+
+  const decodedLogs = await decodeLogs(
+    receipt.logs,
+    networkCtx,
+    accountOrWalletClient
+  );
+
+  return { hash, receipt, decodedLogs };
+}
+
+// Example usage when running as main
+// if (import.meta.main) {
+//   const networkCtx = await import('../../../../_config');
+//   const { networkContext } = networkCtx;
+
+//   const res = await removePermittedAuthMethodScope(
+//     {
+//       tokenId:
+//         '76136736151863037541847315168980811654782785653773679312890341037699996601290',
+//       authMethodType: 1, // AuthMethodType.EthWallet
+//       id: '0x1234567890abcdef1234567890abcdef12345678',
+//       scopeId: 1, // Scope.SignAnything
+//     },
+//     networkContext,
+//     accountOrWalletClient
+//   );
+
+//   console.log('res', res);
+// }

--- a/packages/networks/src/networks/vNaga/LitChainClient/contract-manager/createContractsManager.ts
+++ b/packages/networks/src/networks/vNaga/LitChainClient/contract-manager/createContractsManager.ts
@@ -136,6 +136,7 @@ export const createContractsManager = <T, M>(
     abi: [
       contractData.PKPPermissions.methods.addPermittedAction,
       contractData.PKPPermissions.methods.addPermittedAddress,
+      contractData.PKPPermissions.methods.addPermittedAuthMethod,
       contractData.PKPPermissions.methods.addPermittedAuthMethodScope,
       contractData.PKPPermissions.methods.getPermittedActions,
       contractData.PKPPermissions.methods.getPermittedAddresses,
@@ -144,6 +145,7 @@ export const createContractsManager = <T, M>(
       contractData.PKPPermissions.methods.removePermittedAction,
       contractData.PKPPermissions.methods.removePermittedAddress,
       contractData.PKPPermissions.methods.removePermittedAuthMethod,
+      contractData.PKPPermissions.methods.removePermittedAuthMethodScope,
       contractData.PKPPermissions.methods.isPermittedAction,
       contractData.PKPPermissions.methods.isPermittedAddress,
       contractData.PKPPermissions.methods.getTokenIdsForAuthMethod,


### PR DESCRIPTION
# WHAT

- added `removePermittedAuthMethodScope` and `addPermittedAuthMethod`
- refactored logic init.ts to be more efficient to get or create a new PKP
- a demo script to showcase adding permitted address using an PKP EOA Auth Method