### PR TITLE
chore: sync constants version with lit-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,10 @@
   "version": "0.0.1",
   "license": "MIT",
   "scripts": {
+    "sync-version": "node ./scripts/sync-version.mjs",
     "reset": "bun unlink-all && rimraf dist node_modules doc tmp yarn-error.log yarn.lock package-lock.json bun.lockb learn-debug.log tmp .nx lit-auth-storage pkp-tokens lit-auth-local ./e2e/dist ./e2e/node_modules",
     "go": "bun run build && bun link-all",
-    "build": "bun unlink-all && nx run-many --parallel=false --target=build --all --exclude=wrapped-keys,wrapped-keys-lit-actions && bun run prettier",
+    "build": "bun run sync-version && nx run-many --parallel=false --target=build --all --exclude=wrapped-keys,wrapped-keys-lit-actions && bun run prettier",
     "build:affected": "nx affected --target=build --exclude=wrapped-keys,wrapped-keys-lit-actions",
     "check-deps": "npx nx run-many --target=check-deps --exclude=wrapped-keys,wrapped-keys-lit-actions",
     "validate": "npm run check-deps && npm run build",

--- a/packages/constants/src/lib/version.ts
+++ b/packages/constants/src/lib/version.ts
@@ -1,1 +1,2 @@
-export const version = '8.0.0-alpha.4';
+// This value is kept in sync with @lit-protocol/lit-client via scripts/sync-version.mjs, run by the build command.
+export const version = '8.0.0';


### PR DESCRIPTION
# WHAT

- add `scripts/sync-version.mjs` to copy the `@lit-protocol/lit-client` version into `packages/constants/src/lib/version.ts`
- run the sync as part of `bun run build`

## Testing

```
bun run sync-version

// post-bun/pnpm
pnpm run sync-version
```
