### PR TITLE
fix(getPermissionsContext): include accountOrWalletClient in tokenId …

### DIFF
--- a/packages/networks/src/networks/vNaga/LitChainClient/apis/highLevelApis/PKPPermissionsManager/handlers/getPermissionsContext.ts
+++ b/packages/networks/src/networks/vNaga/LitChainClient/apis/highLevelApis/PKPPermissionsManager/handlers/getPermissionsContext.ts
@@ -42,7 +42,7 @@ export async function getPermissionsContext(
   accountOrWalletClient: ExpectedAccountOrWalletClient
 ): Promise<PermissionsContext> {
   // Resolve the identifier to a tokenId
-  const tokenId = (await resolvePkpTokenId(identifier, networkCtx)).toString();
+  const tokenId = (await resolvePkpTokenId(identifier, networkCtx, accountOrWalletClient)).toString();
   logger.debug({ identifier, tokenId }, 'Loading permissions');
 
   // Fetch all permissions in parallel


### PR DESCRIPTION
 # WHAT

The viewPKPPermissions method throws `accountOrWalletClient is required but was not provided` when using an address as the PKP identifier, but works correctly with tokenId or pubkey identifiers.

In getPermissionsContext.ts, the call to resolvePkpTokenId() is missing the required third parameter accountOrWalletClient:

```ts
// Current (broken)
const tokenId = (await resolvePkpTokenId(identifier, networkCtx)).toString();

// Fixed
const tokenId = (await resolvePkpTokenId(identifier, networkCtx, accountOrWalletClient)).toString();
```