### PR TITLE
chore(workflows): remove NX_DAEMON environment variable from build steps

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -67,8 +67,6 @@ jobs:
         run: bunx changeset version --snapshot beta
 
       - name: Build workspace
-        env:
-          NX_DAEMON: 'false'
         run: bun run build
 
       - name: Publish prerelease packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,8 +70,6 @@ jobs:
           fi
 
       - name: Build
-        env:
-          NX_DAEMON: 'false'
         run: bun run build
         # Enable this after pnpm migration
         # run: pnpm build


### PR DESCRIPTION
# WHAT

CI is failing build, remove NX Daemon to match the e2e CI