### PR TITLE
Feature/jss 34 naga fix getting node prices for session sigs

### DIFF
--- a/packages/lit-client/src/lib/LitClient/createLitClient.ts
+++ b/packages/lit-client/src/lib/LitClient/createLitClient.ts
@@ -219,7 +219,7 @@ export const _createNagaLitClient = async (
       pricingContext: {
         product: 'SIGN',
         userMaxPrice: params.userMaxPrice,
-        nodePrices: currentConnectionInfo.priceFeedInfo.networkPrices,
+        nodePrices: jitContext.nodePrices,
         threshold: currentHandshakeResult.threshold,
       },
       authContext: params.authContext,
@@ -383,7 +383,7 @@ export const _createNagaLitClient = async (
       pricingContext: {
         product: 'LIT_ACTION',
         userMaxPrice: params.userMaxPrice,
-        nodePrices: currentConnectionInfo.priceFeedInfo.networkPrices,
+        nodePrices: jitContext.nodePrices,
         threshold: currentHandshakeResult.threshold,
       },
       authContext: params.authContext,
@@ -650,7 +650,7 @@ export const _createNagaLitClient = async (
       pricingContext: {
         product: 'DECRYPTION',
         userMaxPrice: params.userMaxPrice,
-        nodePrices: currentConnectionInfo.priceFeedInfo.networkPrices,
+        nodePrices: jitContext.nodePrices,
         threshold: currentHandshakeResult.threshold,
       },
       authContext: params.authContext,

--- a/packages/networks/src/networks/vNaga/LitChainClient/apis/highLevelApis/priceFeed/priceFeedApi.ts
+++ b/packages/networks/src/networks/vNaga/LitChainClient/apis/highLevelApis/priceFeed/priceFeedApi.ts
@@ -23,8 +23,9 @@
  * ```
  */
 
+import { NodePrices } from '@lit-protocol/types';
 import { ExpectedAccountOrWalletClient } from '../../../../LitChainClient/contract-manager/createContractsManager';
-import { DefaultNetworkConfig } from '../../../../interfaces/NetworkContext';
+import { INetworkConfig } from '../../../../interfaces/NetworkContext';
 import {
   getNodesForRequest,
   PRODUCT_IDS,
@@ -38,16 +39,13 @@ const PRODUCT_IDS_ARRAY = Object.values(PRODUCT_IDS);
 export interface PriceFeedInfo {
   epochId: any;
   minNodeCount: any;
-  networkPrices: {
-    url: string;
-    prices: bigint[];
-  }[];
+  networkPrices: NodePrices;
 }
 
-// Type for the parameters
+// Type for the parameters - now accepts any valid network config
 export interface GetPriceFeedInfoParams {
   realmId?: number;
-  networkCtx: DefaultNetworkConfig;
+  networkCtx: INetworkConfig<any, any>;
   productIds?: bigint[];
 }
 
@@ -191,7 +189,7 @@ export async function getPriceFeedInfo(
 export async function getNodePrices(
   params: GetPriceFeedInfoParams,
   accountOrWalletClient: ExpectedAccountOrWalletClient
-): Promise<PriceFeedInfo['networkPrices']> {
+): Promise<NodePrices> {
   const priceInfo = await getPriceFeedInfo(params, accountOrWalletClient);
   return priceInfo.networkPrices;
 }

--- a/packages/networks/src/networks/vNaga/LitChainClient/apis/highLevelApis/priceFeed/priceFeedApi.ts
+++ b/packages/networks/src/networks/vNaga/LitChainClient/apis/highLevelApis/priceFeed/priceFeedApi.ts
@@ -23,6 +23,10 @@
  * ```
  */
 
+const _logger = getChildLogger({
+  module: 'priceFeedApi',
+});
+
 import { NodePrices } from '@lit-protocol/types';
 import { ExpectedAccountOrWalletClient } from '../../../../LitChainClient/contract-manager/createContractsManager';
 import { INetworkConfig } from '../../../../interfaces/NetworkContext';
@@ -30,6 +34,7 @@ import {
   getNodesForRequest,
   PRODUCT_IDS,
 } from '../../../apis/rawContractApis/pricing/getNodesForRequest';
+import { getChildLogger } from '@lit-protocol/logger';
 
 // Configuration constants
 const STALE_PRICES_SECONDS = 3 * 1000; // Update prices if > X seconds old
@@ -152,6 +157,7 @@ export async function getPriceFeedInfo(
 ): Promise<PriceFeedInfo> {
   // If there's a local promise, an update is in progress; wait for that
   if (fetchingPriceFeedInfo) {
+    _logger.info('💲 Local promise is already fetching price feed info. Returning that instead.');
     return fetchingPriceFeedInfo;
   }
 
@@ -160,9 +166,13 @@ export async function getPriceFeedInfo(
     priceFeedInfo &&
     Date.now() - lastUpdatedTimestamp < STALE_PRICES_SECONDS
   ) {
+    _logger.info(
+      `💲 Returning stale price feed info. Remaining stale time: ${STALE_PRICES_SECONDS - (Date.now() - lastUpdatedTimestamp)
+      }ms`
+    );
     return priceFeedInfo;
   }
-
+  _logger.info('💲 Fetching new price feed info');
   // Fetch new prices, update local cache values, and return them
   return fetchPriceFeedInfoWithLocalPromise(params, accountOrWalletClient);
 }

--- a/packages/networks/src/networks/vNaga/LitChainClient/apis/rawContractApis/pricing/getNodesForRequest.ts
+++ b/packages/networks/src/networks/vNaga/LitChainClient/apis/rawContractApis/pricing/getNodesForRequest.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { generateValidatorURLs } from '../../../../../shared/utils/transformers';
-import { DefaultNetworkConfig } from '../../../../interfaces/NetworkContext';
+import { DefaultNetworkConfig, INetworkConfig } from '../../../../interfaces/NetworkContext';
 import {
   createContractsManager,
   ExpectedAccountOrWalletClient,
@@ -27,18 +27,15 @@ const getNodesForRequestSchema = z.object({
 type GetNodesForRequestRequest = z.infer<typeof getNodesForRequestSchema>;
 
 /**
- * Get nodes available for a request with their pricing information
- *
- * This function retrieves information about nodes that can service a request,
- * including their pricing data for various product IDs.
- *
+ * Gets nodes for a given set of product IDs with their prices
+ * 
  * @param request - Object containing product IDs to get pricing for
- * @param networkCtx - The Naga network context
+ * @param networkCtx - The network context (any valid network configuration)
  * @returns Information about nodes, their prices, epoch ID, and minimum node count
  */
 export async function getNodesForRequest(
   request: GetNodesForRequestRequest,
-  networkCtx: DefaultNetworkConfig,
+  networkCtx: INetworkConfig<any, any>,
   accountOrWalletClient: ExpectedAccountOrWalletClient
 ) {
   const { productIds } = getNodesForRequestSchema.parse(request);

--- a/packages/networks/src/networks/vNaga/envs/naga-local/naga-local.module.ts
+++ b/packages/networks/src/networks/vNaga/envs/naga-local/naga-local.module.ts
@@ -47,7 +47,7 @@ import type { PKPStorageProvider } from '../../../../storage/types';
 import { createRequestId } from '../../../shared/helpers/createRequestId';
 import { handleAuthServerRequest } from '../../../shared/helpers/handleAuthServerRequest';
 import { composeLitUrl } from '../../endpoints-manager/composeLitUrl';
-import { PKPPermissionsManager } from '../../LitChainClient/apis/highLevelApis';
+import { getNodePrices, PKPPermissionsManager } from '../../LitChainClient/apis/highLevelApis';
 import { PaymentManager } from '../../LitChainClient/apis/highLevelApis/PaymentManager/PaymentManager';
 import { MintWithMultiAuthsRequest } from '../../LitChainClient/apis/highLevelApis/mintPKP/mintWithMultiAuths';
 import { PkpIdentifierRaw } from '../../LitChainClient/apis/rawContractApis/permissions/utils/resolvePkpTokenId';
@@ -80,6 +80,7 @@ import {
 } from './chain-manager/createChainManager';
 import { getMaxPricesForNodeProduct } from './pricing-manager/getMaxPricesForNodeProduct';
 import { getUserMaxPrice } from './pricing-manager/getUserMaxPrice';
+import { privateKeyToAccount } from 'viem/accounts';
 
 const MODULE_NAME = 'naga-local';
 
@@ -482,6 +483,8 @@ const networkModuleObject = {
       connectionInfo: ConnectionInfo,
       handshakeResult: OrchestrateHandshakeResponse
     ): Promise<NagaJitContext> => {
+
+      // 1. Generate a key set for the JIT context
       const keySet: KeySet = {};
 
       for (const url of connectionInfo.bootstrapUrls) {
@@ -494,7 +497,19 @@ const networkModuleObject = {
           secretKey: nacl.box.keyPair().secretKey,
         };
       }
-      return { keySet };
+
+      // Use read-only account for viewing PKPs
+      const account = privateKeyToAccount(
+        '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+      );
+
+      // 2. Fetch the price feed info
+      const nodePrices = await getNodePrices({
+        realmId: 1,
+        networkCtx: networkConfig,
+      }, account);
+
+      return { keySet, nodePrices };
     },
     handshake: {
       schemas: {

--- a/packages/networks/src/networks/vNaga/envs/naga-staging/naga-staging.module.ts
+++ b/packages/networks/src/networks/vNaga/envs/naga-staging/naga-staging.module.ts
@@ -47,7 +47,7 @@ import type { PKPStorageProvider } from '../../../../storage/types';
 import { createRequestId } from '../../../shared/helpers/createRequestId';
 import { handleAuthServerRequest } from '../../../shared/helpers/handleAuthServerRequest';
 import { composeLitUrl } from '../../endpoints-manager/composeLitUrl';
-import { PKPPermissionsManager } from '../../LitChainClient/apis/highLevelApis';
+import { getNodePrices, PKPPermissionsManager } from '../../LitChainClient/apis/highLevelApis';
 import { PaymentManager } from '../../LitChainClient/apis/highLevelApis/PaymentManager/PaymentManager';
 import { MintWithMultiAuthsRequest } from '../../LitChainClient/apis/highLevelApis/mintPKP/mintWithMultiAuths';
 import { PkpIdentifierRaw } from '../../LitChainClient/apis/rawContractApis/permissions/utils/resolvePkpTokenId';
@@ -80,6 +80,7 @@ import {
 } from './chain-manager/createChainManager';
 import { getMaxPricesForNodeProduct } from './pricing-manager/getMaxPricesForNodeProduct';
 import { getUserMaxPrice } from './pricing-manager/getUserMaxPrice';
+import { privateKeyToAccount } from 'viem/accounts';
 
 const MODULE_NAME = 'naga-staging';
 
@@ -484,6 +485,7 @@ const networkModuleObject = {
     ): Promise<NagaJitContext> => {
       const keySet: KeySet = {};
 
+      // 1. Generate a key set for the JIT context
       for (const url of connectionInfo.bootstrapUrls) {
         keySet[url] = {
           publicKey: hexToBytes(
@@ -495,7 +497,18 @@ const networkModuleObject = {
         };
       }
 
-      return { keySet };
+      // Use read-only account for viewing PKPs
+      const account = privateKeyToAccount(
+        '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+      );
+
+      // 2. Fetch the price feed info
+      const nodePrices = await getNodePrices({
+        realmId: 1,
+        networkCtx: networkConfig,
+      }, account);
+
+      return { keySet, nodePrices };
     },
     handshake: {
       schemas: {

--- a/packages/networks/src/networks/vNaga/envs/naga-test/naga-test.module.ts
+++ b/packages/networks/src/networks/vNaga/envs/naga-test/naga-test.module.ts
@@ -508,7 +508,7 @@ const networkModuleObject = {
         networkCtx: networkConfig,
       }, account);
 
-      return { keySet, nodePrices: [] };
+      return { keySet, nodePrices };
     },
     handshake: {
       schemas: {

--- a/packages/networks/src/networks/vNaga/envs/naga-test/naga-test.module.ts
+++ b/packages/networks/src/networks/vNaga/envs/naga-test/naga-test.module.ts
@@ -47,7 +47,7 @@ import type { PKPStorageProvider } from '../../../../storage/types';
 import { createRequestId } from '../../../shared/helpers/createRequestId';
 import { handleAuthServerRequest } from '../../../shared/helpers/handleAuthServerRequest';
 import { composeLitUrl } from '../../endpoints-manager/composeLitUrl';
-import { PKPPermissionsManager } from '../../LitChainClient/apis/highLevelApis';
+import { getNodePrices, PKPPermissionsManager } from '../../LitChainClient/apis/highLevelApis';
 import { PaymentManager } from '../../LitChainClient/apis/highLevelApis/PaymentManager/PaymentManager';
 import { MintWithMultiAuthsRequest } from '../../LitChainClient/apis/highLevelApis/mintPKP/mintWithMultiAuths';
 import { PkpIdentifierRaw } from '../../LitChainClient/apis/rawContractApis/permissions/utils/resolvePkpTokenId';
@@ -80,6 +80,7 @@ import {
 } from './chain-manager/createChainManager';
 import { getMaxPricesForNodeProduct } from './pricing-manager/getMaxPricesForNodeProduct';
 import { getUserMaxPrice } from './pricing-manager/getUserMaxPrice';
+import { privateKeyToAccount } from 'viem/accounts';
 
 const MODULE_NAME = 'naga-test';
 
@@ -484,6 +485,7 @@ const networkModuleObject = {
     ): Promise<NagaJitContext> => {
       const keySet: KeySet = {};
 
+      // 1. Generate a key set for the JIT context
       for (const url of connectionInfo.bootstrapUrls) {
         keySet[url] = {
           publicKey: hexToBytes(
@@ -495,7 +497,18 @@ const networkModuleObject = {
         };
       }
 
-      return { keySet };
+      // Use read-only account for viewing PKPs
+      const account = privateKeyToAccount(
+        '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80'
+      );
+
+      // 2. Fetch the price feed info
+      const nodePrices = await getNodePrices({
+        realmId: 1,
+        networkCtx: networkConfig,
+      }, account);
+
+      return { keySet, nodePrices: [] };
     },
     handshake: {
       schemas: {

--- a/packages/networks/src/networks/vNaga/interfaces/NetworkContext.ts
+++ b/packages/networks/src/networks/vNaga/interfaces/NetworkContext.ts
@@ -22,6 +22,7 @@ export interface INetworkConfig<T, M> {
   };
 }
 
+// TODO: we should use a stablised network config as the default network config
 export type DefaultNetworkConfig = INetworkConfig<
   typeof localDevSignatures,
   any

--- a/packages/types/src/lib/v2types.ts
+++ b/packages/types/src/lib/v2types.ts
@@ -118,6 +118,13 @@ export type KeySet = Record<
   { publicKey: Uint8Array; secretKey: Uint8Array }
 >;
 
+// aka. Network Prices
+export type NodePrices = {
+  url: string;
+  prices: bigint[];
+}[];
+
 export type NagaJitContext = {
   keySet: KeySet;
+  nodePrices: NodePrices;
 };


### PR DESCRIPTION
# WHAT

re: we need to call a method to get the current node prices so that we can use those prices on the sessionSigs

There are two `getMaxPricesForNodeProduct`  functions, one is [async](https://github.com/LIT-Protocol/js-sdk/blob/15091e7926352bb2fdc5774def44d0b8718602f6/packages/lit-node-client-nodejs/src/lib/lit-node-client-nodejs.ts#L1549-L1582) and [another one](https://github.com/LIT-Protocol/js-sdk/blob/15091e7926352bb2fdc5774def44d0b8718602f6/packages/lit-node-client-nodejs/src/lib/helpers/get-max-prices-for-node-product.ts#L22-L76) isn’t.

The issue is that the current implementation in the V8 SDK only uses the helper function without the "intelligent" logic, and the nodePrices is coming from the  [currentConnectionInfo](https://github.com/LIT-Protocol/js-sdk/blob/54b0bdc14ce9c976f0c8930690534628ce193376/packages/lit-client/src/lib/LitClient/createLitClient.ts#L222), the fix here is to replace that line of code to `getNodePrices` which will internally manage the fetching and caching etc.

# Behaviour Tests

Manual log inspection was completed to verify the expected caching behaviour.

## Test 1 - Make two concurrent calls to trigger "Local promise is already fetching"

```ts
const [res1, res2] = await Promise.all([
  ctx.litClient.chain.ethereum.pkpSign({
    authContext: ctx.aliceEoaAuthContext,
    pubKey: ctx.aliceViemAccountPkp.publicKey,
    toSign: 'Hello, concurrent 1!',
  }),
  ctx.litClient.chain.ethereum.pkpSign({
    authContext: ctx.aliceEoaAuthContext,
    pubKey: ctx.aliceViemAccountPkp.publicKey,
    toSign: 'Hello, concurrent 2!',
  }),
]);
```
<img width="788" height="156" alt="image" src="https://github.com/user-attachments/assets/26128ee6-1553-45e1-86e0-900058330544" />

## Test 2 - Testing stale cache by first execute within the cache window (3 seconds) and one beyond cache window of 3 seconds

```ts
// Wait 1 second (within cache window)
await new Promise(resolve => setTimeout(resolve, 1000));

const res3 = await ctx.litClient.chain.ethereum.pkpSign({
  authContext: ctx.aliceEoaAuthContext,
  pubKey: ctx.aliceViemAccountPkp.publicKey,
  toSign: 'Hello, stale cache!',
});

console.log("=== Testing cache expiry (should fetch new) ===");

// Wait 4 seconds (beyond cache window of 3 seconds)
await new Promise(resolve => setTimeout(resolve, 4000));

const res4 = await ctx.litClient.chain.ethereum.pkpSign({
  authContext: ctx.aliceEoaAuthContext,
  pubKey: ctx.aliceViemAccountPkp.publicKey,
  toSign: 'Hello, expired cache!',
});
```

<img width="705" height="78" alt="image" src="https://github.com/user-attachments/assets/53ab8356-b465-4855-b651-d45e2fc059da" />
<img width="669" height="79" alt="image" src="https://github.com/user-attachments/assets/455e8ee8-c630-441f-a89a-16c0accccd5d" />


