### PR TITLE
feat(networks): add fresh price feed fetcher to network modules

### DIFF
--- a/e2e/artillery/src/processors/multi-endpoints.ts
+++ b/e2e/artillery/src/processors/multi-endpoints.ts
@@ -1,5 +1,5 @@
 import { createAuthManager, storagePlugins } from "@lit-protocol/auth";
-import { createLitClient } from "@lit-protocol/lit-client";
+import { createLitClient, LitClientType } from "@lit-protocol/lit-client";
 import { z } from "zod";
 import * as StateManager from "../StateManager";
 import * as NetworkManager from "../../../src/helper/NetworkManager";
@@ -16,7 +16,7 @@ const PkpSignResultSchema = z.object({
 });
 
 // Global variables to cache expensive operations
-let litClient: any = null;
+let litClient: LitClientType;
 let authManager: any = null;
 let masterAccountAuthContext: any = null;
 let networkModule: any = null;
@@ -113,6 +113,7 @@ export async function runPkpSignTest() {
       authContext: authContext,
       pubKey: state.masterAccount.pkp.publicKey,
       toSign: `Hello from Artillery! ${Date.now()}`, // Unique message per request
+      // userMaxPrice: await litClient
     });
 
     // Validate the result using Zod schema

--- a/packages/lit-client/src/lib/LitClient/createLitClient.ts
+++ b/packages/lit-client/src/lib/LitClient/createLitClient.ts
@@ -715,6 +715,9 @@ export const _createNagaLitClient = async (
         handshakeResult: _stateManager.getCallbackResult(),
         getMaxPricesForNodeProduct: networkModule.getMaxPricesForNodeProduct,
         getUserMaxPrice: networkModule.getUserMaxPrice,
+        getFreshPriceFeedInfo: async () => {
+          return await networkModule.getFreshPriceFeedInfo();
+        },
         signSessionKey: _signSessionKey,
         signCustomSessionKey: _signCustomSessionKey,
         executeJs: _executeJs,

--- a/packages/networks/src/networks/vNaga/envs/naga-dev/naga-dev.module.ts
+++ b/packages/networks/src/networks/vNaga/envs/naga-dev/naga-dev.module.ts
@@ -80,6 +80,8 @@ import {
 } from './chain-manager/createChainManager';
 import { getMaxPricesForNodeProduct } from './pricing-manager/getMaxPricesForNodeProduct';
 import { getUserMaxPrice } from './pricing-manager/getUserMaxPrice';
+import { getPriceFeedInfo } from '../../LitChainClient/apis/highLevelApis/priceFeed/priceFeedApi';
+import { createReadOnlyContractsManager } from '../../LitChainClient/contract-manager/createContractsManager';
 
 const MODULE_NAME = 'naga-dev';
 
@@ -321,6 +323,19 @@ const networkModuleObject = {
       callback: params.callback,
       networkModule: params.networkModule as LitNetworkModuleBase,
     });
+  },
+
+  // Expose a fresh price feed fetcher (chain read; independent of state refresh)
+  getFreshPriceFeedInfo: async () => {
+    const { walletClient } = createReadOnlyContractsManager(networkConfig);
+    const realmId = Number(networkConfig.networkSpecificConfigs?.realmId ?? 1);
+    return await getPriceFeedInfo(
+      {
+        realmId,
+        networkCtx: networkConfig as any,
+      },
+      walletClient
+    );
   },
 
   getMaxPricesForNodeProduct: getMaxPricesForNodeProduct,

--- a/packages/networks/src/networks/vNaga/envs/naga-local/naga-local.module.ts
+++ b/packages/networks/src/networks/vNaga/envs/naga-local/naga-local.module.ts
@@ -80,6 +80,8 @@ import {
 } from './chain-manager/createChainManager';
 import { getMaxPricesForNodeProduct } from './pricing-manager/getMaxPricesForNodeProduct';
 import { getUserMaxPrice } from './pricing-manager/getUserMaxPrice';
+import { getPriceFeedInfo } from '../../LitChainClient/apis/highLevelApis/priceFeed/priceFeedApi';
+import { createReadOnlyContractsManager } from '../../LitChainClient/contract-manager/createContractsManager';
 
 const MODULE_NAME = 'naga-local';
 
