### PR TITLE
chore(ci): run e2e workflow on naga branch

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,9 +3,8 @@ name: E2E Tests
 on:
   push:
     branches:
-      - main
-      - master
-      - develop
+      - naga
+      - canary-naga
   pull_request:
 env:
   LIT_STATUS_WRITE_KEY: ${{ secrets.LIT_STATUS_WRITE_KEY }}
@@ -51,9 +50,9 @@ jobs:
         run: NETWORK=naga-dev bun run test:e2e all
         timeout-minutes: 10
 
-      # - name: Run health check for naga-test
-      #   run: NETWORK=naga-test bun run test:e2e all
-      #   timeout-minutes: 10
+      - name: Run health check for naga-test
+        run: NETWORK=naga-test bun run test:e2e all
+        timeout-minutes: 10
 
       - name: Run health check for naga-staging
         run: NETWORK=naga-staging bun run test:e2e all

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,9 +50,9 @@ jobs:
         run: NETWORK=naga-dev bun run test:e2e all
         timeout-minutes: 10
 
-      - name: Run health check for naga-test
-        run: NETWORK=naga-test bun run test:e2e all
-        timeout-minutes: 10
+      # - name: Run health check for naga-test
+      #   run: NETWORK=naga-test bun run test:e2e all
+      #   timeout-minutes: 10
 
       - name: Run health check for naga-staging
         run: NETWORK=naga-staging bun run test:e2e all


### PR DESCRIPTION
# WHAT

enable the E2E workflow to run on the `naga` branch