### PR TITLE
chore(ci): align rust toolchain across workflows

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -47,7 +47,11 @@ jobs:
           bun-version: latest
 
       - name: Install rust
-        uses: dtolnay/rust-toolchain@1.76.0
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rust-std
 
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,12 @@ jobs:
           bun-version: latest
 
       - name: Install rust
-        uses: dtolnay/rust-toolchain@1.76.0
-
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rust-std
+        
       - name: Install wasm-pack
         uses: jetli/wasm-pack-action@v0.4.0
         with:


### PR DESCRIPTION
# WHAT
- swap release and prerelease workflows to use the same `actions-rs/toolchain@v1` setup as e2e, ensuring Cargo matches our lockfile version
- keep the Bun/Rust/wasm-pack ordering consistent so the release and prerelease jobs mirror the proven e2e pipeline
