### PR TITLE
Feature/node 4611 fix error is not surfacing properly when error occurs on

### DIFF
--- a/packages/networks/src/networks/vNaga/envs/naga-staging/naga-staging.module.ts
+++ b/packages/networks/src/networks/vNaga/envs/naga-staging/naga-staging.module.ts
@@ -599,6 +599,15 @@ const networkModuleObject = {
         requestId: string,
         jitContext: NagaJitContext
       ) => {
+
+        if (!result.success) {
+          E2EERequestManager.handleEncryptedError(
+            result,
+            jitContext,
+            'PKP Sign'
+          );
+        }
+
         const decryptedValues = E2EERequestManager.decryptBatchResponse(
           result,
           jitContext,


### PR DESCRIPTION
# WHAT

This fix should surface the error properly when pkpSign fails on naga-staging