@@ -321,6 +323,19 @@ const networkModuleObject = {
       callback: params.callback,
       networkModule: params.networkModule as LitNetworkModuleBase,
     });
+  },
+
+  // Expose a fresh price feed fetcher (chain read; independent of state refresh)
+  getFreshPriceFeedInfo: async () => {
+    const { walletClient } = createReadOnlyContractsManager(networkConfig);
+    const realmId = Number(networkConfig.networkSpecificConfigs?.realmId ?? 1);
+    return await getPriceFeedInfo(
+      {
+        realmId,
+        networkCtx: networkConfig as any,
+      },
+      walletClient
+    );
   },
 
   getMaxPricesForNodeProduct: getMaxPricesForNodeProduct,

--- a/packages/networks/src/networks/vNaga/envs/naga-staging/naga-staging.module.ts
+++ b/packages/networks/src/networks/vNaga/envs/naga-staging/naga-staging.module.ts
@@ -80,6 +80,8 @@ import {
 } from './chain-manager/createChainManager';
 import { getMaxPricesForNodeProduct } from './pricing-manager/getMaxPricesForNodeProduct';
 import { getUserMaxPrice } from './pricing-manager/getUserMaxPrice';
+import { getPriceFeedInfo } from '../../LitChainClient/apis/highLevelApis/priceFeed/priceFeedApi';
+import { createReadOnlyContractsManager } from '../../LitChainClient/contract-manager/createContractsManager';
 
 const MODULE_NAME = 'naga-staging';
 
@@ -321,6 +323,19 @@ const networkModuleObject = {
       callback: params.callback,
       networkModule: params.networkModule as LitNetworkModuleBase,
     });
+  },
+
+  // Expose a fresh price feed fetcher (chain read; independent of state refresh)
+  getFreshPriceFeedInfo: async () => {
+    const { walletClient } = createReadOnlyContractsManager(networkConfig);
+    const realmId = Number(networkConfig.networkSpecificConfigs?.realmId ?? 1);
+    return await getPriceFeedInfo(
+      {
+        realmId,
+        networkCtx: networkConfig as any,
+      },
+      walletClient
+    );
   },
 
   getMaxPricesForNodeProduct: getMaxPricesForNodeProduct,

--- a/packages/networks/src/networks/vNaga/envs/naga-test/naga-test.module.ts
+++ b/packages/networks/src/networks/vNaga/envs/naga-test/naga-test.module.ts
@@ -80,6 +80,8 @@ import {
 } from './chain-manager/createChainManager';
 import { getMaxPricesForNodeProduct } from './pricing-manager/getMaxPricesForNodeProduct';
 import { getUserMaxPrice } from './pricing-manager/getUserMaxPrice';
+import { getPriceFeedInfo } from '../../LitChainClient/apis/highLevelApis/priceFeed/priceFeedApi';
+import { createReadOnlyContractsManager } from '../../LitChainClient/contract-manager/createContractsManager';
 
 const MODULE_NAME = 'naga-test';
 
@@ -321,6 +323,19 @@ const networkModuleObject = {
       callback: params.callback,
       networkModule: params.networkModule as LitNetworkModuleBase,
     });
+  },
+
+  // Expose a fresh price feed fetcher (chain read; independent of state refresh)
+  getFreshPriceFeedInfo: async () => {
+    const { walletClient } = createReadOnlyContractsManager(networkConfig);
+    const realmId = Number(networkConfig.networkSpecificConfigs?.realmId ?? 1);
+    return await getPriceFeedInfo(
+      {
+        realmId,
+        networkCtx: networkConfig as any,
+      },
+      walletClient
+    );
   },
 
   getMaxPricesForNodeProduct: getMaxPricesForNodeProduct,


### PR DESCRIPTION
# WHAT

- Added `getFreshPriceFeedInfo()` to vNaga modules (`naga-staging`, `naga-dev`, `naga-test`, `naga-local`) to fetch the latest sorted node prices directly from the PriceFeed contract (RPC), without reinitialising state/handshake.
- Exposed the above via `litClient.getContext().getFreshPriceFeedInfo()` in `createLitClient.ts`.
- No behavioural change to existing calls: SDK still uses cached `latestConnectionInfo` by default; cheapest‑N selection remains unchanged. This new method enables callers (e.g. Artillery) to fetch fresh prices just before requests when needed.