### PR TITLE
Feature/jss 77 bug complete custom auth e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ lit-auth-local
 artillery-state.json
 artillery-pkp-tokens
 lit-auth-artillery
+alice-auth-manager-data

--- a/e2e/src/e2e.spec.ts
+++ b/e2e/src/e2e.spec.ts
@@ -25,7 +25,7 @@ describe('all', () => {
 
   // Auth contexts for testing
   let alicePkpAuthContext: any;
-  let aliceCustomAuthContext: any;
+  let eveCustomAuthContext: any;
 
   beforeAll(async () => {
     try {
@@ -33,7 +33,7 @@ describe('all', () => {
 
       // Create PKP and custom auth contexts using helper functions
       // alicePkpAuthContext = await createPkpAuthContext(ctx);
-      aliceCustomAuthContext = await createCustomAuthContext(ctx);
+      eveCustomAuthContext = await createCustomAuthContext(ctx);
     } catch (e) {
       console.error(e);
       process.exit(1);
@@ -124,34 +124,36 @@ describe('all', () => {
 
       describe('endpoints', () => {
         it('pkpSign', () =>
-          createPkpSignTest(ctx, () => aliceCustomAuthContext)());
+          createPkpSignTest(ctx, () => eveCustomAuthContext, ctx.eveViemAccountPkp.pubkey)());
         it('executeJs', () =>
-          createExecuteJsTest(ctx, () => aliceCustomAuthContext)());
+          createExecuteJsTest(ctx, () => eveCustomAuthContext, ctx.eveViemAccountPkp.pubkey)());
         it('viewPKPsByAddress', () =>
-          createViewPKPsByAddressTest(ctx, () => aliceCustomAuthContext)());
+          createViewPKPsByAddressTest(ctx, () => eveCustomAuthContext, ctx.eveViemAccountPkp.pubkey)());
         it('viewPKPsByAuthData', () =>
-          createViewPKPsByAuthDataTest(ctx, () => aliceCustomAuthContext)());
+          createViewPKPsByAuthDataTest(ctx, () => eveCustomAuthContext, ctx.eveCustomAuthData)());
         it('pkpEncryptDecrypt', () =>
-          createPkpEncryptDecryptTest(ctx, () => aliceCustomAuthContext)());
+          createPkpEncryptDecryptTest(ctx, () => eveCustomAuthContext, ctx.eveViemAccountPkp.ethAddress)());
         it('encryptDecryptFlow', () =>
-          createEncryptDecryptFlowTest(ctx, () => aliceCustomAuthContext)());
-        it('pkpPermissionsManagerFlow', () =>
-          createPkpPermissionsManagerFlowTest(
-            ctx,
-            () => aliceCustomAuthContext
-          )());
+          createEncryptDecryptFlowTest(ctx, () => eveCustomAuthContext, ctx.eveViemAccountPkp.pubkey)());
+
+        // Disable for now because it requires a different flow
+        // it('pkpPermissionsManagerFlow', () =>
+        //   createPkpPermissionsManagerFlowTest(
+        //     ctx,
+        //     () => eveCustomAuthContext, ctx.eveViemAccountPkp.pubkey
+        //   )());
       });
 
-      describe('integrations', () => {
-        describe('pkp viem account', () => {
-          it('sign message', () =>
-            createViemSignMessageTest(ctx, () => aliceCustomAuthContext)());
-          it('sign transaction', () =>
-            createViemSignTransactionTest(ctx, () => aliceCustomAuthContext)());
-          it('sign typed data', () =>
-            createViemSignTypedDataTest(ctx, () => aliceCustomAuthContext)());
-        });
-      });
+      // describe('integrations', () => {
+      //   describe('pkp viem account', () => {
+      //     it('sign message', () =>
+      //       createViemSignMessageTest(ctx, () => eveCustomAuthContext, ctx.eveViemAccountPkp.pubkey)());
+      //     it('sign transaction', () =>
+      //       createViemSignTransactionTest(ctx, () => eveCustomAuthContext, ctx.eveViemAccountPkp.pubkey)());
+      //     it('sign typed data', () =>
+      //       createViemSignTypedDataTest(ctx, () => eveCustomAuthContext, ctx.eveViemAccountPkp.pubkey)());
+      //   });
+      // });
     });
 
     describe('EOA Native', () => {

--- a/e2e/src/helper/auth-contexts.ts
+++ b/e2e/src/helper/auth-contexts.ts
@@ -39,18 +39,12 @@ export const createCustomAuthContext = async (
   ctx: Awaited<ReturnType<typeof init>>
 ) => {
   console.log('🔁 Creating Custom Auth Context');
+
   try {
     // Set up custom auth method type and validation IPFS CID (from custom-auth-flow example)
-    const uniqueDappName = 'e2e-test-dapp';
-    const uniqueAuthMethodType = hexToBigInt(
-      keccak256(toBytes(uniqueDappName))
-    );
-    const uniqueUserId = `${uniqueDappName}-alice`;
-    const authMethodId = keccak256(toBytes(uniqueUserId));
-    const validationIpfsCid = 'QmYLeVmwJPVs7Uebk85YdVPivMyrvoeKR6X37kyVRZUXW4';
 
     const customAuthContext = await ctx.authManager.createCustomAuthContext({
-      pkpPublicKey: ctx.aliceViemAccountPkp.publicKey,
+      pkpPublicKey: ctx.eveViemAccountPkp.pubkey,
       authConfig: {
         resources: [
           ['pkp-signing', '*'],
@@ -61,17 +55,17 @@ export const createCustomAuthContext = async (
       },
       litClient: ctx.litClient,
       customAuthParams: {
-        litActionIpfsId: validationIpfsCid,
+        litActionIpfsId: ctx.eveValidationIpfsCid,
         jsParams: {
-          pkpPublicKey: ctx.aliceViemAccountPkp.publicKey,
-          username: 'alice',
+          pkpPublicKey: ctx.eveViemAccountPkp.pubkey,
+          username: 'eve',
           password: 'lit',
-          authMethodId: authMethodId,
+          authMethodId: ctx.eveCustomAuthData.authMethodId,
         },
       },
     });
 
-    console.log('✅ Custom Auth Context created');
+    console.log('✅ Custom Auth Context created', customAuthContext);
     return customAuthContext;
   } catch (e) {
     console.error('❌ Error creating Custom Auth Context', e);

--- a/e2e/src/helper/tests/encrypt-decrypt-flow.ts
+++ b/e2e/src/helper/tests/encrypt-decrypt-flow.ts
@@ -3,7 +3,8 @@ import { assert } from '../assertions';
 
 export const createEncryptDecryptFlowTest = (
   ctx: Awaited<ReturnType<typeof init>>,
-  getAuthContext: () => any
+  getAuthContext: () => any,
+  address?: string
 ) => {
   return async () => {
     const { createAccBuilder } = await import(
@@ -17,7 +18,7 @@ export const createEncryptDecryptFlowTest = (
     if (authContext === ctx.aliceEoaAuthContext) {
       aliceAddress = ctx.aliceViemAccount.address;
     } else {
-      aliceAddress = ctx.aliceViemAccountPkp.ethAddress;
+      aliceAddress = address || ctx.aliceViemAccountPkp.ethAddress;
     }
 
     // Set up access control conditions requiring Bob's wallet ownership

--- a/e2e/src/helper/tests/execute-js.ts
+++ b/e2e/src/helper/tests/execute-js.ts
@@ -3,7 +3,8 @@ import { assert } from '../assertions';
 
 export const createExecuteJsTest = (
   ctx: Awaited<ReturnType<typeof init>>,
-  getAuthContext: () => any
+  getAuthContext: () => any,
+  pubkey?: string
 ) => {
   return async () => {
     const litActionCode = `
@@ -29,7 +30,7 @@ export const createExecuteJsTest = (
         message: 'Test message from e2e executeJs',
         sigName: 'e2e-test-sig',
         toSign: 'Test message from e2e executeJs',
-        publicKey: ctx.aliceViemAccountPkp.publicKey,
+        publicKey: pubkey || ctx.aliceViemAccountPkp.publicKey,
       },
     });
 

--- a/e2e/src/helper/tests/pkp-encrypt-decrypt.ts
+++ b/e2e/src/helper/tests/pkp-encrypt-decrypt.ts
@@ -3,7 +3,8 @@ import { assert } from '../assertions';
 
 export const createPkpEncryptDecryptTest = (
   ctx: Awaited<ReturnType<typeof init>>,
-  getAuthContext: () => any
+  getAuthContext: () => any,
+  address?: string
 ) => {
   return async () => {
     const { createAccBuilder } = await import(
@@ -19,7 +20,7 @@ export const createPkpEncryptDecryptTest = (
       addressToUse = ctx.aliceViemAccount.address;
     } else {
       // PKP or Custom auth contexts
-      addressToUse = ctx.aliceViemAccountPkp.ethAddress;
+      addressToUse = address || ctx.aliceViemAccountPkp.ethAddress;
     }
 
     // Set up access control conditions requiring wallet ownership

--- a/e2e/src/helper/tests/pkp-sign.ts
+++ b/e2e/src/helper/tests/pkp-sign.ts
@@ -3,12 +3,13 @@ import { assert } from '../assertions';
 
 export const createPkpSignTest = (
   ctx: Awaited<ReturnType<typeof init>>,
-  getAuthContext: () => any
+  getAuthContext: () => any,
+  pubkey?: string
 ) => {
   return async () => {
     const res = await ctx.litClient.chain.ethereum.pkpSign({
       authContext: getAuthContext(),
-      pubKey: ctx.aliceViemAccountPkp.publicKey,
+      pubKey: pubkey || ctx.aliceViemAccountPkp.publicKey,
       toSign: 'Hello, world!',
     });
 

--- a/e2e/src/helper/tests/view-pkps-by-address.ts
+++ b/e2e/src/helper/tests/view-pkps-by-address.ts
@@ -3,7 +3,8 @@ import { assert } from '../assertions';
 
 export const createViewPKPsByAddressTest = (
   ctx: Awaited<ReturnType<typeof init>>,
-  getAuthContext: () => any
+  getAuthContext: () => any,
+  pubkey?: string
 ) => {
   return async () => {
     const pkps = await ctx.litClient.viewPKPsByAddress({

--- a/e2e/src/helper/tests/view-pkps-by-auth-data.ts
+++ b/e2e/src/helper/tests/view-pkps-by-auth-data.ts
@@ -3,18 +3,19 @@ import { assert } from '../assertions';
 
 export const createViewPKPsByAuthDataTest = (
   ctx: Awaited<ReturnType<typeof init>>,
-  getAuthContext: () => any
+  getAuthContext: () => any,
+  authData?: any,
 ) => {
   return async () => {
     const { ViemAccountAuthenticator } = await import('@lit-protocol/auth');
-    const authData = await ViemAccountAuthenticator.authenticate(
+    const _authData = authData ||  await ViemAccountAuthenticator.authenticate(
       ctx.aliceViemAccount
     );
 
     const pkps = await ctx.litClient.viewPKPsByAuthData({
       authData: {
-        authMethodType: authData.authMethodType,
-        authMethodId: authData.authMethodId,
+        authMethodType: _authData.authMethodType,
+        authMethodId: _authData.authMethodId,
       },
       pagination: {
         limit: 10,

--- a/e2e/src/init.ts
+++ b/e2e/src/init.ts
@@ -3,12 +3,12 @@ import {
   storagePlugins,
   ViemAccountAuthenticator,
 } from '@lit-protocol/auth';
-import { createLitClient } from '@lit-protocol/lit-client';
-import { Account, PrivateKeyAccount } from 'viem';
+import { createLitClient, utils as litUtils } from '@lit-protocol/lit-client';
 import { generatePrivateKey, privateKeyToAccount } from 'viem/accounts';
 import { z } from 'zod';
 import { fundAccount } from './helper/fundAccount';
 import { getOrCreatePkp } from './helper/pkp-utils';
+
 // import { createPkpAuthContext } from './helper/auth-contexts';
 
 const SupportedNetworkSchema = z.enum([
@@ -17,6 +17,7 @@ const SupportedNetworkSchema = z.enum([
   'naga-local',
   'naga-staging',
 ]);
+
 type SupportedNetwork = z.infer<typeof SupportedNetworkSchema>;
 
 const LogLevelSchema = z.enum(['silent', 'info', 'debug']);
@@ -26,6 +27,9 @@ type LogLevel = z.infer<typeof LogLevelSchema>;
 const LIVE_NETWORK_FUNDING_AMOUNT = '0.01';
 const LOCAL_NETWORK_FUNDING_AMOUNT = '1';
 const LIVE_NETWORK_LEDGER_DEPOSIT_AMOUNT = '2';
+
+const EVE_VALIDATION_IPFS_CID =
+  'QmcxWmo3jefFsPUnskJXYBwsJYtiFuMAH1nDQEs99AwzDe';
 
 export const init = async (
   network?: SupportedNetwork,
@@ -42,6 +46,10 @@ export const init = async (
   bobViemAccountPkp: any;
   aliceEoaAuthContext: any;
   alicePkpAuthContext: any;
+  eveViemAccount: any;
+  eveCustomAuthData: Awaited<ReturnType<typeof litUtils.generateAuthData>>;
+  eveViemAccountPkp: Awaited<ReturnType<typeof litClient.mintWithCustomAuth>>['pkpData']['data'];
+  eveValidationIpfsCid: string;
   masterDepositForUser: (userAddress: string) => Promise<void>;
   // alicePkpViemAccountPermissionsManager: any,
 }> => {
@@ -65,6 +73,8 @@ export const init = async (
   const bobViemAccountAuthData = await ViemAccountAuthenticator.authenticate(
     bobViemAccount
   );
+
+  const eveViemAccount = privateKeyToAccount(generatePrivateKey());
 
   /**
    * ====================================
@@ -129,6 +139,11 @@ export const init = async (
     thenFundWith: fundingAmount,
   });
 
+  await fundAccount(eveViemAccount, masterAccount, _networkModule, {
+    ifLessThan: fundingAmount,
+    thenFundWith: fundingAmount,
+  });
+
   /**
    * ====================================
    * Initialise the LitClient
@@ -184,6 +199,27 @@ export const init = async (
       _network
     ),
   ]);
+  // Use custom auth to create a PKP for Eve
+  const uniqueDappName = 'e2e-test-dapp';
+
+  const authMethodConfig = litUtils.generateUniqueAuthMethodType({
+    uniqueDappName: uniqueDappName,
+  });
+
+  const eveCustomAuthData = litUtils.generateAuthData({
+    uniqueDappName: uniqueDappName,
+    uniqueAuthMethodType: authMethodConfig.bigint,
+    userId: 'eve',
+  });
+
+  const { pkpData } = await litClient.mintWithCustomAuth({
+    account: eveViemAccount,
+    authData: eveCustomAuthData,
+    scope: 'sign-anything',
+    validationIpfsCid: EVE_VALIDATION_IPFS_CID,
+  });
+
+  const eveViemAccountPkp = pkpData.data;
 
   /**
    * ====================================
@@ -270,6 +306,12 @@ export const init = async (
   // Deposit to the Bob PKP Ledger
   await masterDepositForUser(bobViemAccountPkp.ethAddress);
 
+  // Deposit to the Eve EOA Ledger
+  await masterDepositForUser(eveViemAccount.address);
+
+  // Deposit to the Eve PKP Ledger
+  await masterDepositForUser(eveViemAccountPkp.ethAddress);
+
   // const alicePkpViemAccountPermissionsManager = await litClient.getPKPPermissionsManager({
   //   pkpIdentifier: {
   //     tokenId: aliceViemAccountPkp.tokenId,
@@ -292,6 +334,10 @@ export const init = async (
     bobViemAccount,
     bobViemAccountAuthData,
     bobViemAccountPkp,
+    eveViemAccount,
+    eveCustomAuthData,
+    eveViemAccountPkp,
+    eveValidationIpfsCid: EVE_VALIDATION_IPFS_CID,
     aliceEoaAuthContext,
     alicePkpAuthContext,
     masterDepositForUser,

--- a/e2e/src/tickets/custom-auth.spec.ts
+++ b/e2e/src/tickets/custom-auth.spec.ts
@@ -1,0 +1,172 @@
+import { createAuthManager, storagePlugins } from '@lit-protocol/auth';
+import { createLitClient, utils as litUtils } from '@lit-protocol/lit-client';
+import { nagaDev } from '@lit-protocol/networks';
+import { privateKeyToAccount } from 'viem/accounts';
+
+// CONFIGURATION
+const NETWORK = 'naga-dev';
+const SITE_OWNER_ACCOUNT = privateKeyToAccount(
+  process.env['LIVE_MASTER_ACCOUNT'] as `0x${string}`
+);
+
+const YOU_UNIQUE_DAPP_NAME = 'amazing-app-x35ju8';
+
+class MockDatabase {
+  users: Record<string, { pkpPublicKey: string }> = {
+    alice: {
+      pkpPublicKey: '',
+    },
+    bob: {
+      pkpPublicKey: '',
+    },
+  };
+}
+
+describe('Custom Auth Frontend Logic', () => {
+  test('should be able to create custom auth for alice', async () => {
+    // =========================================================
+    //                      SITE OWNER FLOW
+    // =========================================================
+    // Step 1: Configure dApp and Generate Auth Method Type
+    const authMethodConfig = litUtils.generateUniqueAuthMethodType({
+      uniqueDappName: YOU_UNIQUE_DAPP_NAME,
+    });
+
+    console.log('authMethodConfig:', authMethodConfig);
+
+    // Step 2: Create and Pin Validation Lit Action
+    // This is done manually in the browser at https://explorer.litprotocol.com/create-action
+    // This is the code used
+    // ============================================================
+    // (async () => {
+    //   const dAppUniqueAuthMethodType = "0x20b2c2163698c4ba8166450ff2378d96c009016deba048b9b125a696c74ea4b5";
+    //   const { pkpPublicKey, username, password, authMethodId } = jsParams;
+
+    //   // Custom validation logic for amazing-app-x35ju8
+    //   const EXPECTED_USERNAME = 'alice';
+    //   const EXPECTED_PASSWORD = 'lit';
+    //   const userIsValid = username === EXPECTED_USERNAME && password === EXPECTED_PASSWORD;
+
+    //   // Check PKP permissions
+    //   const tokenId = await Lit.Actions.pubkeyToTokenId({ publicKey: pkpPublicKey });
+    //   const permittedAuthMethods = await Lit.Actions.getPermittedAuthMethods({ tokenId });
+
+    //   const isPermitted = permittedAuthMethods.some((permittedAuthMethod) => {
+    //     return permittedAuthMethod["auth_method_type"] === dAppUniqueAuthMethodType &&
+    //           permittedAuthMethod["id"] === authMethodId;
+    //   });
+
+    //   const isValid = isPermitted && userIsValid;
+    //   LitActions.setResponse({ response: isValid ? "true" : "false" });
+    // })();
+    // ============================================================
+    const validationIpfsCid = 'QmP3ZoTSGQ2P9cAZ4pBUjmPC34xbJZFRoWnCXT2SdHA2uD';
+
+    // Step 3: Mint PKPs for Users - Mint PKPs for your users using the custom auth method  
+    // type and validation CID.
+    // Each user gets their own unique PKP tied to your dApp's authentication system.
+    const litClient = await createLitClient({ network: nagaDev });
+    const mockDatabase = new MockDatabase();
+
+    for (const userId of [
+      'alice',
+      // , 'bob'
+    ]) {
+      console.log(`🔄 Minting a PKP for ${userId}...`);
+
+      const authData = litUtils.generateAuthData({
+        uniqueDappName: YOU_UNIQUE_DAPP_NAME,
+        uniqueAuthMethodType: authMethodConfig.bigint,
+        userId: userId,
+      });
+
+      const { pkpData } = await litClient.mintWithCustomAuth({
+        account: SITE_OWNER_ACCOUNT,
+        authData: authData,
+        scope: 'sign-anything',
+        validationIpfsCid: validationIpfsCid,
+      });
+
+      // Store PKP info for user
+      mockDatabase.users[userId].pkpPublicKey = pkpData.data.pubkey;
+    }
+
+    console.log('mockDatabase:', mockDatabase);
+
+    // =========================================================
+    //                      USER FLOW
+    // =========================================================
+
+    // -- perpare the auth manager client
+    const authManager = createAuthManager({
+      storage: storagePlugins.localStorageNode({
+        storagePath: 'alice-auth-manager-data',
+        appName: YOU_UNIQUE_DAPP_NAME,
+        networkName: NETWORK,
+      }),
+    });
+
+    // 1. Pretend that alice and bob are users of the dApp
+    // Alice login to the dApp, and the dApp will display the PKPs that they have
+    const alicePkpPublicKey = mockDatabase.users['alice'].pkpPublicKey;
+
+    const aliceAuthMethodConfig = litUtils.generateUniqueAuthMethodType({
+      uniqueDappName: YOU_UNIQUE_DAPP_NAME,
+    });
+
+    // 2. a util will prepare the following data for alice
+    const aliceAuthData = litUtils.generateAuthData({
+      uniqueDappName: YOU_UNIQUE_DAPP_NAME,
+      uniqueAuthMethodType: aliceAuthMethodConfig.bigint,
+      userId: 'alice',
+    });
+
+    // 3. Alice will pass some params to proof that she is the owner of the PKP
+    // Create custom auth context for user
+    const aliceAuthContext = await authManager.createCustomAuthContext({
+      pkpPublicKey: alicePkpPublicKey,
+      authConfig: {
+        resources: [
+          ['pkp-signing', '*'],
+          ['lit-action-execution', '*'],
+          ['access-control-condition-decryption', '*'],
+        ],
+        expiration: new Date(Date.now() + 1000 * 60 * 15).toISOString(),
+      },
+      litClient: litClient,
+      customAuthParams: {
+        litActionIpfsId: validationIpfsCid,
+        jsParams: {
+          pkpPublicKey: alicePkpPublicKey,
+          username: 'alice',
+          password: 'lit',
+          authMethodId: aliceAuthData.authMethodId,
+        },
+      },
+    });
+
+    console.log('aliceAuthContext:', aliceAuthContext);
+
+    // 4. Auth context consumption - user can pass in the auth context into different Lit public APIs, such
+    // as pkpSign, executeJs, decrypt, etc.
+
+    // The message string will be UTF-8 encoded before signing.
+    // Hashing (e.g., Keccak256 for Ethereum, SHA256 for Bitcoin)
+    // is handled automatically by the Lit Protocol based on the selected chain.
+    const messageBytes = new TextEncoder().encode('Hello from Artillery!');
+
+    const signatures = await litClient.chain.raw.pkpSign({
+      chain: 'ethereum',
+      signingScheme: 'EcdsaK256Sha256', // From dropdown
+      pubKey: alicePkpPublicKey,
+      authContext: aliceAuthContext,
+      toSign: messageBytes, // UTF-8 encoded message
+
+      // 💰 Optional: Set custom maximum price you're willing to pay
+      // userMaxPrice: BigInt("1000000000000000"), // 0.001 ETH in Wei
+      // If not specified, Lit Protocol will automatically find the most optimised price
+    });
+
+    console.log('signatures:', signatures);
+  });
+});

--- a/e2e/src/tickets/custom-auth.spec.ts
+++ b/e2e/src/tickets/custom-auth.spec.ts
@@ -62,7 +62,7 @@ describe('Custom Auth Frontend Logic', () => {
     // ============================================================
     const validationIpfsCid = 'QmP3ZoTSGQ2P9cAZ4pBUjmPC34xbJZFRoWnCXT2SdHA2uD';
 
-    // Step 3: Mint PKPs for Users - Mint PKPs for your users using the custom auth method  
+    // Step 3: Mint PKPs for Users - Mint PKPs for your users using the custom auth method
     // type and validation CID.
     // Each user gets their own unique PKP tied to your dApp's authentication system.
     const litClient = await createLitClient({ network: nagaDev });
@@ -157,16 +157,14 @@ describe('Custom Auth Frontend Logic', () => {
 
     const signatures = await litClient.chain.raw.pkpSign({
       chain: 'ethereum',
-      signingScheme: 'EcdsaK256Sha256', // From dropdown
+      signingScheme: 'EcdsaK256Sha256',
       pubKey: alicePkpPublicKey,
       authContext: aliceAuthContext,
-      toSign: messageBytes, // UTF-8 encoded message
-
-      // 💰 Optional: Set custom maximum price you're willing to pay
-      // userMaxPrice: BigInt("1000000000000000"), // 0.001 ETH in Wei
-      // If not specified, Lit Protocol will automatically find the most optimised price
+      toSign: messageBytes,
     });
 
     console.log('signatures:', signatures);
+
+    expect(signatures).toBeDefined();
   });
 });

--- a/packages/networks/src/networks/vNaga/shared/managers/api-manager/e2ee-request-manager/E2EERequestManager.ts
+++ b/packages/networks/src/networks/vNaga/shared/managers/api-manager/e2ee-request-manager/E2EERequestManager.ts
@@ -182,9 +182,9 @@ const handleEncryptedError = (
 
       throw new Error(
         `"${operationName}" failed. The nodes returned an encrypted error response that could not be decrypted. ` +
-          `This may indicate a configuration or network connectivity issue. ${JSON.stringify(
-            errorResult
-          )}`
+        `This may indicate a configuration or network connectivity issue. ${JSON.stringify(
+          errorResult
+        )}. If you are running custom session sigs, it might mean the validation has failed. We will continue to improve this error message to provide more information.`
       );
     }
   } else {


### PR DESCRIPTION
# WHAT

- Fixed the custom auth test to use Eve's PKP instead of Alice as it was producing false-positive tests results because it was using the cached delegation auth sigs from Alice's PKP.
- Updated the custom auth validation ipfs cid [QmcxWmo3jefFsPUnskJXYBwsJYtiFuMAH1nDQEs99AwzDe](https://explorer.litprotocol.com/ipfs/QmcxWmo3jefFsPUnskJXYBwsJYtiFuMAH1nDQEs99AwzDe)
- Disabled some custom auth tests for the time being, will need to have follow up PRs for that.